### PR TITLE
Hard-fail on a missing or empty corpus and add --doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.5.0** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.6.0** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just
@@ -53,6 +53,10 @@ python rcekit.py --listen --correlate payloads.txt.map.jsonl
 Exploitation payloads require `--acknowledge-consent`; `--detection-only` is benign
 and does not. Only run any of this against systems you are authorised to test.
 
+If the payload corpus is missing or corrupt (for example quarantined by EDR after
+clone), RCEKit refuses to run and exits non-zero instead of silently generating
+nothing. Run `python rcekit.py --doctor` to check corpus integrity.
+
 ## Options
 
 | Option | Description | Default |
@@ -66,6 +70,7 @@ and does not. Only run any of this against systems you are authorised to test.
 | `--max-payloads` | Cap the number of payloads | Unlimited |
 | `--attacker-ip` / `--attacker-domain` | Substituted into reverse-shell / download payloads | `192.168.1.100` / `attacker.com` |
 | `--template-file` | Custom JSON/YAML payload templates | `templates/payloads.json` |
+| `--doctor` | Check corpus integrity (template found, parses, payload counts) and exit non-zero if missing/empty | Off |
 | `--detection-only` | Benign canary/timing probes for safe validation | Off |
 | `--include-metadata` | Write a `.meta.jsonl` sidecar (indicators, safety tiers, notes) | Off |
 | `--max-safety` | Highest safety tier: `safe`, `intrusive`, `stateful` | `safe` (detection) / `intrusive` |

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.5.0"
+__version__ = "2.6.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -168,11 +168,16 @@ class RCEKit:
         self.default_encodings = ["none", "url_encode", "double_url_encode", "random_case", "base64_decode_exec"]
 
     def _load_template_payloads(self) -> None:
-        """Load payload templates from JSON/YAML files."""
+        """Load payload templates from JSON/YAML files. Records the reason in
+        ``self.template_error`` (``None`` on success) so callers can hard-fail
+        on a missing or corrupt corpus instead of silently generating nothing."""
+        self.template_error: Optional[str] = None
         if not self.template_path.exists():
-            logger.warning("Template file %s not found. Using fallback templates.", self.template_path)
+            message = f"template file not found: {self.template_path}"
+            logger.warning("%s", message)
             self.payload_categories = {}
             self.detection_payloads = {}
+            self.template_error = message
             return
 
         try:
@@ -193,9 +198,63 @@ class RCEKit:
             self.payload_categories = data.get("payload_categories", {})
             self.detection_payloads = data.get("detection_payloads", {})
         except Exception as exc:
-            logger.error("Unable to load payload templates: %s", exc)
+            message = f"unable to parse {self.template_path}: {exc}"
+            logger.error("%s", message)
             self.payload_categories = {}
             self.detection_payloads = {}
+            self.template_error = message
+
+    def _corpus_stats(self) -> Tuple[int, int, Set[str]]:
+        """Return (exploit payload count, environment count, environments)."""
+        total = 0
+        envs: Set[str] = set()
+        for category in self.payload_categories.values():
+            if not isinstance(category, dict):
+                continue
+            for env, payloads in category.items():
+                envs.add(env)
+                if isinstance(payloads, dict):
+                    total += sum(len(items) for items in payloads.values())
+                else:
+                    total += len(payloads)
+        return total, len(envs), envs
+
+    def check_integrity(self) -> Tuple[bool, List[str]]:
+        """Validate the loaded payload corpus for the ``--doctor`` health check.
+        Returns ``(ok, report_lines)``."""
+        report = [f"template: {self.template_path}"]
+        if self.template_error:
+            report.append(f"  [FAIL] {self.template_error}")
+            return False, report
+        report.append("  [ok] file loaded and parsed")
+        total, env_count, _ = self._corpus_stats()
+        detection_total = sum(len(v) for v in self.detection_payloads.values())
+        report.append(f"  exploit categories: {len(self.payload_categories)}  "
+                      f"payloads: {total}  environments: {env_count}")
+        report.append(f"  detection environments: {len(self.detection_payloads)}  "
+                      f"payloads: {detection_total}")
+        ok = True
+        if not self.payload_categories:
+            report.append("  [warn] no exploit payload categories loaded")
+        if not self.detection_payloads:
+            report.append("  [warn] no detection payloads loaded")
+        if not self.payload_categories and not self.detection_payloads:
+            report.append("  [FAIL] corpus is empty")
+            ok = False
+        return ok, report
+
+    def corpus_ready(self, mode: str) -> Tuple[bool, str]:
+        """Whether the corpus can serve a run in ``mode`` ('detection' or
+        'exploit'). Returns ``(ok, reason)``; used to hard-fail before a run
+        would otherwise silently generate zero payloads."""
+        if self.template_error:
+            return False, self.template_error
+        if mode == "detection":
+            if not self.detection_payloads:
+                return False, "no detection payloads loaded from the corpus"
+        elif not self.payload_categories:
+            return False, "no exploit payload categories loaded from the corpus"
+        return True, ""
 
     def apply_watermark(self, payload: str, env: str, context_name: str, marker: str) -> str:
         """Embed a watermark comment or command into generated payloads where feasible."""
@@ -1705,6 +1764,8 @@ def main():
                              "back reverse shells, download-execute, credential access, lateral movement, "
                              "container escape, cloud-metadata and OOB payloads; pass 'intrusive' to include "
                              "them. Independent of --max-safety, which only governs file output")
