### PR TITLE
Reject reflected canaries with a paired same-token control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.3.0** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.3.1** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just
@@ -15,7 +15,7 @@ payload generation:
 - **Targeted generation** — payloads tailored to the **environment** (Unix, Windows, Node.js, Python, PHP, Java, .NET, Ruby, Perl, Go, GraphQL, MongoDB/NoSQL, Docker, Kubernetes), the injection **context** (with container-aware escaping for JSON/XML/YAML/headers/shell-quoted strings), and the specific execution **sink** (OS commands, SSTI, SpEL/OGNL/Groovy, Mongo `$where`, …).
 - **Executable-only output** — every payload runs as-is on its channel/sink or carries its own decoder; non-runnable transforms are removed and decoder-required blobs are opt-in, so you never copy a payload that silently does nothing.
 - **Sink-aware target profiles** — describe the target once (denied characters, max length, needs-separator, blind, decodes-input) and emit only payloads that could actually fire.
-- **Auto-verification** — `--verify-url` fires payloads at an authorised target and reports which executed, using each payload's built-in oracle: a `match` regex, a reflected canary, or a timing delay. Confirmation is **differential**, so `confirmed` means execution and not coincidence: a timing hit must clear a noise-aware margin over a multi-sample baseline *and* reproduce on a re-fire, and a command-output signature already present in the payload-free response is reported `inconclusive` instead of a false positive.
+- **Auto-verification** — `--verify-url` fires payloads at an authorised target and reports which executed, using each payload's built-in oracle: a `match` regex, a reflected canary, or a timing delay. Confirmation is **differential**, so `confirmed` means execution and not coincidence: a timing hit must clear a noise-aware margin over a multi-sample baseline *and* reproduce on a re-fire, a reflected canary is re-checked against a paired same-token control so a target that merely echoes input is not mistaken for execution, and a command-output signature already present in the payload-free response is reported `inconclusive` instead of a false positive.
 - **Built-in OOB listener** — `--listen` receives HTTP/DNS callbacks and correlates each back to the exact payload, closing the blind-RCE loop without a separate interactsh/Collaborator.
 - **Tooling integrations** — export as context-split Burp wordlists, a ready-to-run ffuf attack (`request.txt` + `run.sh`) when a target profile is given, or runnable Nuclei templates with built-in OOB / time-based / reflection oracles.
 - **Safe by default** — a benign `--detection-only` canary mode, safety tiers, a consent gate, and audit logging.
