### PR TITLE
Split ffuf export from burp; stop dropping encoded payloads from wordlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.1.0** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.2.0** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just
@@ -17,7 +17,7 @@ payload generation:
 - **Sink-aware target profiles** — describe the target once (denied characters, max length, needs-separator, blind, decodes-input) and emit only payloads that could actually fire.
 - **Auto-verification** — `--verify-url` fires payloads at an authorised target and reports which executed, using each payload's built-in oracle: a `match` regex, a reflected canary, or a timing delay. Confirmation is **differential**, so `confirmed` means execution and not coincidence: a timing hit must clear a noise-aware margin over a multi-sample baseline *and* reproduce on a re-fire, and a command-output signature already present in the payload-free response is reported `inconclusive` instead of a false positive.
 - **Built-in OOB listener** — `--listen` receives HTTP/DNS callbacks and correlates each back to the exact payload, closing the blind-RCE loop without a separate interactsh/Collaborator.
-- **Tooling integrations** — export as Burp/ffuf wordlists or runnable Nuclei templates with built-in OOB / time-based / reflection oracles.
+- **Tooling integrations** — export as context-split Burp wordlists, a ready-to-run ffuf attack (`request.txt` + `run.sh`) when a target profile is given, or runnable Nuclei templates with built-in OOB / time-based / reflection oracles.
 - **Safe by default** — a benign `--detection-only` canary mode, safety tiers, a consent gate, and audit logging.
 
 ## Install
@@ -62,7 +62,7 @@ and does not. Only run any of this against systems you are authorised to test.
 | `--categories` | Categories to generate | All |
 | `--contexts` | Injection contexts to generate | Default (language/structural) set |
 | `--encodings` | Encodings to apply | Default (self-contained) set |
-| `--output-format` | `text`, `jsonl`, `burp`, or `nuclei` | `text` |
+| `--output-format` | `text`, `jsonl`, `burp`, `ffuf`, or `nuclei` | `text` |
 | `--max-payloads` | Cap the number of payloads | Unlimited |
 | `--attacker-ip` / `--attacker-domain` | Substituted into reverse-shell / download payloads | `192.168.1.100` / `attacker.com` |
 | `--template-file` | Custom JSON/YAML payload templates | `templates/payloads.json` |
@@ -270,8 +270,11 @@ at the listener.
 ## Output Formats & Integrations
 
 - **`text` / `jsonl`** — payloads (or full JSONL records). A `<output>.map.jsonl` manifest is written for every payload that has an oracle — a correlation `token` or a machine-readable `match` regex — so a callback, reflected canary, or command-output signature is traceable to one payload and auto-confirmable.
