### PR TITLE
Differential RCE verification: make "confirmed" mean execution, not coincidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.0.0** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.1.0** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just
@@ -15,7 +15,7 @@ payload generation:
 - **Targeted generation** — payloads tailored to the **environment** (Unix, Windows, Node.js, Python, PHP, Java, .NET, Ruby, Perl, Go, GraphQL, MongoDB/NoSQL, Docker, Kubernetes), the injection **context** (with container-aware escaping for JSON/XML/YAML/headers/shell-quoted strings), and the specific execution **sink** (OS commands, SSTI, SpEL/OGNL/Groovy, Mongo `$where`, …).
 - **Executable-only output** — every payload runs as-is on its channel/sink or carries its own decoder; non-runnable transforms are removed and decoder-required blobs are opt-in, so you never copy a payload that silently does nothing.
 - **Sink-aware target profiles** — describe the target once (denied characters, max length, needs-separator, blind, decodes-input) and emit only payloads that could actually fire.
-- **Auto-verification** — `--verify-url` fires payloads at an authorised target and reports which executed, using each payload's built-in oracle: a `match` regex, a reflected canary, or a timing delay.
+- **Auto-verification** — `--verify-url` fires payloads at an authorised target and reports which executed, using each payload's built-in oracle: a `match` regex, a reflected canary, or a timing delay. Confirmation is **differential**, so `confirmed` means execution and not coincidence: a timing hit must clear a noise-aware margin over a multi-sample baseline *and* reproduce on a re-fire, and a command-output signature already present in the payload-free response is reported `inconclusive` instead of a false positive.
 - **Built-in OOB listener** — `--listen` receives HTTP/DNS callbacks and correlates each back to the exact payload, closing the blind-RCE loop without a separate interactsh/Collaborator.
 - **Tooling integrations** — export as Burp/ffuf wordlists or runnable Nuclei templates with built-in OOB / time-based / reflection oracles.
 - **Safe by default** — a benign `--detection-only` canary mode, safety tiers, a consent gate, and audit logging.
