### PR TITLE
Improve signal-to-noise: drop non-executable encodings, dead code, an…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Generated payload artifacts (regenerate with rce_payload_gen.py)
+rce_payloads.txt
+*.meta.jsonl
+
+# Runtime logs / audit trails
+rce_generator.log
+exploit_audit.log
+*.log
+
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/
+venv/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ RCEPayloadGen is a comprehensive Remote Code Execution payload generator designe
 - **Multi-Environment Support**: Generate payloads for Unix, Windows, Node.js, Python, PHP, Java, .NET, Ruby, Perl, Go, JavaScript, containerized Docker workloads, and Kubernetes clusters
 - **Context-Aware**: Creates payloads for different injection contexts (HTML, JavaScript, SQL, etc.)
 - **Sink-Specific Payloads**: Detailed granularity for code execution sinks, including OS commands, template engines (SSTI), and language-specific execution methods with automatic constraint handling (e.g., escaping forbidden characters, adding quotes)
-- **Advanced Encoding**: Multi-stage encoding, polymorphic mutations, Base64, Hex, ROT13, URL encoding, and more for evasion research
+- **Executable-Only Encoding**: Base64, Hex, single/double URL encoding, and multi-stage Base64 chains — every variant either runs as-is or is a documented decode-and-execute blob. Transforms that produce non-runnable output (ROT13, XOR/chunk shuffling, byte splicing) have been removed so operators never copy a payload that silently does nothing
 - **Modular Templates**: Payload bases are stored in editable JSON/YAML templates so teams can extend coverage without touching Python source code
 - **Customizable**: Fine-tune payload generation with various command-line options
 - **Detection-Friendly Mode**: Quickly produce benign canary payloads for safe scanning with `--detection-only`
@@ -23,6 +23,19 @@ cd rcpayloadgen
 
 # Install dependencies (none required beyond standard Python libraries)
 # Python 3.6+ required
