### PR TITLE
Make the timing oracle expected-delay aware and fix OOB/timeout ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.3.1** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.4.0** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just
@@ -254,7 +254,12 @@ python rcekit.py --acknowledge-consent --environments unix --categories basic_en
 Confirmation is differential to avoid false positives: the timing oracle samples
 the baseline several times and requires a candidate delay to both clear a
 noise-aware margin and reproduce on a second fire (a one-off slow response is
-reported `no-delay`), and the reflection oracle reports `inconclusive` rather
+reported `no-delay`). The timing threshold and per-request timeout adapt to each
+payload's own `expected_delay_ms` (parsed from the sleep call, runtime-aware), so
+a short sleep that the old flat 2s floor could never confirm now can, and a
+request that hangs past the timeout is reported `timing-candidate-on-timeout`
+(the hang may be the expected delay) rather than a flat `error`. The reflection
+oracle reports `inconclusive` rather
 than a false `confirmed` when the match is not proof of execution: a canary hit
 is re-checked against a paired **same-token control** (the token in an inert,
 non-executing carrier at the same injection point), so a target that merely

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.3.1"
+__version__ = "2.4.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -53,6 +53,7 @@ class PayloadRecord:
     token: Optional[str] = None
     oob_host: Optional[str] = None
     match: Optional[str] = None
+    expected_delay_ms: Optional[int] = None
 
 class RCEKit:
     def __init__(
@@ -344,6 +345,60 @@ class RCEKit:
         if re.search(r"(^|[^a-z0-9_])(pg_)?sleep\(", lower_payload) or ".sleep(" in lower_payload:
             return True
         return False
+
+    def _expected_delay_ms(self, payload: str, environment: str) -> Optional[int]:
+        """Best-effort parse of a blocking payload's intended delay, in
+        milliseconds. The runtime disambiguates the seconds-vs-milliseconds
+        sleep APIs (``time.sleep(2)`` is 2s in Python but ``Thread.sleep(2000)``
+        is 2000ms in Java). Returns ``None`` when no delay can be determined, so
+        the verifier falls back to its conservative fixed floor."""
+        low = payload.lower()
+
+        def sec(value: str) -> int:
+            return int(round(float(value) * 1000))
+
+        # Explicit, unambiguous units first.
+        match = re.search(r"-milliseconds\s+([\d.]+)", low)
+        if match:
+            return int(round(float(match.group(1))))
+        match = re.search(r"-seconds\s+([\d.]+)", low)
+        if match:
+            return sec(match.group(1))
+        match = re.search(r"timeout\s+/t\s+([\d.]+)", low)
+        if match:
+            return sec(match.group(1))
+        # Go: time.Sleep(N * time.Second|Millisecond).
+        match = re.search(r"time\.sleep\(\s*([\d.]+)\s*\*\s*time\.(second|millisecond)", low)
+        if match:
+            return sec(match.group(1)) if match.group(2) == "second" else int(round(float(match.group(1))))
+        # Perl: select(undef, undef, undef, N) -> seconds.
+        match = re.search(r"select\(\s*undef\s*,\s*undef\s*,\s*undef\s*,\s*([\d.]+)", low)
+        if match:
+            return sec(match.group(1))
+        # Java / .NET Thread.Sleep(N) -> milliseconds.
+        if "thread.sleep(" in low:
+            match = re.search(r"thread\.sleep\(\s*([\d.]+)", low)
+            if match:
+                return int(round(float(match.group(1))))
+        # Node: setTimeout(cb, N) -> milliseconds.
+        match = re.search(r"settimeout\([^,]*,\s*([\d.]+)\s*\)", low)
+        if match:
+            return int(round(float(match.group(1))))
+        # SQL sleep helpers -> seconds.
+        if environment in {"sql"}:
+            match = re.search(r"(?:pg_sleep|sleep)\(\s*([\d.]+)", low)
+            if match:
+                return sec(match.group(1))
+        # Python / Ruby sleep(N)/time.sleep(N) -> seconds.
+        if environment in {"python", "ruby"}:
+            match = re.search(r"sleep\(\s*([\d.]+)", low)
+            if match:
+                return sec(match.group(1))
+        # Shell `sleep N` (seconds); also the generic fallback.
+        match = re.search(r"\bsleep\s+([\d.]+)", low)
+        if match:
+            return sec(match.group(1))
+        return None
 
     def _is_stateful(self, payload: str) -> bool:
         lower_payload = payload.lower()
@@ -688,6 +743,7 @@ class RCEKit:
     ) -> Iterator[PayloadRecord]:
         context = self.contexts[context_name]
         destructive = self._is_destructive(payload, category)