-- **`burp`** — a `<output>_burp/` directory of deduplicated, watermark-free wordlists split per context, a combined `payloads-all.txt`, and a `request.txt` template. Load into Burp Intruder or `ffuf -request request.txt -w payloads-all.txt:FUZZ`.
+- **`burp`** — a `<output>_burp/` directory of deduplicated, watermark-free wordlists split per context (`payloads-<context>.txt`) plus a combined `payloads-all.txt`. Load a list as a Burp Intruder payload set and set the injection point from your captured request. A `request.txt` (with Burp's `§…§` position marker) is written **only** when a `--target-profile` supplies a real request — no generic placeholder is fabricated.
+- **`ffuf`** — a `<output>_ffuf/` directory with the same wordlists and, when a `--target-profile` supplies a `request` block, a ready-to-run `request.txt` (with a real `FUZZ` marker) and an executable `run.sh` (`ffuf -request request.txt -w payloads-all.txt -request-proto <scheme>`). Without a request there is nowhere to inject, so only the wordlists are written and a warning is printed.
 - **`nuclei`** — a `<output>_nuclei/` directory of runnable templates grouped by environment and oracle: OOB (`interactsh_protocol`), time-based (`duration>=6`), and reflection (canary in body). For the fullest pack, run `--detection-only --output-format nuclei`.
+
+The `burp`/`ffuf` wordlists honour whatever `--encodings` you selected: each distinct final payload is emitted as a literal line, so self-contained variants like `base64_decode_exec` (which Burp/ffuf can't reproduce with a processing rule) are kept. For a raw-only list, generate with `--encodings none`.
 
 ## Safety & Ethics
 

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -846,6 +846,8 @@ class RCEKit:
 
         if output_format == "burp":
             return self._write_burp(output_path, records, max_payloads, request_template)
+        if output_format == "ffuf":
+            return self._write_ffuf(output_path, records, max_payloads, request_template)
         if output_format == "nuclei":
             return self._write_nuclei(output_path, records, max_payloads, request_template)
 
@@ -931,18 +933,20 @@ class RCEKit:
             rendered += "\n\n" + body.replace("FUZZ", other_sub)
         return rendered
 
-    def _write_burp(self, output_path: Path, records: Iterator[PayloadRecord], max_payloads: Optional[int],
-                    request_template: Optional[Dict[str, Any]] = None) -> int:
-        """Write deduplicated, watermark-free payload wordlists grouped by injection context."""
-        outdir = self._format_outdir(output_path, "burp")
-        outdir.mkdir(parents=True, exist_ok=True)
-        groups: "Dict[str, List[str]]" = {}
+    def _write_wordlists(self, outdir: Path, records: Iterator[PayloadRecord],
+                         max_payloads: Optional[int]) -> Tuple[int, Dict[str, List[str]]]:
+        """Write deduplicated, watermark-free payload wordlists grouped by
+        injection context (``payloads-<context>.txt`` plus a combined
+        ``payloads-all.txt``). Whatever encodings the caller selected are honoured
+        as-is — the wordlist is the literal set of strings to fuzz with, so a
+        ``base64_decode_exec`` or ``random_case`` variant (which Burp/ffuf cannot
+        reproduce with a processing rule) is kept rather than silently dropped.
+        For a raw-only list, generate with ``--encodings none``.
+        """
+        groups: Dict[str, List[str]] = {}
         seen: Set[str] = set()
         count = 0
         for record in records:
-            # Emit the unencoded payloads; Burp/ffuf apply their own encoding.
-            if record.encoding != "none":
-                continue
             if record.payload in seen:
                 continue
             seen.add(record.payload)
@@ -950,37 +954,76 @@ class RCEKit:
             count += 1
             if max_payloads and count >= max_payloads:
                 break
+        for context_name, items in groups.items():
+            (outdir / f"payloads-{context_name}.txt").write_text("\n".join(items) + "\n", encoding="utf-8")
+        all_items = [p for items in groups.values() for p in items]
+        (outdir / "payloads-all.txt").write_text("\n".join(all_items) + "\n", encoding="utf-8")
+        return count, groups
+
+    def _write_burp(self, output_path: Path, records: Iterator[PayloadRecord], max_payloads: Optional[int],
+                    request_template: Optional[Dict[str, Any]] = None) -> int:
+        """Write context-split payload wordlists for Burp Intruder.
+
+        A ``request.txt`` (with Burp's ``\xa7...\xa7`` position marker) is written
+        only when a target profile supplies a real request; without one Burp users
+        set the injection point themselves from a captured request, so no generic
+        placeholder request is emitted.
+        """
+        outdir = self._format_outdir(output_path, "burp")
+        outdir.mkdir(parents=True, exist_ok=True)
+        count = 0
         try:
-            for context_name, items in groups.items():
-                (outdir / f"payloads-{context_name}.txt").write_text("\n".join(items) + "\n", encoding="utf-8")
-            all_items = [p for items in groups.values() for p in items]
-            (outdir / "payloads-all.txt").write_text("\n".join(all_items) + "\n", encoding="utf-8")
-            (outdir / "request.txt").write_text(self._burp_request_template(request_template), encoding="utf-8")
-            logger.info("Burp/ffuf wordlists written to %s/ (%s payloads across %s context files)", outdir, count, len(groups))
+            count, groups = self._write_wordlists(outdir, records, max_payloads)
+            rendered = self._render_request(request_template, "\xa7payload\xa7", "\xa7payload\xa7", "")
+            if rendered:
+                (outdir / "request.txt").write_text(
+                    "# Burp Intruder: load payloads-*.txt as a payload set; the \xa7...\xa7\n"
+                    "# marker below is the injection point from your target profile.\n"
+                    + rendered + "\n", encoding="utf-8")
+                hint = "request.txt from the target profile"
+            else:
+                hint = "set the payload position in Burp from your captured request"
+            logger.info("Burp wordlists written to %s/ (%s payloads across %s context files; %s)",
+                        outdir, count, len(groups), hint)
         except Exception as exc:
             logger.error("Error writing Burp output to %s: %s", outdir, exc)
         return count
 
-    def _burp_request_template(self, request_template: Optional[Dict[str, Any]] = None) -> str:
-        header = (
-            "# Burp Intruder: load payloads-*.txt as a payload set; the injection\n"
-            "# point is Burp's position marker (\xa7...\xa7 below).\n"
-            "# ffuf: replace the marker with FUZZ and run\n"
-            "#   ffuf -request request.txt -w payloads-all.txt:FUZZ\n"
-        )
-        rendered = self._render_request(request_template, "\xa7payload\xa7", "\xa7payload\xa7", "")
-        if rendered:
-            return header + rendered + "\n"
-        return (
-            header
-            + "POST /vulnerable-endpoint HTTP/1.1\n"
-            "Host: TARGET-HOST\n"
-            "User-Agent: rcekit\n"
-            "Content-Type: application/x-www-form-urlencoded\n"
-            "Connection: close\n"
-            "\n"
-            "vulnerable_param=\xa7payload\xa7\n"
-        )
+    def _write_ffuf(self, output_path: Path, records: Iterator[PayloadRecord], max_payloads: Optional[int],
+                    request_template: Optional[Dict[str, Any]] = None) -> int:
+        """Write ffuf wordlists plus, when a target profile supplies a request, a
+        ready-to-run ``request.txt`` (with a real ``FUZZ`` marker) and ``run.sh``.
+
+        Without a request/injection point ffuf has nowhere to inject, so only the
+        wordlists are written and the caller is warned — no unusable placeholder
+        request is fabricated.
+        """
+        outdir = self._format_outdir(output_path, "ffuf")
+        outdir.mkdir(parents=True, exist_ok=True)
+        count = 0
+        try:
+            count, _ = self._write_wordlists(outdir, records, max_payloads)
+            rendered = self._render_request(request_template, "FUZZ", "FUZZ", "")
+            if rendered:
+                (outdir / "request.txt").write_text(rendered + "\n", encoding="utf-8")
+                from urllib.parse import urlsplit
+                proto = urlsplit((request_template or {}).get("url", "")).scheme or "https"
+                run = outdir / "run.sh"
+                run.write_text(
+                    "#!/bin/sh\n"
+                    f"ffuf -request request.txt -w payloads-all.txt -request-proto {proto}\n",
+                    encoding="utf-8")
+                run.chmod(0o755)
+                logger.info("ffuf export written to %s/ (%s payloads; request.txt + run.sh ready)", outdir, count)
+            else:
+                logger.warning(
+                    "ffuf export: no target request/FUZZ marker supplied, so only wordlists were written "
+                    "to %s/. For a runnable attack, pass --target-profile with a `request` block "
+                    "(URL/method/headers/body containing FUZZ) so request.txt and run.sh can be generated.",
+                    outdir)
+        except Exception as exc:
+            logger.error("Error writing ffuf output to %s: %s", outdir, exc)
+        return count
 
     def _write_nuclei(self, output_path: Path, records: Iterator[PayloadRecord], max_payloads: Optional[int],
                       request_template: Optional[Dict[str, Any]] = None) -> int:
@@ -1390,8 +1433,8 @@ def main():
                         help="Path to a custom payload template file (JSON or YAML)")
     parser.add_argument("--detection-only", action="store_true",
                         help="Generate benign payloads for detection and validation")
-    parser.add_argument("--output-format", choices=["text", "jsonl", "burp", "nuclei"], default="text",
-                        help="text/jsonl single file, burp (per-context wordlists + request template), or nuclei (runnable templates)")
+    parser.add_argument("--output-format", choices=["text", "jsonl", "burp", "ffuf", "nuclei"], default="text",
+                        help="text/jsonl single file, burp (per-context wordlists + optional Burp request), ffuf (wordlists + ready request.txt/run.sh when a profile request is given), or nuclei (runnable templates)")
     parser.add_argument("--oob-domain", default=None,
                         help="Collaborator/interactsh domain for out-of-band payloads; each payload gets a unique subdomain token")
     parser.add_argument("--verify-url", default=None,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -553,8 +553,62 @@ class GeneratorTestCase(unittest.TestCase):
             self.assertGreater(count, 0)
             outdir = Path(tmp) / "run_burp"
             self.assertTrue((outdir / "payloads-all.txt").exists())
-            self.assertTrue((outdir / "request.txt").exists())
             self.assertTrue(any(outdir.glob("payloads-*.txt")))
+            # Without a target profile Burp users set positions themselves, so no
+            # generic placeholder request is fabricated.
+            self.assertFalse((outdir / "request.txt").exists())
+
+    def test_wordlist_export_honours_selected_encodings(self):
+        # The exporter must not silently drop encoded variants: an encoding the
+        # tools cannot reproduce (or simply one the user asked for) belongs in the
+        # wordlist as a literal line.
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "run.txt"
+            self.gen.save_payloads_to_file(
+                file_path=str(out), output_format="burp",
+                selected_categories=["basic_enum"], selected_environments=["unix"],
+                selected_contexts=["raw"], selected_encodings=["none", "base64_decode_exec"],
+            )
+            allp = (Path(tmp) / "run_burp" / "payloads-all.txt").read_text()
+            self.assertIn("; id", allp)
+            self.assertTrue(any("base64 -d" in line for line in allp.splitlines()),
+                            "self-contained encoded variants must survive into the wordlist")
+
+    def test_ffuf_export_with_profile_is_runnable(self):
+        request = {"url": "https://target.example/api/v1/lookup", "method": "POST",
+                   "headers": {"Content-Type": "application/json"},
+                   "body": '{"host": "FUZZ"}'}
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "run.txt"
+            self.gen.save_payloads_to_file(
+                file_path=str(out), output_format="ffuf", request_template=request,
+                selected_categories=["basic_enum"], selected_environments=["unix"],
+                selected_contexts=["raw"], selected_encodings=["none"],
+            )
+            outdir = Path(tmp) / "run_ffuf"
+            self.assertTrue((outdir / "payloads-all.txt").exists())
+            req = (outdir / "request.txt").read_text()
+            # A real FUZZ marker, not Burp's section sign.
+            self.assertIn('{"host": "FUZZ"}', req)
+            self.assertNotIn("\xa7", req)
+            run = (outdir / "run.sh").read_text()
+            self.assertIn("ffuf -request request.txt -w payloads-all.txt", run)
+            self.assertIn("-request-proto https", run)
+
+    def test_ffuf_export_without_profile_writes_wordlists_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "run.txt"
+            count = self.gen.save_payloads_to_file(
+                file_path=str(out), output_format="ffuf",
+                selected_categories=["basic_enum"], selected_environments=["unix"],
+                selected_contexts=["raw"], selected_encodings=["none"],
+            )
+            self.assertGreater(count, 0)
+            outdir = Path(tmp) / "run_ffuf"
+            self.assertTrue((outdir / "payloads-all.txt").exists())
+            # No injection point -> no fabricated request or runner.
+            self.assertFalse((outdir / "request.txt").exists())
+            self.assertFalse((outdir / "run.sh").exists())
 
     def test_export_is_profile_request_aware(self):
         request = {"url": "/api/v1/lookup", "method": "POST",


### PR DESCRIPTION
## Summary

The single `burp` format overreached as a "Burp/ffuf integration." This keeps the real value (context-split wordlists, profile-aware requests) and fixes the parts that didn't hold up, without a disruptive rename — `burp` stays, `ffuf` is added.

## Problems fixed

- **ffuf marker was unusable out of the box.** The request file shipped with Burp's `§payload§` marker and a comment telling ffuf users to hand-edit it to `FUZZ`.
- **A fake endpoint was fabricated** (`POST /vulnerable-endpoint … vulnerable_param=§payload§`) when no target profile was given — copy-pasteable but useless.
- **Encoded payloads were silently dropped** (`if record.encoding != "none": continue`), losing self-contained variants like `base64_decode_exec`, `random_case`, and `double_url_encode` that Burp/ffuf cannot reproduce with a processing rule.

## Changes

- **Shared wordlist writer** that honours the caller's `--encodings`: each distinct final payload is emitted as a literal line (dedup on the final string). For a raw-only list, use `--encodings none`.
- **`burp`** — context-split wordlists + `payloads-all.txt`. `request.txt` (with the `§…§` marker) is written **only** when a profile supplies a real request; no placeholder otherwise.
- **`ffuf`** (new format) — same wordlists, plus a ready `request.txt` with a real `FUZZ` marker and an executable `run.sh` (`ffuf -request request.txt -w payloads-all.txt -request-proto <scheme>`, scheme derived from the profile URL) when a profile request is given. Without a request it writes only the wordlists and warns — no fake endpoint.
- README + `--output-format` help updated.

## Tests

- `test_burp_export_writes_context_wordlists` — updated: no `request.txt` without a profile.
- `test_wordlist_export_honours_selected_encodings` — `base64_decode_exec` survives into the wordlist.
- `test_ffuf_export_with_profile_is_runnable` — real `FUZZ` (no `§`), runnable `run.sh` with the right proto.
- `test_ffuf_export_without_profile_writes_wordlists_only` — wordlists only, no `request.txt`/`run.sh`.
- Full suite: 57 tests pass.

## Version

Bumped `2.1.0` → `2.2.0` (minor / new `ffuf` format).

## Notes

Scope was deliberately kept additive: I did not introduce a separate standalone `wordlist` format (it would largely duplicate `burp` without a request) or rename existing formats, to avoid breaking current invocations and integrations.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdiSLKVMLuYoa4FbAmqs79)_