### PR TITLE
Harden ffuf export: require a concrete host, clear stale artifacts

### DIFF
--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -991,36 +991,45 @@ class RCEKit:
 
     def _write_ffuf(self, output_path: Path, records: Iterator[PayloadRecord], max_payloads: Optional[int],
                     request_template: Optional[Dict[str, Any]] = None) -> int:
-        """Write ffuf wordlists plus, when a target profile supplies a request, a
-        ready-to-run ``request.txt`` (with a real ``FUZZ`` marker) and ``run.sh``.
+        """Write ffuf wordlists plus, when a target profile supplies a request
+        with a concrete host, a ready-to-run ``request.txt`` (with a real ``FUZZ``
+        marker) and ``run.sh``.
 
-        Without a request/injection point ffuf has nowhere to inject, so only the
-        wordlists are written and the caller is warned — no unusable placeholder
-        request is fabricated.
+        Without a request/injection point — or with only a path-only URL that
+        can't name the target host — ffuf has nothing runnable to point at, so
+        only the wordlists are written, any stale request/runner is removed, and
+        the caller is warned. No unusable placeholder request is fabricated.
         """
+        from urllib.parse import urlsplit
         outdir = self._format_outdir(output_path, "ffuf")
         outdir.mkdir(parents=True, exist_ok=True)
+        request_path = outdir / "request.txt"
+        run_path = outdir / "run.sh"
         count = 0
         try:
             count, _ = self._write_wordlists(outdir, records, max_payloads)
             rendered = self._render_request(request_template, "FUZZ", "FUZZ", "")
-            if rendered:
-                (outdir / "request.txt").write_text(rendered + "\n", encoding="utf-8")
-                from urllib.parse import urlsplit
-                proto = urlsplit((request_template or {}).get("url", "")).scheme or "https"
-                run = outdir / "run.sh"
-                run.write_text(
+            # ffuf parses the Host from the raw request itself, so a runnable
+            # export needs a concrete host — a path-only profile URL only yields a
+            # `Host: TARGET-HOST` placeholder, which would run against nothing.
+            parts = urlsplit((request_template or {}).get("url", "") if request_template else "")
+            if rendered and parts.netloc:
+                request_path.write_text(rendered + "\n", encoding="utf-8")
+                run_path.write_text(
                     "#!/bin/sh\n"
-                    f"ffuf -request request.txt -w payloads-all.txt -request-proto {proto}\n",
+                    f"ffuf -request request.txt -w payloads-all.txt -request-proto {parts.scheme or 'https'}\n",
                     encoding="utf-8")
-                run.chmod(0o755)
+                run_path.chmod(0o755)
                 logger.info("ffuf export written to %s/ (%s payloads; request.txt + run.sh ready)", outdir, count)
             else:
+                # Wordlist-only: never leave a stale runnable request behind from a
+                # previous profile-backed run against a different target.
+                request_path.unlink(missing_ok=True)
+                run_path.unlink(missing_ok=True)
                 logger.warning(
-                    "ffuf export: no target request/FUZZ marker supplied, so only wordlists were written "
-                    "to %s/. For a runnable attack, pass --target-profile with a `request` block "
-                    "(URL/method/headers/body containing FUZZ) so request.txt and run.sh can be generated.",
-                    outdir)
+                    "ffuf export: no runnable request (needs a --target-profile whose `request.url` is an "
+                    "absolute URL including the host, e.g. https://target.example/path, with a FUZZ marker), "
+                    "so only wordlists were written to %s/.", outdir)
         except Exception as exc:
             logger.error("Error writing ffuf output to %s: %s", outdir, exc)
         return count

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -610,6 +610,53 @@ class GeneratorTestCase(unittest.TestCase):
             self.assertFalse((outdir / "request.txt").exists())
             self.assertFalse((outdir / "run.sh").exists())
 
+    def test_ffuf_export_path_only_profile_is_not_runnable(self):
+        # A path-only URL cannot name the target host, so ffuf has nothing to run
+        # against -> wordlists only, no misleading request.txt/run.sh pointing at
+        # a placeholder host.
+        request = {"url": "/api/v1/lookup", "method": "POST",
+                   "headers": {"Content-Type": "application/json"},
+                   "body": '{"host": "FUZZ"}'}
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "run.txt"
+            self.gen.save_payloads_to_file(
+                file_path=str(out), output_format="ffuf", request_template=request,
+                selected_categories=["basic_enum"], selected_environments=["unix"],
+                selected_contexts=["json"], selected_encodings=["none"],
+            )
+            outdir = Path(tmp) / "run_ffuf"
+            self.assertTrue((outdir / "payloads-all.txt").exists())
+            self.assertFalse((outdir / "request.txt").exists())
+            self.assertFalse((outdir / "run.sh").exists())
+
+    def test_ffuf_export_clears_stale_request_artifacts(self):
+        # A profile-backed run followed by a wordlist-only run on the same output
+        # directory must not leave the old request.txt/run.sh behind, or an
+        # operator could fire a stale runner at the previous target.
+        abs_request = {"url": "https://target.example/api/v1/lookup", "method": "POST",
+                       "headers": {"Content-Type": "application/json"},
+                       "body": '{"host": "FUZZ"}'}
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "run.txt"
+            outdir = Path(tmp) / "run_ffuf"
+            # First run: concrete host -> request.txt + run.sh created.
+            self.gen.save_payloads_to_file(
+                file_path=str(out), output_format="ffuf", request_template=abs_request,
+                selected_categories=["basic_enum"], selected_environments=["unix"],
+                selected_contexts=["json"], selected_encodings=["none"],
+            )
+            self.assertTrue((outdir / "request.txt").exists())
+            self.assertTrue((outdir / "run.sh").exists())
+            # Second run on the same dir with no profile -> stale runner is gone.
+            self.gen.save_payloads_to_file(
+                file_path=str(out), output_format="ffuf",
+                selected_categories=["basic_enum"], selected_environments=["unix"],
+                selected_contexts=["raw"], selected_encodings=["none"],
+            )
+            self.assertTrue((outdir / "payloads-all.txt").exists())
+            self.assertFalse((outdir / "request.txt").exists())
+            self.assertFalse((outdir / "run.sh").exists())
+
     def test_export_is_profile_request_aware(self):
         request = {"url": "/api/v1/lookup", "method": "POST",
                    "headers": {"Content-Type": "application/json"},


### PR DESCRIPTION
## Summary

Follow-up to the ffuf export work, fixing two review findings on `_write_ffuf`.

## Fixes

1. **Require a concrete host before emitting a runner.** A path-only profile URL (e.g. the shipped `profiles/json-api-post.json` → `/api/v1/lookup`) only resolves to a `Host: TARGET-HOST` placeholder, so the "ready" `run.sh` would fire ffuf at nothing. `request.txt`/`run.sh` are now written **only** when the profile URL carries a host (absolute URL); otherwise the export falls back to wordlist-only with a clear warning telling the user to supply an absolute URL. This closes the last instance of the "unusable artifact" problem the ffuf format was meant to eliminate.
2. **Clear stale artifacts on wordlist-only runs.** Re-running an export to a directory that previously held a profile-backed `request.txt`/`run.sh` now removes those files, so an operator can't accidentally run a stale runner against the previous target.

## Tests

- `test_ffuf_export_path_only_profile_is_not_runnable` — path-only profile → wordlists only, no `request.txt`/`run.sh`.
- `test_ffuf_export_clears_stale_request_artifacts` — profile-backed run followed by a wordlist-only run leaves no stale runner.
- Existing `test_ffuf_export_with_profile_is_runnable` still passes (absolute URL → runnable). Full suite: 59 tests.

## Version

Bumped `2.2.0` → `2.2.1` (patch).

## Note

Deliberately out of scope: stale *wordlist* files (e.g. a leftover `payloads-json.txt` when a later run only produces `payloads-raw.txt`) are not cleaned — that is a separate, broader concern affecting `burp` too, and wasn't part of these findings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdiSLKVMLuYoa4FbAmqs79)_