+        expected_delay_ms = self._expected_delay_ms(payload, environment) if blocking else None
         for enc_name in encodings:
             if enc_name not in self.encoding_methods or not self._encoding_is_compatible(enc_name, runner):
                 continue
@@ -759,6 +815,7 @@ class RCEKit:
                     token=token,
                     oob_host=oob_host,
                     match=match,
+                    expected_delay_ms=expected_delay_ms,
                 )
             except Exception as exc:
                 logger.error("Error encoding payload with %s: %s", enc_name, exc)
@@ -1232,9 +1289,13 @@ class RCEKit:
         coincidence:
 
         * **timing** — a candidate delay must clear ``baseline`` by ``margin``
-          (a noise-aware threshold, not a fixed constant) *and* reproduce on a
+          (a noise-aware threshold that adapts to the payload's own
+          ``expected_delay_ms``, not a fixed constant) *and* reproduce on a
           second fire (``elapsed_confirm``); a one-off slow response is jitter,
-          not a sleep, and is reported ``no-delay``.
+          not a sleep, and is reported ``no-delay``. A request that hangs past
+          the timeout (``status is None``) is itself a signal for a sleep
+          payload — reported ``timing-candidate-on-timeout`` rather than a flat
+          ``error`` — since the timeout may be the expected delay.
         * **reflection** — a ``match`` that is also present in ``control_body``
           is not evidence of execution, so it is reported ``inconclusive``
           rather than a false ``confirmed``. For a canary token the caller