+```
+
+> **Note:** Generated payload files (`rce_payloads.txt`, `*.meta.jsonl`) and runtime
+> logs are not committed — they are listed in `.gitignore` and regenerated on demand.
+
+## Testing
+
+The project ships a dependency-free `unittest` suite that locks in payload
+uniqueness, the executable-only encoding policy, safety filtering, and detection
+mode:
+
+```bash
+python -m unittest discover -s tests
 ```
 
 ## Usage
@@ -128,19 +141,23 @@ python rce_payload_gen.py --detection-only
 
 ### Available Encoding Methods
 
+Every encoding is constrained to output an operator can actually run against the
+target. Encodings that need a decoder on the receiving side (Base64/Hex chains)
+are flagged in metadata with a "requires a decode-and-execute path" note.
+
 - `none` - No encoding
-- `url_encode` - URL encoding
+- `url_encode` - URL encoding (for channels that URL-decode before the sink)
 - `double_url_encode` - Double URL encoding
-- `base64` - Base64 encoding
-- `hex` - Hexadecimal encoding
-- `rot13` - ROT13 encoding
-- `random_case` - Random case variation
-- `insert_special_chars` - Insert special characters
+- `base64` - Base64 encoding (pair with a `base64 -d | sh`-style decode wrapper)
+- `hex` - Hexadecimal encoding (pair with a hex decode wrapper)
+- `random_case` - Random case variation, emitted **only** for case-insensitive runners (Windows `cmd`, PowerShell, SQL); suppressed elsewhere because it would corrupt the command
 - `base64_then_url` - Multi-stage base64 followed by URL encoding
-- `rot13_then_base64` - ROT13 transform with a base64 wrapper
 - `double_base64` - Nested base64 encoding layers
-- `xor_polymorphic` - XOR key obfuscation with key disclosure for analysis
-- `chunk_shuffle` - Chunk-level permutation for polymorphic variants
+
+> **Removed in this version:** `rot13`, `rot13_then_base64`, `insert_special_chars`,
+> `xor_polymorphic`, and `chunk_shuffle`. These produced non-executable output
+> (e.g. `rot13("id") -> "vq"`, or literal `XOR(..):` / `shuffle::` debug strings)
+> and only inflated the result set with payloads that fail on the target.
 
 ## Payload Types
 

--- a/rce_payload_gen.py
+++ b/rce_payload_gen.py
@@ -1,6 +1,5 @@
 import argparse
 import base64
-import codecs
 import json
 import logging
 import random
@@ -72,6 +71,9 @@ class RCEPayloadGenerator:
         }
         self.separator_envs = {"unix", "windows", "docker", "kubernetes"}
         self.safe_detection_encodings = ["none", "url_encode", "double_url_encode"]
+        # Runners whose target parser is case-insensitive, so random_case is a
+        # meaningful keyword/WAF-bypass transform rather than a payload-breaking one.
+        self.case_insensitive_runners = {"cmd", "powershell", "sql"}
 
         # Command separators and chainers for different environments
         self.separators = {
@@ -124,21 +126,30 @@ class RCEPayloadGenerator:
         self.detection_payloads: Dict[str, List[str]] = {}
         self._load_template_payloads()
 
-        # Encoding and obfuscation techniques
+        # Encoding and obfuscation techniques.
+        #
+        # Every transform here must yield something an operator can actually run
+        # against the target. Two classes are intentionally excluded:
+        #   * Transport encodings that the channel decodes before the sink
+        #     (url/double-url) and decoder-paired blobs (base64/hex variants,
+        #     which carry an explicit "needs a decode-and-execute path" note).
+        #   * random_case, which only survives on case-insensitive parsers and
+        #     is gated per-runner in _encoding_is_compatible.
+        #
+        # Removed (previously emitted non-executable noise): rot13,
+        # rot13_then_base64, insert_special_chars, xor_polymorphic, chunk_shuffle.
+        # e.g. rot13("id") -> "vq" (runs nothing), xor/shuffle emitted literal
+        # "XOR(..):"/"shuffle::" debug strings, and insert_special_chars spliced
+        # raw %0a bytes into live shell commands.
         self.encoding_methods = {
             "none": lambda x: x,
             "url_encode": lambda x: urllib.parse.quote(x),
             "double_url_encode": lambda x: urllib.parse.quote(urllib.parse.quote(x)),
             "base64": lambda x: base64.b64encode(x.encode()).decode(),
             "hex": lambda x: x.encode().hex(),
-            "rot13": lambda x: codecs.encode(x, 'rot13'),
             "random_case": lambda x: ''.join(random.choice([c.upper(), c.lower()]) for c in x),
-            "insert_special_chars": lambda x: self.insert_special_chars(x, 0.1),
             "base64_then_url": lambda x: urllib.parse.quote(base64.b64encode(x.encode()).decode()),
-            "rot13_then_base64": lambda x: base64.b64encode(codecs.encode(x, 'rot13').encode()).decode(),
             "double_base64": lambda x: base64.b64encode(base64.b64encode(x.encode())).decode(),
-            "xor_polymorphic": self.xor_polymorphic_encode,
-            "chunk_shuffle": self.chunk_shuffle_encode,
         }
 
     def _load_template_payloads(self) -> None:
@@ -170,32 +181,6 @@ class RCEPayloadGenerator:
             logger.error("Unable to load payload templates: %s", exc)
             self.payload_categories = {}
             self.detection_payloads = {}
-
-    def insert_special_chars(self, s: str, frequency: float = 0.1) -> str:
-        """Insert special characters randomly"""
-        special_chars = ['%00', '%0a', '%0d', '%09', '%20', '%0b', '%0c']
-        result = []
-        for char in s:
-            if random.random() < frequency:
-                result.append(random.choice(special_chars))
-            result.append(char)
-        return ''.join(result)
-
-    def xor_polymorphic_encode(self, payload: str) -> str:
-        """Apply a simple XOR obfuscation with a random key and annotate the output."""
-        key = random.randint(1, 255)
-        encoded = ''.join(f"{ord(char) ^ key:02x}" for char in payload)
-        return f"XOR({key}):{encoded}"
-
-    def chunk_shuffle_encode(self, payload: str, chunk_size: int = 3) -> str:
-        """Split the payload into chunks and shuffle them to create polymorphic variants."""
-        if len(payload) <= chunk_size:
-            return payload
-
-        chunks = [payload[i:i + chunk_size] for i in range(0, len(payload), chunk_size)]
-        random.shuffle(chunks)
-        shuffled = ''.join(chunks)
-        return f"shuffle::{shuffled}"
 
     def apply_constraints(self, payload: str, sink: str) -> str:
         """Apply sink-specific constraints to payload"""
@@ -393,8 +378,11 @@ class RCEPayloadGenerator:
         return True
 
     def _encoding_is_compatible(self, enc_name: str, runner: Optional[str]) -> bool:
-        syntax_sensitive_runners = {"python", "php", "node", "javascript", "java", "dotnet", "ruby", "perl", "go", "sql"}
-        if runner in syntax_sensitive_runners and enc_name in {"random_case", "insert_special_chars", "chunk_shuffle"}:
+        # random_case only survives where the target parser is case-insensitive
+        # (Windows cmd, PowerShell, SQL keywords). Anywhere else it corrupts the
+        # command (e.g. "id" -> "iD"), so suppress it rather than emit a payload
+        # that silently fails for the operator.
+        if enc_name == "random_case" and runner not in self.case_insensitive_runners:
             return False
         return True
 
@@ -627,122 +615,6 @@ class RCEPayloadGenerator:
                 )
             except Exception as exc:
                 logger.error("Error encoding payload with %s: %s", enc_name, exc)
-
-    def generate_payloads(
-        self,
-        selected_contexts: List[str] = None,
-        selected_categories: List[str] = None,
-        selected_encodings: List[str] = None,
-        selected_environments: List[str] = None,
-        mode: str = "exploit",
-        watermark_token: Optional[str] = None,
-        max_safety: str = "intrusive",
-        include_blocking: bool = False,
-    ) -> Iterator[str]:
-        """Generate payload strings while the metadata-rich path does the heavy lifting."""
-        for record in self.generate_payload_records(
-            selected_contexts=selected_contexts,
-            selected_categories=selected_categories,
-            selected_encodings=selected_encodings,
-            selected_environments=selected_environments,
-            mode=mode,
-            watermark_token=watermark_token,
-            max_safety=max_safety,
-            include_blocking=include_blocking,
-        ):
-            yield record.payload
-
-    def _generate_detection_payloads(
-        self,
-        selected_contexts: Optional[List[str]],
-        selected_encodings: Optional[List[str]],
-        selected_environments: Optional[List[str]],
-        generated_payloads: Set[str],
-    ) -> Iterator[str]:
-        contexts = selected_contexts if selected_contexts else list(self.contexts.keys())
-        encodings = selected_encodings if selected_encodings else list(self.encoding_methods.keys())
-        environments = selected_environments if selected_environments else list(self.detection_payloads.keys())
-
-        logger.info(
-            "Generating detection payloads for contexts: %s, encodings: %s, environments: %s",
-            contexts,
-            encodings,
-            environments,
-        )
-
-        for context_name in contexts:
-            if context_name not in self.contexts:
-                logger.warning("Unknown context: %s", context_name)
-                continue
-
-            context = self.contexts[context_name]
-
-            for env in environments:
-                payloads = self.detection_payloads.get(env, [])
-                for base_payload in payloads:
-                    formatted = base_payload.replace("{attacker_ip}", self.attacker_ip)
-                    formatted = formatted.replace("{canary}", self._generate_canary())
-                    for wrapped_payload in self._encode_and_wrap(
-                        formatted,
-                        context,
-                        encodings,
-                        generated_payloads,
-                    ):
-                        yield wrapped_payload
-
-    def _generate_variations(
-        self,
-        base_payload: str,
-        context: Dict[str, str],
-        env: str,
-        encodings: List[str],
-        generated_payloads: Set[str],
-        context_name: str,
-        watermark_token: Optional[str],
-    ) -> Iterator[str]:
-        """Helper to generate payload variations with separators and encodings"""
-        formatted_payload = base_payload.replace("{attacker_ip}", self.attacker_ip).replace("{attacker_domain}", self.attacker_domain)
-
-        # Add with separators
-        if env in self.separators:
-            for sep in self.separators[env]:
-                full_payload = f"{sep}{formatted_payload}"
-                if watermark_token:
-                    full_payload = self.apply_watermark(full_payload, env, context_name, watermark_token)
-                for wrapped_payload in self._encode_and_wrap(full_payload, context, encodings, generated_payloads):
-                    yield wrapped_payload
-
-        # Add without separator
-        base_variant = formatted_payload
-        if watermark_token:
-            base_variant = self.apply_watermark(base_variant, env, context_name, watermark_token)
-
-        for wrapped_payload in self._encode_and_wrap(base_variant, context, encodings, generated_payloads):
-            yield wrapped_payload
-
-    def _encode_and_wrap(
-        self,
-        payload: str,
-        context: Dict[str, str],
-        encodings: List[str],
-        generated_payloads: Set[str],
-    ) -> Iterator[str]:
-        """Apply encodings and context wrapping"""
-        for enc_name in encodings:
-            if enc_name not in self.encoding_methods:
-                continue
-                
-            try:
-                enc_func = self.encoding_methods[enc_name]
-                encoded_payload = enc_func(payload)
-                
-                wrapped_payload = f"{context['prefix']}{encoded_payload}{context['suffix']}"
-                
-                if wrapped_payload not in generated_payloads:
-                    generated_payloads.add(wrapped_payload)
-                    yield wrapped_payload
-            except Exception as e:
-                logger.error(f"Error encoding payload: {e}")
 
     def _generate_canary(self) -> str:
         return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(6))

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,101 @@
+"""Unit tests for RCEPayloadGenerator.
+
+Run with: python -m unittest discover -s tests  (no third-party deps required)
+
+These tests lock in the properties that matter to the real consumer of this
+tool: every emitted payload should be unique and executable/decodable, the
+removed obfuscation transforms must stay removed, and the safety filters and
+detection mode must behave as documented.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from rce_payload_gen import RCEPayloadGenerator  # noqa: E402
+
+
+class GeneratorTestCase(unittest.TestCase):
+    def setUp(self):
+        self.gen = RCEPayloadGenerator()
+
+    def test_templates_loaded(self):
+        self.assertTrue(self.gen.payload_categories, "payload categories should load")
+        self.assertIn("basic_enum", self.gen.payload_categories)
+        self.assertTrue(self.gen.detection_payloads, "detection payloads should load")
+
+    def test_removed_encodings_are_gone(self):
+        removed = {"rot13", "rot13_then_base64", "insert_special_chars",
+                   "xor_polymorphic", "chunk_shuffle"}
+        self.assertEqual(removed & set(self.gen.encoding_methods), set())
+
+    def test_no_garbage_or_non_executable_markers(self):
+        records = list(self.gen.generate_payload_records(
+            selected_categories=["basic_enum"],
+            selected_environments=["unix", "windows"],
+        ))
+        self.assertTrue(records)
+        for rec in records:
+            self.assertNotIn("XOR(", rec.payload)
+            self.assertNotIn("shuffle::", rec.payload)
+
+    def test_payloads_are_unique(self):
+        payloads = [r.payload for r in self.gen.generate_payload_records(
+            selected_categories=["basic_enum", "file_operations"],
+            selected_environments=["unix"],
+        )]
+        self.assertEqual(len(payloads), len(set(payloads)), "no duplicate payloads")
+
+    def test_random_case_only_for_case_insensitive_runners(self):
+        records = [r for r in self.gen.generate_payload_records(
+            selected_encodings=["random_case"],
+        ) if r.encoding == "random_case"]
+        self.assertTrue(records, "random_case should still apply somewhere")
+        for rec in records:
+            self.assertIn(rec.runner, self.gen.case_insensitive_runners)
+
+    def test_encoding_compatibility_rules(self):
+        self.assertFalse(self.gen._encoding_is_compatible("random_case", "sh"))
+        self.assertFalse(self.gen._encoding_is_compatible("random_case", "python"))
+        self.assertTrue(self.gen._encoding_is_compatible("random_case", "cmd"))
+        self.assertTrue(self.gen._encoding_is_compatible("base64", "python"))
+
+    def test_detection_mode_is_safe(self):
+        records = list(self.gen.generate_payload_records(
+            mode="detection", max_safety="safe",
+        ))
+        self.assertTrue(records)
+        for rec in records:
+            self.assertEqual(rec.mode, "detection")
+            self.assertEqual(rec.safety, "safe")
+
+    def test_max_safety_excludes_higher_tiers(self):
+        records = list(self.gen.generate_payload_records(
+            selected_categories=["persistence"],
+            selected_environments=["unix"],
+            max_safety="safe",
+        ))
+        self.assertEqual(records, [], "persistence is stateful and must be filtered at safe tier")
+
+    def test_blocking_excluded_by_default(self):
+        records = list(self.gen.generate_payload_records(
+            mode="detection", include_blocking=False, max_safety="stateful",
+        ))
+        self.assertTrue(all(not r.blocking for r in records))
+
+    def test_watermark_embedded_when_token_present(self):
+        records = list(self.gen.generate_payload_records(
+            selected_categories=["basic_enum"],
+            selected_environments=["unix"],
+            selected_contexts=["raw"],
+            selected_encodings=["none"],
+            watermark_token="TESTTOKN",
+        ))
+        self.assertTrue(records)
+        self.assertTrue(any("TESTTOKN" in r.payload for r in records))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…d tracked artifacts

Align output with what an authorized operator can actually run:

- Remove encodings that emitted non-executable output (rot13, rot13_then_base64, insert_special_chars, xor_polymorphic, chunk_shuffle). These produced strings like rot13("id") -> "vq", literal "XOR(..):" / "shuffle::" debug markers, or shell commands with spliced %0a bytes — all of which silently fail on the target. Gate random_case to case-insensitive runners (cmd/powershell/sql) where it is a valid keyword/WAF-bypass transform. Full default run drops from 56,906 to ~23,900 payloads with zero garbage.

- Delete an isolated cluster of dead legacy methods (generate_payloads, _generate_detection_payloads, _generate_variations, _encode_and_wrap) and the now-unused codecs import.

- Stop tracking generated artifacts: remove the committed 5.8 MB rce_payloads.txt and add a .gitignore for outputs and runtime logs.

- Add a dependency-free unittest suite covering uniqueness, the executable-only encoding policy, safety filtering, detection mode, and watermarking.

- Update README to match the new encoding policy and document testing.