@@ -232,6 +232,12 @@ python rcekit.py --acknowledge-consent \
   [file_operations/raw] ; cat /etc/passwd            (matched /root:.*?:0:0:/)
   [waf_bypass/raw]      ; cat${IFS}/etc/passwd        (matched /root:.*?:0:0:/)
 ```
+
+Confirmation is differential to avoid false positives: the timing oracle samples
+the baseline several times and requires a candidate delay to both clear a
+noise-aware margin and reproduce on a second fire (a one-off slow response is
+reported `no-delay`), and the reflection oracle reports `inconclusive` when the
+command-output signature already appears in the payload-free response.
 
 Rate-limit with `--verify-delay` and cap with `--max-payloads`. OOB payloads are
 sent but confirmed out-of-band (see below). **Destructive payloads (persistence,

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.0.1"
+__version__ = "2.1.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -1099,18 +1099,36 @@ class RCEKit:
         )
 
     def _evaluate_verify(self, record: PayloadRecord, status: Optional[int], body: str,
-                         elapsed: float, baseline: float) -> Tuple[str, str]:
-        """Apply the payload's built-in oracle to a target response."""
+                         elapsed: float, baseline: float, margin: float = 2.0,
+                         control_body: str = "", elapsed_confirm: Optional[float] = None) -> Tuple[str, str]:
+        """Apply the payload's built-in oracle to a target response.
+
+        The verdicts are *differential* so ``confirmed`` means execution, not
+        coincidence:
+
+        * **timing** — a candidate delay must clear ``baseline`` by ``margin``
+          (a noise-aware threshold, not a fixed constant) *and* reproduce on a
+          second fire (``elapsed_confirm``); a one-off slow response is jitter,
+          not a sleep, and is reported ``no-delay``.
+        * **reflection** — a ``match`` that is already present in the
+          payload-free ``control_body`` is not evidence of execution, so it is
+          reported ``inconclusive`` rather than a false ``confirmed``.
+        """
         if status is None:
             return "error", body[:80]
         if record.expected_channel == "interactsh":
             return "oob-pending", f"watch token {record.token} at your OOB listener"
         if record.expected_channel == "timing" or record.blocking:
-            if elapsed - baseline >= 2.0:
-                return "confirmed", f"delay {elapsed:.1f}s vs baseline {baseline:.1f}s"
-            return "no-delay", f"{elapsed:.1f}s"
+            if elapsed - baseline < margin:
+                return "no-delay", f"{elapsed:.1f}s vs baseline {baseline:.1f}s (needs +{margin:.1f}s)"
+            if elapsed_confirm is not None and elapsed_confirm - baseline < margin:
+                return "no-delay", (f"delay {elapsed:.1f}s did not reproduce on re-fire "
+                                    f"({elapsed_confirm:.1f}s vs baseline {baseline:.1f}s)")
+            return "confirmed", f"delay {elapsed:.1f}s vs baseline {baseline:.1f}s (margin {margin:.1f}s)"
         if record.match:
             if re.search(record.match, body):
+                if control_body and re.search(record.match, control_body):
+                    return "inconclusive", f"signature /{record.match}/ also present without the payload"
                 return "confirmed", f"matched /{record.match}/"
             return "no-match", ""
         return "no-signature", "no machine-readable oracle for this payload"
@@ -1151,8 +1169,22 @@ class RCEKit:
             except Exception as exc:  # network error, timeout, etc.
                 return None, str(exc), time.time() - start
 
-        # Baseline latency from a benign request, used by the timing oracle.
-        _, _, baseline = fire(f"rcekit-baseline-{self._generate_canary()}")
+        # Baseline from several benign requests: a single sample can be a cold
+        # start or a jitter spike, which would poison every timing verdict. Take
+        # a robust centre (median) plus a noise-aware margin (floored, but at
+        # least a few times the observed spread), and keep one payload-free body
+        # as the control for the reflection differential.
+        import statistics
+
+        baseline_samples: List[float] = []
+        control_body = ""
+        for _ in range(3):
+            _, cbody, sample = fire(f"rcekit-baseline-{self._generate_canary()}")
+            baseline_samples.append(sample)
+            control_body = cbody
+        baseline = statistics.median(baseline_samples)
+        spread = max(baseline_samples) - min(baseline_samples)
+        margin = max(2.0, 3 * spread)
 
         results: List[Dict[str, Any]] = []
         seen: Set[str] = set()
@@ -1161,7 +1193,14 @@ class RCEKit:
                 continue
             seen.add(record.payload)
             status, body, elapsed = fire(record.payload)
-            verdict, detail = self._evaluate_verify(record, status, body, elapsed, baseline)
+            # Only a candidate delay is worth a confirmatory re-fire; this keeps
+            # the extra request off the vast majority of payloads.
+            elapsed_confirm: Optional[float] = None
+            is_timing = record.expected_channel == "timing" or record.blocking
+            if is_timing and status is not None and elapsed - baseline >= margin:
+                _, _, elapsed_confirm = fire(record.payload)
+            verdict, detail = self._evaluate_verify(
+                record, status, body, elapsed, baseline, margin, control_body, elapsed_confirm)
             results.append({
                 "verdict": verdict, "detail": detail, "status": status,
                 "payload": record.payload, "category": record.category,
@@ -1553,6 +1592,12 @@ def main():
         if confirmed:
             print(f"\n[verify] CONFIRMED execution ({len(confirmed)}):")
             for result in confirmed:
+                print(f"  [{result['category']}/{result['context']}] {result['payload']}   ({result['detail']})")
+        inconclusive = [r for r in results if r["verdict"] == "inconclusive"]
+        if inconclusive:
+            print(f"\n[verify] {len(inconclusive)} INCONCLUSIVE (signature seen without the payload — "
+                  "the target reflects it regardless, so it is not proof of execution):")
+            for result in inconclusive:
                 print(f"  [{result['category']}/{result['context']}] {result['payload']}   ({result['detail']})")
         oob_pending = [r for r in results if r["verdict"] == "oob-pending"]
         if oob_pending:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -19,7 +19,18 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import rcekit  # noqa: E402
-from rcekit import OOBListener, RCEKit  # noqa: E402
+from rcekit import OOBListener, PayloadRecord, RCEKit  # noqa: E402
+
+
+def make_record(**overrides):
+    """A minimal PayloadRecord for exercising the verification oracle."""
+    base = dict(
+        payload="; id", mode="exploit", category="basic_enum", environment="unix",
+        context="raw", encoding="none", sink=None, indicator="", safety="intrusive",
+        expected_channel="response", runner="sh",
+    )
+    base.update(overrides)
+    return PayloadRecord(**base)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = REPO_ROOT / "rcekit.py"
@@ -635,6 +646,73 @@ class GeneratorTestCase(unittest.TestCase):
             confirmed = [r for r in results if r["verdict"] == "confirmed"]
             self.assertTrue(confirmed, "the harness must confirm at least one RCE")
             self.assertTrue(any(r["payload"] == "; id" for r in confirmed))
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_timing_oracle_requires_a_reproducible_delay(self):
+        # A blocking/timing payload is only "confirmed" when the delay clears the
+        # noise margin AND reproduces on the re-fire; a one-off spike is jitter.
+        rec = make_record(payload="; sleep 8", expected_channel="timing", blocking=True)
+        confirmed, _ = self.gen._evaluate_verify(
+            rec, 200, "", elapsed=8.4, baseline=1.0, margin=2.0, elapsed_confirm=8.1)
+        self.assertEqual(confirmed, "confirmed")
+        # First request was slow but the delay did not reproduce -> not execution.
+        jitter, _ = self.gen._evaluate_verify(
+            rec, 200, "", elapsed=8.4, baseline=1.0, margin=2.0, elapsed_confirm=1.2)
+        self.assertEqual(jitter, "no-delay")
+        # Below the margin at all -> not a delay.
+        quick, _ = self.gen._evaluate_verify(
+            rec, 200, "", elapsed=1.5, baseline=1.0, margin=2.0, elapsed_confirm=None)
+        self.assertEqual(quick, "no-delay")
+
+    def test_reflection_oracle_rejects_signature_present_without_payload(self):
+        # The command-output signature confirms execution only when it is absent
+        # from the payload-free control response.
+        rec = make_record(payload="; id", match=r"uid=\d+", expected_channel="response")
+        confirmed, _ = self.gen._evaluate_verify(
+            rec, 200, "uid=0(root) gid=0(root)", elapsed=0.1, baseline=0.1,
+            control_body="welcome home")
+        self.assertEqual(confirmed, "confirmed")
+        # Same signature already in the baseline response -> not proof of execution.
+        inconclusive, _ = self.gen._evaluate_verify(
+            rec, 200, "uid=0(root) gid=0(root)", elapsed=0.1, baseline=0.1,
+            control_body="debug: uid=0(root) always shown")
+        self.assertEqual(inconclusive, "inconclusive")
+
+    def test_verify_marks_always_reflected_signature_inconclusive(self):
+        # End-to-end: a target that echoes the signature regardless of input must
+        # not be reported as a confirmed RCE.
+        import http.server
+        import socketserver
+        import threading
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_GET(self):
+                self.send_response(200)
+                self.end_headers()
+                # Signature present for every request, payload or not.
+                self.wfile.write(b"uid=0(root) gid=0(root) groups=0(root)")
+
+        server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            records = self.gen.generate_payload_records(
+                selected_categories=["basic_enum"], selected_environments=["unix"],
+                selected_contexts=["raw"], selected_encodings=["none"],
+            )
+            results = self.gen.run_verification(
+                records, url=f"http://127.0.0.1:{port}/lookup?host=FUZZ",
+            )
+            id_results = [r for r in results if r["payload"] == "; id"]
+            self.assertTrue(id_results)
+            self.assertEqual(id_results[0]["verdict"], "inconclusive")
+            self.assertFalse(any(r["verdict"] == "confirmed" for r in results),
+                             "a signature echoed regardless of payload must not confirm")
         finally:
             server.shutdown()
             server.server_close()


### PR DESCRIPTION
## Summary

The whole value of `--verify-url` rests on trusting the `confirmed` verdict, but the two oracles that produce it were prone to false positives:

- **Timing** confirmed from a *single* baseline sample against a *fixed* 2s threshold. A cold start or a jitter spike would poison the baseline, and one slow response was enough to "confirm."
- **Reflection** confirmed on any `match` in the body, without checking whether that signature was already there — a target that echoes `uid=0(root)` on its default page would be reported as RCE.

This makes both oracles **differential**, so `confirmed` means execution and not coincidence.

## Changes

- **Timing:** `run_verification` now samples the baseline several times and uses a robust centre (median) plus a noise-aware margin (`max(2.0, 3 × spread)`). A candidate delay is re-fired once and must reproduce; a one-off spike is reported `no-delay`.
- **Reflection:** a payload-free control response is captured during baselining. A `match` that is also present in the control is reported with a new `inconclusive` verdict instead of a false `confirmed`.
- `_evaluate_verify` is now a pure function (all evidence passed in), so the verdict logic is unit-tested directly; the confirmatory re-fire only runs for candidate delays, keeping the extra request off the vast majority of payloads.
- CLI prints an `INCONCLUSIVE` section explaining why those hits are not proof.
- README updated to document the differential confirmation.

## Tests

- `test_timing_oracle_requires_a_reproducible_delay` — confirmed only when the delay clears the margin **and** reproduces; jitter and sub-margin cases are `no-delay`.
- `test_reflection_oracle_rejects_signature_present_without_payload` — `confirmed` vs `inconclusive` by control response.
- `test_verify_marks_always_reflected_signature_inconclusive` — end-to-end against a target that echoes the signature regardless of input.
- Full suite: 54 tests pass.

## Version

Bumped `2.0.1` → `2.1.0` (minor / new capability).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdiSLKVMLuYoa4FbAmqs79)_