@@ -1243,17 +1304,28 @@ class RCEKit:
           execution; for a command-output signature the control is the
           payload-free baseline response.
         """
-        if status is None:
-            return "error", body[:80]
+        # OOB is confirmed out-of-band, so a timed-out delivery request does not
+        # change the verdict — check it before the generic status==None error.
         if record.expected_channel == "interactsh":
             return "oob-pending", f"watch token {record.token} at your OOB listener"
         if record.expected_channel == "timing" or record.blocking:
+            if status is None:
+                # The delivery request hung past the timeout. For a sleep payload
+                # that hang is the signal, but we could not measure it, so flag a
+                # candidate the operator can confirm with a larger --verify-timeout.
+                if elapsed - baseline >= margin:
+                    return "timing-candidate-on-timeout", (
+                        f"request hung {elapsed:.1f}s (>= timeout) vs baseline {baseline:.1f}s; "
+                        "raise --verify-timeout above the expected delay to confirm")
+                return "error", body[:80]
             if elapsed - baseline < margin:
                 return "no-delay", f"{elapsed:.1f}s vs baseline {baseline:.1f}s (needs +{margin:.1f}s)"
             if elapsed_confirm is not None and elapsed_confirm - baseline < margin:
                 return "no-delay", (f"delay {elapsed:.1f}s did not reproduce on re-fire "
                                     f"({elapsed_confirm:.1f}s vs baseline {baseline:.1f}s)")
             return "confirmed", f"delay {elapsed:.1f}s vs baseline {baseline:.1f}s (margin {margin:.1f}s)"
+        if status is None:
+            return "error", body[:80]
         if record.match:
             if re.search(record.match, body):
                 if control_body and re.search(record.match, control_body):
@@ -1286,13 +1358,13 @@ class RCEKit:
         if data is not None:
             logger.info("Verification body injected as '%s'", resolved_body_location)
 
-        def fire(payload: str):
+        def fire(payload: str, req_timeout: Optional[float] = None):
             target, body, hdrs = self._build_verify_request(
                 payload, url, data, headers, url_location, resolved_body_location)
             request = urllib.request.Request(target, data=body, headers=hdrs, method=method)
             start = time.time()
             try:
-                with urllib.request.urlopen(request, timeout=timeout) as response:
+                with urllib.request.urlopen(request, timeout=req_timeout or timeout) as response:
                     return response.status, response.read().decode(errors="replace"), time.time() - start
             except urllib.error.HTTPError as exc:
                 return exc.code, exc.read().decode(errors="replace"), time.time() - start
@@ -1314,7 +1386,7 @@ class RCEKit:
             control_body = cbody
         baseline = statistics.median(baseline_samples)
         spread = max(baseline_samples) - min(baseline_samples)
-        margin = max(2.0, 3 * spread)
+        noise = 3 * spread
 
         results: List[Dict[str, Any]] = []
         seen: Set[str] = set()
@@ -1322,13 +1394,26 @@ class RCEKit:
             if record.payload in seen:
                 continue
             seen.add(record.payload)
-            status, body, elapsed = fire(record.payload)
+            is_timing = record.expected_channel == "timing" or record.blocking
+            # Adapt the confirmation threshold and the request timeout to the
+            # payload's own expected delay. A known short sleep (e.g. 1s) only
+            # needs to clear the measured noise plus half its expected delay, so
+            # it is no longer unverifiable under the old flat 2s floor; an unknown
+            # delay keeps the conservative 2s floor. The timeout is stretched past
+            # the expected delay so the sleep can complete instead of timing out.
+            expected = (record.expected_delay_ms / 1000.0) if (is_timing and record.expected_delay_ms) else None
+            if expected is not None:
+                margin = max(0.5, noise, 0.5 * expected)
+                req_timeout = max(timeout, baseline + expected + 2.0)
+            else:
+                margin = max(2.0, noise)
+                req_timeout = timeout
+            status, body, elapsed = fire(record.payload, req_timeout if is_timing else None)
             # Only a candidate delay is worth a confirmatory re-fire; this keeps
             # the extra request off the vast majority of payloads.
             elapsed_confirm: Optional[float] = None
-            is_timing = record.expected_channel == "timing" or record.blocking
             if is_timing and status is not None and elapsed - baseline >= margin:
-                _, _, elapsed_confirm = fire(record.payload)
+                _, _, elapsed_confirm = fire(record.payload, req_timeout)
             # Paired negative control for a reflected canary. The canary token
             # sits verbatim in the payload, so a target that merely echoes input
             # returns it without executing anything. Re-fire the SAME token in an
@@ -1754,6 +1839,12 @@ def main():
         oob_pending = [r for r in results if r["verdict"] == "oob-pending"]
         if oob_pending:
             print(f"\n[verify] {len(oob_pending)} OOB payloads sent — check your listener for the tokens.")
+        timing_candidates = [r for r in results if r["verdict"] == "timing-candidate-on-timeout"]
+        if timing_candidates:
+            print(f"\n[verify] {len(timing_candidates)} TIMING CANDIDATES timed out (the hang may be the "
+                  "expected delay — raise --verify-timeout above it to confirm):")
+            for result in timing_candidates:
+                print(f"  [{result['category']}/{result['context']}] {result['payload']}   ({result['detail']})")
         if not confirmed and not oob_pending:
             print("\n[verify] No execution confirmed. The target may be patched, or the payloads "
                   "may not fit its sink/context (try --target-profile or a different --environments/--contexts).")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1004,6 +1004,97 @@ class GeneratorTestCase(unittest.TestCase):
         self.assertTrue(executed)
         self.assertEqual(executed[0]["verdict"], "confirmed")
 
+    def test_expected_delay_ms_is_runtime_aware(self):
+        cases = [
+            ("sleep 5", "unix", 5000),
+            ("sleep 2", "docker", 2000),
+            ("sleep 1", "ruby", 1000),
+            ("timeout /T 5", "windows", 5000),
+            ("Start-Sleep -Seconds 3", "powershell", 3000),
+            ("Start-Sleep -Milliseconds 500", "powershell", 500),
+            ("import time; time.sleep(2)", "python", 2000),
+            ("__import__('time').sleep(1)", "python", 1000),
+            ("Thread.sleep(2000)", "java", 2000),
+            ("System.Threading.Thread.Sleep(2000)", "dotnet", 2000),
+            ("select(undef, undef, undef, 1)", "perl", 1000),
+            ("time.Sleep(1 * time.Second)", "go", 1000),
+            ("SELECT pg_sleep(1)", "sql", 1000),
+            ("setTimeout(()=>console.log('x'), 1000)", "nodejs", 1000),
+            ("echo DETECTION_ABC", "unix", None),  # not a sleep
+        ]
+        for payload, env, expected in cases:
+            self.assertEqual(self.gen._expected_delay_ms(payload, env), expected,
+                             f"{payload!r} @ {env}")
+
+    def test_generated_blocking_record_carries_expected_delay(self):
+        records = list(self.gen.generate_payload_records(
+            mode="detection", selected_environments=["unix"],
+            selected_contexts=["raw"], selected_encodings=["none"],
+            include_blocking=True))
+        sleeps = [r for r in records if r.payload == "sleep 5"]
+        self.assertTrue(sleeps, "the blocking 'sleep 5' detection payload should be present")
+        self.assertTrue(sleeps[0].blocking)
+        self.assertEqual(sleeps[0].expected_delay_ms, 5000)
+        # A non-blocking payload leaves the field unset.
+        echoes = [r for r in records if r.payload.startswith("echo DETECTION_")]
+        self.assertTrue(echoes)
+        self.assertIsNone(echoes[0].expected_delay_ms)
+
+    def test_oob_pending_survives_a_timed_out_delivery(self):
+        # An OOB payload is confirmed out-of-band, so a timed-out delivery
+        # request (status=None) must stay oob-pending, not become a flat error.
+        rec = make_record(payload="; curl http://x/", expected_channel="interactsh", token="TOK")
+        verdict, _ = self.gen._evaluate_verify(
+            rec, None, "timed out", elapsed=8.0, baseline=1.0, margin=2.0)
+        self.assertEqual(verdict, "oob-pending")
+
+    def test_timing_timeout_is_a_candidate_not_an_error(self):
+        rec = make_record(payload="; sleep 8", expected_channel="timing", blocking=True)
+        # Hung past the timeout for at least the margin -> the hang may be the
+        # sleep itself, so surface it as a candidate rather than a flat error.
+        verdict, _ = self.gen._evaluate_verify(
+            rec, None, "timed out", elapsed=6.0, baseline=1.0, margin=2.0)
+        self.assertEqual(verdict, "timing-candidate-on-timeout")
+        # A short hang that never cleared the margin is just an error.
+        verdict, _ = self.gen._evaluate_verify(
+            rec, None, "boom", elapsed=1.2, baseline=1.0, margin=2.0)
+        self.assertEqual(verdict, "error")
+
+    def test_verify_confirms_subsecond_sleep_via_expected_delay(self):
+        # A 1s sleep — impossible to confirm under the old flat 2s floor — is
+        # confirmed once the threshold adapts to the payload's expected delay.
+        import http.server
+        import socketserver
+        import threading
+        import time as _time
+        import urllib.parse as up
+
+        class Sleeper(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_GET(self):
+                q = up.parse_qs(up.urlparse(self.path).query)
+                host = q.get("host", [""])[0]
+                if "sleep" in host:
+                    _time.sleep(1.0)  # the injected 1s sleep executes here
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"")
+
+        server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), Sleeper)
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            records = [make_record(payload="; sleep 1", expected_channel="timing",
+                                   blocking=True, expected_delay_ms=1000)]
+            results = self.gen.run_verification(
+                records, url=f"http://127.0.0.1:{port}/lookup?host=FUZZ")
+            self.assertEqual(results[0]["verdict"], "confirmed")
+        finally:
+            server.shutdown()
+            server.server_close()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Three timing-oracle defects undermined blind RCE detection:

1. **Flat 2s floor.** The confirmation margin was `max(2.0, 3*spread)`, so any payload sleeping under 2s (the corpus has 500ms, 1s and 2s sleeps) could never be confirmed — the delay could not clear the floor no matter how clean the baseline.
2. **`status==None` treated as a flat error.** A sleep that outlived the request timeout returned `status=None → error`, even though that hang can be exactly the expected signal.
3. **OOB ordering bug.** The `status is None → error` check ran *before* the `interactsh` branch, so an OOB payload whose delivery request timed out was reported `error` instead of `oob-pending`.

## Fix

- **`expected_delay_ms` metadata.** Parse each blocking payload's intended delay into a new runtime-aware `PayloadRecord.expected_delay_ms` field. The runtime disambiguates the seconds-vs-milliseconds sleep APIs (`time.sleep(2)` = 2s in Python, `Thread.sleep(2000)` = 2000ms in Java, `Start-Sleep -Milliseconds 500`, `pg_sleep(1)`, `time.Sleep(1 * time.Second)`, …). It also surfaces in the JSONL/meta output for operators.
- **Adaptive threshold + timeout.** For a known delay the verifier requires only `max(0.5, noise, 0.5 × expected)` and stretches the per-request timeout past the delay so the sleep can complete; an unknown delay keeps the conservative 2s floor. A short sleep is now confirmable when the baseline is clean.
- **Reordered `_evaluate_verify`.** The `interactsh` branch runs before the `status is None` check, so a timed-out OOB delivery stays `oob-pending`; and a sleep payload that hangs past the timeout is reported `timing-candidate-on-timeout` (surfaced in the CLI summary) rather than a flat `error`.

## Tests

- Runtime-aware delay parser across unix/windows/powershell/python/java/dotnet/perl/go/sql/nodejs/ruby.
- Generated blocking record carries `expected_delay_ms`; a non-blocking one leaves it unset.
- OOB stays `oob-pending` on a timed-out delivery.
- `timing-candidate-on-timeout` vs plain `error`.
- End-to-end: a 1s sleep — impossible under the old 2s floor — is now `confirmed`.
- Full suite: 71/71 green, offline, no third-party dependencies.

## Versioning

Bumped to `2.4.0` (new metadata field, verdict and adaptive behaviour) and synced the README version badge.

## Not included (possible follow-up)

The Nuclei exporter still only normalises `sleep N` / `-seconds N` / `/t N` / `pg_sleep(N)` to its `duration>=6` matcher and misses millisecond APIs (`Thread.sleep(2000)`, `time.Sleep(...)`); wiring `expected_delay_ms` into that exporter is a separate change.

---
_Generated by [Claude Code](https://claude.ai/code/session_013vVUUNtsiMzfdCKPouUjB6)_