### PR TITLE
Judge sink_needs_separator on the canonical payload, not the encoded form

### DIFF
--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -49,6 +49,7 @@ class PayloadRecord:
     blocking: bool = False
     stateful: bool = False
     destructive: bool = False
+    separator_led: bool = True
     token: Optional[str] = None
     oob_host: Optional[str] = None
     match: Optional[str] = None
@@ -708,6 +709,10 @@ class RCEKit:
                     token = self._generate_canary()
                     working = working.replace("{canary}", token)
 
+                # Decide separator-validity on the canonical payload, before any
+                # encoding hides (or spuriously reveals) the leading separator.
+                separator_led = self._is_separator_led(working, environment, context_name)
+
                 encoded_payload = self.encoding_methods[enc_name](working)
                 escape = context.get("escape", "none")
                 escaped_payload = self._escape_for_context(encoded_payload, escape)
@@ -750,6 +755,7 @@ class RCEKit:
                     blocking=blocking,
                     stateful=stateful,
                     destructive=destructive,
+                    separator_led=separator_led,
                     token=token,
                     oob_host=oob_host,
                     match=match,
@@ -763,14 +769,20 @@ class RCEKit:
     def _generate_canary(self) -> str:
         return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(6))
 
-    def _is_separator_led(self, record: PayloadRecord) -> bool:
-        """True if the payload can break out of a mid-command injection point."""
-        if record.environment not in self.separator_envs:
+    def _is_separator_led(self, core: str, environment: str, context: str) -> bool:
+        """True if this canonical (pre-encoding) payload can break out of a
+        mid-command injection point.
+
+        Judged on the raw payload rather than the final encoded/wrapped string:
+        a url-encoded ``; id`` no longer *looks* separator-led once the ``;`` is
+        percent-escaped, but it still fires once the sink decodes it. Conversely
+        a bare ``id`` never fires mid-command no matter how it is encoded, so its
+        separator-validity must be decided before encoding is applied.
+        """
+        if environment not in self.separator_envs:
             return True  # non-shell sinks are not command-concatenation points
-        if record.context in {"shell_single_quoted", "shell_double_quoted"}:
+        if context in {"shell_single_quoted", "shell_double_quoted"}:
             return True  # quote break-outs supply their own separator
-        prefix = self.contexts.get(record.context, {}).get("prefix", "")
-        core = record.payload[len(prefix):] if prefix and record.payload.startswith(prefix) else record.payload
         return core.startswith(self.command_separators)
 
     def _filter_by_profile(
@@ -787,7 +799,8 @@ class RCEKit:
           (checked on the final wrapped/encoded payload, so a URL-encoded quote
           survives a quote filter because the literal character is gone).
         * ``needs_separator`` (sink concatenates input mid shell command) keeps
-          only unencoded payloads that begin with a command separator.
+          only payloads whose canonical form begins with a command separator, so
+          an encoded break-out survives while an encoded bare command does not.
         * ``blind`` (sink returns no output) keeps only payloads confirmable
           out-of-band: timing (blocking) or OOB callbacks.
         """
@@ -797,7 +810,7 @@ class RCEKit:
                 continue
             if denied and any(char in record.payload for char in denied):
                 continue
-            if needs_separator and record.encoding == "none" and not self._is_separator_led(record):
+            if needs_separator and not record.separator_led:
                 continue
             if blind and not (record.blocking or record.oob_host or record.expected_channel == "interactsh"):
                 continue

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -458,6 +458,27 @@ class GeneratorTestCase(unittest.TestCase):
         # A separator-led variant must survive.
         self.assertIn("; id", [r.payload for r in filtered])
 
+    def test_sink_needs_separator_judges_encoded_payloads_by_canonical_form(self):
+        # Separator-validity must be decided on the pre-encoding payload, not the
+        # final string: a url-encoded bare command still can't fire mid-command,
+        # while a url-encoded break-out still can.
+        records = list(self.gen.generate_payload_records(
+            selected_categories=["basic_enum"], selected_environments=["unix"],
+            selected_contexts=["raw"], selected_encodings=["none", "url_encode"],
+        ))
+        filtered = list(self.gen._filter_by_profile(records, needs_separator=True))
+        # Encoded bare command (decodes to plain "id") cannot break out -> dropped.
+        self.assertIn("id", [r.payload for r in records])
+        self.assertNotIn("id", [r.payload for r in filtered])
+        # Encoded break-out (";" percent-escaped) is still a valid separator once
+        # the sink decodes it, so it must survive even though its literal form no
+        # longer starts with a separator.
+        self.assertIn("%3B%20id", [r.payload for r in records])
+        self.assertIn("%3B%20id", [r.payload for r in filtered])
+        # Nothing that survives should be an encoded bare command.
+        for record in filtered:
+            self.assertTrue(record.separator_led)
+
     def test_sink_blind_keeps_only_out_of_band_confirmable(self):
         records = list(self.gen.generate_payload_records(
             selected_categories=["basic_enum", "oob"], selected_environments=["unix"],


### PR DESCRIPTION
## Summary

The mid-command separator filter (`sink_needs_separator`) only ran when `record.encoding == "none"`. That meant an encoded variant of a non-separator-led base payload (e.g. url-encoded `uname -a` → `uname%20-a`) slipped through the filter, even though it can never break out of a concatenated command. This contradicts the tool's promise to "emit only payloads that could actually fire."

## Fix

Separator-validity is now decided on the **canonical (pre-encoding)** payload and stored on the record, instead of being inferred from the final encoded string:

- Added a `separator_led` field to `PayloadRecord`.
- `_is_separator_led` now evaluates the raw pre-encoding core (plus environment/context) rather than the wrapped/encoded payload.
- The value is computed once per variant in `_encode_record_variants` and persisted on the record.
- `_filter_by_profile` drops `not record.separator_led` regardless of encoding.

This keeps encoded break-outs that fire once a sink decodes them (a percent-escaped `;` → `%3B%20id`) while dropping encoded bare commands that never fire mid-command.

## Behavior

- `uname%20-a`, `ls%20-la`, `cat%20/etc/os-release` (encoded bare commands) → now dropped
- `%3B%20id`, `%3B%20uname%20-a` (encoded break-outs) → still kept
- `encoding="none"` path is unchanged (canonical == literal), so the shipped `shell-concat-noquotes` profile behaves identically.

## Tests

- Added `test_sink_needs_separator_judges_encoded_payloads_by_canonical_form`.
- Full suite (51 tests) passes.

## Version

Bumped `2.0.0` → `2.0.1` (patch / bug fix).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdiSLKVMLuYoa4FbAmqs79)_