@@ -254,8 +254,12 @@ python rcekit.py --acknowledge-consent --environments unix --categories basic_en
 Confirmation is differential to avoid false positives: the timing oracle samples
 the baseline several times and requires a candidate delay to both clear a
 noise-aware margin and reproduce on a second fire (a one-off slow response is
-reported `no-delay`), and the reflection oracle reports `inconclusive` when the
-command-output signature already appears in the payload-free response.
+reported `no-delay`), and the reflection oracle reports `inconclusive` rather
+than a false `confirmed` when the match is not proof of execution: a canary hit
+is re-checked against a paired **same-token control** (the token in an inert,
+non-executing carrier at the same injection point), so a target that merely
+echoes input cannot pass as execution, and a command-output signature is checked
+against the payload-free baseline response.
 
 Rate-limit with `--verify-delay` and cap with `--max-payloads`. OOB payloads are
 sent but confirmed out-of-band (see below). **Destructive payloads (persistence,

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -1235,9 +1235,13 @@ class RCEKit:
           (a noise-aware threshold, not a fixed constant) *and* reproduce on a
           second fire (``elapsed_confirm``); a one-off slow response is jitter,
           not a sleep, and is reported ``no-delay``.
-        * **reflection** — a ``match`` that is already present in the
-          payload-free ``control_body`` is not evidence of execution, so it is
-          reported ``inconclusive`` rather than a false ``confirmed``.
+        * **reflection** — a ``match`` that is also present in ``control_body``
+          is not evidence of execution, so it is reported ``inconclusive``
+          rather than a false ``confirmed``. For a canary token the caller
+          supplies a *same-token* control (the token in an inert, non-executing
+          carrier), so a target that merely echoes input cannot masquerade as
+          execution; for a command-output signature the control is the
+          payload-free baseline response.
         """
         if status is None:
             return "error", body[:80]
@@ -1253,6 +1257,9 @@ class RCEKit:
         if record.match:
             if re.search(record.match, body):
                 if control_body and re.search(record.match, control_body):
+                    if record.token:
+                        return "inconclusive", ("canary reflected by the target in an inert control "
+                                                "(no execution needed), so the match is not proof")
                     return "inconclusive", f"signature /{record.match}/ also present without the payload"
                 return "confirmed", f"matched /{record.match}/"
             return "no-match", ""
@@ -1322,8 +1329,21 @@ class RCEKit:
             is_timing = record.expected_channel == "timing" or record.blocking
             if is_timing and status is not None and elapsed - baseline >= margin:
                 _, _, elapsed_confirm = fire(record.payload)
+            # Paired negative control for a reflected canary. The canary token
+            # sits verbatim in the payload, so a target that merely echoes input
+            # returns it without executing anything. Re-fire the SAME token in an
+            # inert carrier (no command structure) at the same injection point:
+            # if the token still comes back, the match is reflection, not
+            # execution, and _evaluate_verify downgrades it to inconclusive. Only
+            # done when the primary actually matched, so it costs nothing on the
+            # vast majority of payloads.
+            reflection_control = control_body
+            if (record.token and record.match and not is_timing
+                    and record.expected_channel != "interactsh"
+                    and status is not None and re.search(record.match, body)):
+                _, reflection_control, _ = fire(f"rcekit-control-{record.token}")
             verdict, detail = self._evaluate_verify(
-                record, status, body, elapsed, baseline, margin, control_body, elapsed_confirm)
+                record, status, body, elapsed, baseline, margin, reflection_control, elapsed_confirm)
             results.append({
                 "verdict": verdict, "detail": detail, "status": status,
                 "payload": record.payload, "category": record.category,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -915,6 +915,95 @@ class GeneratorTestCase(unittest.TestCase):
             server.shutdown()
             server.server_close()
 
+    def test_canary_oracle_rejects_reflected_token(self):
+        # The same-token control disambiguates reflection from execution.
+        rec = make_record(payload="echo DETECTION_ABC123", token="ABC123",
+                          match=r"ABC123", expected_channel="response")
+        # Token in the response AND in the inert same-token control -> the target
+        # echoes input, so the match is not proof of execution.
+        reflected, _ = self.gen._evaluate_verify(
+            rec, 200, "you sent: echo DETECTION_ABC123", elapsed=0.1, baseline=0.1,
+            control_body="you sent: rcekit-control-ABC123")
+        self.assertEqual(reflected, "inconclusive")
+        # Token in the response but absent from the inert control -> execution.
+        executed, _ = self.gen._evaluate_verify(
+            rec, 200, "DETECTION_ABC123", elapsed=0.1, baseline=0.1,
+            control_body="(command not found)")
+        self.assertEqual(executed, "confirmed")
+
+    def _run_detection_echo_verify(self, handler_cls):
+        import socketserver
+        import threading
+
+        server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), handler_cls)
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            records = [
+                r for r in self.gen.generate_payload_records(
+                    mode="detection", selected_environments=["unix"],
+                    selected_contexts=["raw"], selected_encodings=["none"])
+                if r.payload.startswith("echo DETECTION_")
+            ]
+            self.assertTrue(records, "expected a canary detection payload")
+            results = self.gen.run_verification(
+                records, url=f"http://127.0.0.1:{port}/lookup?host=FUZZ")
+            return [r for r in results if r["payload"].startswith("echo DETECTION_")]
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_verify_canary_inconclusive_against_reflecting_target(self):
+        # A target that echoes input back returns the canary without executing
+        # anything, so it must never be reported as confirmed execution.
+        import http.server
+        import urllib.parse as up
+
+        class Reflect(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_GET(self):
+                q = up.parse_qs(up.urlparse(self.path).query)
+                host = q.get("host", [""])[0]
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(host.encode(errors="replace"))  # reflect, do NOT execute
+
+        echoed = self._run_detection_echo_verify(Reflect)
+        self.assertTrue(echoed)
+        self.assertEqual(echoed[0]["verdict"], "inconclusive")
+        self.assertFalse(any(r["verdict"] == "confirmed" for r in echoed),
+                         "a reflected canary must not confirm execution")
+
+    def test_verify_canary_confirmed_against_executing_target(self):
+        # A target that actually runs the input yields the canary only for the
+        # executing payload, not for the inert same-token control -> confirmed.
+        import http.server
+        import os
+        import urllib.parse as up
+
+        class Execute(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_GET(self):
+                q = up.parse_qs(up.urlparse(self.path).query)
+                host = q.get("host", [""])[0]
+                pipe = os.popen(host + " 2>/dev/null")  # runs the input directly
+                out = pipe.read()
+                pipe.close()
+                self.send_response(200)
+                self.end_headers()
+                try:
+                    self.wfile.write(out.encode(errors="replace"))
+                except BrokenPipeError:
+                    pass
+
+        executed = self._run_detection_echo_verify(Execute)
+        self.assertTrue(executed)
+        self.assertEqual(executed[0]["verdict"], "confirmed")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

The canary detection oracle set `match = re.escape(token)` and reported `confirmed` on any response containing the token. But the canary sits **verbatim** in the payload (`echo DETECTION_<token>`), so a target that merely reflects/echoes input returns the token **without executing anything** — a false positive. The existing differential control did not catch it: the baseline requests used a *different* random string, so the reflected token was never present in the control body.

## Fix

When a canary match is seen, re-fire the **same token** in an inert, non-executing carrier (`rcekit-control-<token>`) at the same injection point:

- Token still comes back in the control → the target reflects input, so the match is **not** proof of execution → verdict downgraded to `inconclusive`.
- Token present only for the real payload → genuine execution → `confirmed`.

The control request only fires when the primary payload actually matched, so it costs nothing on the vast majority of payloads. Command-output signatures (e.g. `uid=\d+`) keep using the payload-free baseline as their control, unchanged.

This trades a false positive on reflect-only targets for correctness; an execute-*and*-reflect target is now reported `inconclusive` rather than falsely `confirmed`, which is the safe direction.

## Tests

- Unit test for the token control (reflected → `inconclusive`, executed → `confirmed`).
- End-to-end test against a reflecting target (echoes input) → must be `inconclusive`.
- End-to-end test against an executing target (runs the input) → must be `confirmed`.
- Full suite: 66/66 green, offline, no third-party dependencies.

## Versioning

Bumped to `2.3.1` (false-positive fix) and synced the README version badge.

---
_Generated by [Claude Code](https://claude.ai/code/session_013vVUUNtsiMzfdCKPouUjB6)_