+    parser.add_argument("--doctor", action="store_true",
+                        help="Run a corpus integrity check (template found, parses, payload counts) and exit non-zero if it is missing or empty")
     parser.add_argument("--listen", action="store_true",
                         help="Run the built-in OOB listener (HTTP+DNS) that records callbacks and correlates them to payload tokens")
     parser.add_argument("--listen-http-port", type=int, default=8080,
@@ -1804,6 +1865,14 @@ def main():
         template_path=template_path,
     )
 
+    if args.doctor:
+        ok, report = generator.check_integrity()
+        print("[doctor] RCEKit corpus integrity check")
+        for line in report:
+            print(line)
+        print("[doctor] OK" if ok else "[doctor] PROBLEMS FOUND")
+        return 0 if ok else 1
+
     if sink_decodes:
         # The sink decodes these, so the encoded form is a valid, executable
         # delivery here — add them to the encoding set that is in effect.
@@ -1812,6 +1881,15 @@ def main():
         selected_encodings = list(dict.fromkeys(current + additions))
 
     mode = "detection" if args.detection_only else "exploit"
+
+    # Refuse to run on a missing or empty corpus rather than silently emitting
+    # zero payloads (e.g. the corpus file was quarantined by EDR after clone).
+    corpus_ok, corpus_reason = generator.corpus_ready(mode)
+    if not corpus_ok:
+        print(f"[!] Payload corpus is not usable: {corpus_reason}")
+        print("[!] Refusing to run with an incomplete corpus. Run "
+              "'python rcekit.py --doctor' to diagnose, or pass --template-file with a valid corpus.")
+        return 1
 
     if mode == "exploit" and not args.acknowledge_consent:
         print("[!] Exploitation mode requires explicit consent. Re-run with --acknowledge-consent after confirming authorization.")
@@ -1965,4 +2043,4 @@ def main():
     print(f"Generated {count} payloads to {args.output} in {mode} mode")
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1175,5 +1175,54 @@ class VerifySafeByDefaultTestCase(unittest.TestCase):
             server.server_close()
 
 
+class DoctorTestCase(unittest.TestCase):
+    """Corpus integrity check and hard-fail on a missing/empty corpus."""
+
+    def _run(self, *args):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120,
+        )
+
+    def test_check_integrity_ok_on_shipped_corpus(self):
+        ok, report = RCEKit().check_integrity()
+        self.assertTrue(ok)
+        self.assertTrue(any("file loaded and parsed" in line for line in report))
+
+    def test_check_integrity_fails_on_missing_corpus(self):
+        gen = RCEKit(template_path=Path("/no/such/corpus.json"))
+        ok, report = gen.check_integrity()
+        self.assertFalse(ok)
+        self.assertTrue(any("FAIL" in line for line in report))
+        self.assertFalse(gen.corpus_ready("exploit")[0])
+        self.assertFalse(gen.corpus_ready("detection")[0])
+
+    def test_corpus_ready_is_mode_aware(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = Path(tmp) / "only_detection.json"
+            tf.write_text(json.dumps(
+                {"detection_payloads": {"unix": ["echo DETECTION_{canary}"]}}))
+            gen = RCEKit(template_path=tf)
+            self.assertTrue(gen.corpus_ready("detection")[0])
+            self.assertFalse(gen.corpus_ready("exploit")[0])  # no exploit categories
+
+    def test_doctor_cli_exit_codes(self):
+        good = self._run("--doctor")
+        self.assertEqual(good.returncode, 0)
+        self.assertIn("[doctor] OK", good.stdout)
+        bad = self._run("--doctor", "--template-file", "/no/such/corpus.json")
+        self.assertEqual(bad.returncode, 1)
+        self.assertIn("PROBLEMS FOUND", bad.stdout)
+
+    def test_run_hard_fails_on_missing_corpus(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "d.txt"
+            res = self._run("--detection-only", "--template-file", "/no/such/corpus.json",
+                            "-o", str(out))
+            self.assertEqual(res.returncode, 1)
+            self.assertIn("Refusing to run", res.stdout)
+            self.assertFalse(out.exists())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

When `templates/payloads.json` was missing or unparseable, `_load_template_payloads` logged a warning and continued with empty dicts. The tool then generated zero payloads and exited **0** — easy to miss, especially when EDR quarantines the corpus right after clone (the exact scenario from the review).

## Fix

- **Record the failure.** The loader now stores the reason on `self.template_error` (`None` on success).
- **Refuse to run.** `main()` checks `corpus_ready(mode)` before generating or verifying and returns a **non-zero** exit code with a clear message instead of silently producing nothing. The entrypoint now propagates it via `sys.exit(main())`. The check is **mode-aware**: a custom detection-only or exploit-only corpus is accepted for the matching mode.
- **`--doctor`.** New integrity command that reports the template path, parse status, and exploit/detection payload counts, exiting non-zero when the corpus is missing or empty:

```
[doctor] RCEKit corpus integrity check
template: /path/to/templates/payloads.json
  [ok] file loaded and parsed
  exploit categories: 17  payloads: 316  environments: 14
  detection environments: 14  payloads: 47
[doctor] OK
```

(The review suggested an `rcekit doctor` subcommand; implemented as a `--doctor` flag to avoid restructuring the CLI into subparsers.)

## Tests

- `check_integrity` OK on the shipped corpus; FAIL on a missing one.
- Mode-aware `corpus_ready` (detection-only corpus serves detection, not exploit).
- CLI `--doctor` exit codes (0 healthy / 1 missing).
- CLI run hard-fails (exit 1, no output file) on a missing corpus.
- Full suite: 78/78 green, offline, no third-party dependencies.

## Versioning

Bumped to `2.6.0` (new `--doctor` command and hard-fail behaviour) and documented `--doctor` in the README.

---
_Generated by [Claude Code](https://claude.ai/code/session_013vVUUNtsiMzfdCKPouUjB6)_