### PR TITLE
feat(detection): ReflectedMath results-based RCE detection engine (phase 1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,3 +33,25 @@ Please **do not** submit:
 git clone https://github.com/kabiri-labs/rcekit.git
 cd rcekit        # Python 3.8+, standard library only — no dependencies
 python -m unittest discover -s tests
+```
+
+## Adding a detection method
+
+The `--methods` engine confirms RCE by proving the target *computed or executed*
+a value RCEKit chose — never a literal the payload already carried. Methods live
+in the clearly separated **Detection methods** section of `rcekit.py`
+(`Probe` / `Verdict` / `Observation` / `DetectionMethod` and its subclasses).
+
+To add one:
+
+1. Subclass `DetectionMethod`: set `name` and `tier` (`confirmed` for
+   execution-proven methods, `needs-review` for candidates — the two tiers are
+   never merged), then implement `applicable`, `build_probes`, and `confirm`.
+2. Compute the expected value **locally** with random inputs and compare it
+   against the payload-free control (reuse `self._search`, which is
+   encoding-aware). A verdict is `confirmed` only when the computed value is
+   present and absent from the control.
+3. Register the class in `DETECTION_METHODS`.
+4. Add a `/vuln` (executes) vs `/reflect` (echoes) test to
+   `DetectionMethodTestCase`: the method must `confirm` on `/vuln` and stay
+   unconfirmed on `/reflect`. No third-party deps; keep the suite green on 3.8+.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.9.0** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.10.0** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just
@@ -24,6 +24,7 @@ auto-confirms a blind Log4Shell RCE via an OOB DNS callback:
 - **Executable-only output** — every payload runs as-is on its channel/sink or carries its own decoder; non-runnable transforms are removed and decoder-required blobs are opt-in, so you never copy a payload that silently does nothing.
 - **Sink-aware target profiles** — describe the target once (denied characters, max length, needs-separator, blind, decodes-input) and emit only payloads that could actually fire.
 - **Auto-verification** — `--verify-url` fires payloads at an authorised target and reports which executed, using each payload's built-in oracle: a `match` regex, a reflected canary, or a timing delay. Confirmation is **differential**, so `confirmed` means execution and not coincidence: a timing hit must clear a noise-aware margin over a multi-sample baseline *and* reproduce on a re-fire, a reflected canary is re-checked against a paired same-token control so a target that merely echoes input is not mistaken for execution, and a command-output signature already present in the payload-free response is reported `inconclusive` instead of a false positive.
+- **Results-based detection** — `--methods reflected` confirms RCE by forcing the target's shell to compute an arithmetic value on **random operands** (`$((a+b))` plus a `$(echo TAG)` substitution collapse) and checking that value appears in the response but not in a payload-free control. A target that merely echoes the payload returns the literal `$((a+b))`, never the sum, so reflection cannot fake a `confirmed`. Confirmed (execution proven) and needs-review (candidate) verdicts are reported as **separate tiers, never merged**.
 - **Built-in OOB listener** — `--listen` receives HTTP/DNS callbacks and correlates each back to the exact payload, closing the blind-RCE loop without a separate interactsh/Collaborator.
 - **Tooling integrations** — export as context-split Burp wordlists, a ready-to-run ffuf attack (`request.txt` + `run.sh`) when a target profile is given, or runnable Nuclei templates with built-in OOB / time-based / reflection oracles.
 - **Safe by default** — a benign `--detection-only` canary mode, safety tiers, a consent gate, and audit logging.
@@ -91,6 +92,7 @@ nothing. Run `python rcekit.py --doctor` to check corpus integrity.
 | `--verify-data` / `--verify-header` / `--verify-method` | Body (with `FUZZ`) / repeatable header / HTTP method | — |
 | `--verify-url-location` / `--verify-body-location` | How to encode the payload at the URL / body injection point | `query_value` / auto |
 | `--verify-delay` / `--verify-timeout` | Seconds between requests / per-request timeout | `0` / `8` |
+| `--methods <list>` | Run named detection methods against `--verify-url` instead of the classic per-payload oracle (phase 1: `reflected`). Opt-in and additive | None |
 | `--verify-active-risk` | Highest safety tier `--verify-url` may fire (`safe`/`intrusive`/`stateful`) | `safe` |
 | `--verify-allow-destructive` | Let verification fire destructive payloads (persistence/backdoors); skipped by default | Off |
 | `--verify-chain <profile.json>` | Deliver each payload through a multi-step, session-aware flow (login/CSRF → prerequisites → payload delivery → trigger) and confirm in-band or out-of-band | None |
@@ -281,6 +283,37 @@ is re-checked against a paired **same-token control** (the token in an inert,
 non-executing carrier at the same injection point), so a target that merely
 echoes input cannot pass as execution, and a command-output signature is checked
 against the payload-free baseline response.
+
+### Results-based detection (`--methods reflected`)
+
+The oracles above key off each payload's *own* signature. `--methods reflected`
+adds a stronger, results-based proof: instead of a fixed signature it makes the
+target's shell **compute a value RCEKit picked at random**, so only execution can
+produce it.
+
+```bash
+python rcekit.py --acknowledge-consent --environments unix \
+  --verify-url "https://target.example/lookup?host=FUZZ" --methods reflected
+```
+
+```
+[detect] methods: reflected
+[detect] sent 6 probes: confirmed=4, negative=2
+
+[detect] CONFIRMED execution (4):
+  [reflected/unix/raw] ; echo RKYZRIP$((540141+314681))RKFWVFS$(echo RKBWOOC)RKYZRIP   (target computed 'RKYZRIP854822RKFWVFSRKBWOOCRKYZRIP' ...)
+```
+
+Each probe carries two independent proofs: arithmetic on random operands
+(`$((a+b))` — the response must contain the *sum*, never the literal expression)
+and a `$(echo TAG)` substitution collapse (proof the shell *ran* the
+substitution). The computed value is checked with the same encoding-aware search
+and payload-free control as the classic oracle, so a target that only echoes
+input is reported `negative`, and a value that also appears without the payload is
+`inconclusive` — never `confirmed`. Verdicts are split into two tiers,
+`confirmed` (execution proven) and `needs-review` (candidate), and never merged.
+Unix and Windows (`set /a`) shells are covered; the method is opt-in, so omitting
+`--methods` leaves the classic `--verify-url` behaviour unchanged.
 
 **Safe by default.** Verification fires only low-impact proofs (enumeration,
 file reads, code-execution and WAF-bypass signatures). Reverse shells,

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.9.0"
+__version__ = "2.10.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -1487,6 +1487,29 @@ class RCEKit:
                 continue
         return any(re.search(pattern, c) for c in candidates)
 
+    def _fire(self, payload: str, url: str, method: str, data: Optional[str],
+              headers: Optional[List[str]], url_location: str, body_location: str,
+              timeout: float) -> Tuple[Optional[int], str, float]:
+        """Deliver one request with ``payload`` substituted at the FUZZ marker(s),
+        encoded independently for each injection point. Returns
+        ``(status, body, elapsed)`` — ``status`` is ``None`` on a delivery error
+        or timeout. Shared delivery layer for ``run_verification`` and the
+        method-driven detection engine so both encode payloads identically."""
+        import time
+        import urllib.request
+        import urllib.error
+        target, body, hdrs = self._build_verify_request(
+            payload, url, data, headers, url_location, body_location)
+        request = urllib.request.Request(target, data=body, headers=hdrs, method=method)
+        start = time.time()
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return response.status, response.read().decode(errors="replace"), time.time() - start
+        except urllib.error.HTTPError as exc:
+            return exc.code, exc.read().decode(errors="replace"), time.time() - start
+        except Exception as exc:  # network error, timeout, etc.
+            return None, str(exc), time.time() - start
+
     def run_verification(self, records: Iterator[PayloadRecord], url: str, method: str = "GET",
                          data: Optional[str] = None, headers: Optional[List[str]] = None,
                          delay: float = 0.0, timeout: float = 8.0,
@@ -1501,25 +1524,14 @@ class RCEKit:
         given), and single-line escaping for headers.
         """
         import time
-        import urllib.request
-        import urllib.error
 
         resolved_body_location = body_location or self._detect_body_location(data, headers)
         if data is not None:
             logger.info("Verification body injected as '%s'", resolved_body_location)
 
         def fire(payload: str, req_timeout: Optional[float] = None):
-            target, body, hdrs = self._build_verify_request(
-                payload, url, data, headers, url_location, resolved_body_location)
-            request = urllib.request.Request(target, data=body, headers=hdrs, method=method)
-            start = time.time()
-            try:
-                with urllib.request.urlopen(request, timeout=req_timeout or timeout) as response:
-                    return response.status, response.read().decode(errors="replace"), time.time() - start
-            except urllib.error.HTTPError as exc:
-                return exc.code, exc.read().decode(errors="replace"), time.time() - start
-            except Exception as exc:  # network error, timeout, etc.
-                return None, str(exc), time.time() - start
+            return self._fire(payload, url, method, data, headers, url_location,
+                              resolved_body_location, req_timeout or timeout)
 
         # Baseline from several benign requests: a single sample can be a cold
         # start or a jitter spike, which would poison every timing verdict. Take
@@ -1589,6 +1601,77 @@ class RCEKit:
                 time.sleep(delay)
             if max_payloads and len(results) >= max_payloads:
                 break
+        return results
+
+    def run_detection(self, records: Iterator[PayloadRecord], url: str,
+                      methods: List[str], method: str = "GET",
+                      data: Optional[str] = None, headers: Optional[List[str]] = None,
+                      delay: float = 0.0, timeout: float = 8.0,
+                      max_payloads: Optional[int] = None,
+                      url_location: str = "query_value",
+                      body_location: Optional[str] = None,
+                      rng: Optional["random.Random"] = None) -> List[Dict[str, Any]]:
+        """Method-driven RCE detection against an AUTHORISED target.
+
+        For each selected :class:`DetectionMethod`, build probes from the
+        applicable records, fire them through the shared delivery layer
+        (:meth:`_fire`), and confirm each against a single payload-free control
+        body. Every result carries ``method`` and ``tier`` so the two tiers
+        (``confirmed`` vs ``needs-review``) are never collapsed in reporting.
+
+        This is additive: it does not alter the classic ``run_verification``
+        oracle path, and only runs when the operator opts in via ``--methods``.
+        """
+        import time
+        rng = rng or random.Random()
+        resolved_body_location = body_location or self._detect_body_location(data, headers)
+        selected = [DETECTION_METHODS[name](self) for name in methods
+                    if name in DETECTION_METHODS]
+
+        # One payload-free control body for the reflection differential: the
+        # computed value must be absent here for a confirmation to hold.
+        _, control_body, _ = self._fire(
+            f"rcekit-control-{self._generate_canary()}", url, method, data, headers,
+            url_location, resolved_body_location, timeout)
+
+        # Reduce records to distinct (environment, context) carriers so the same
+        # probe shape is not refired for every payload sharing that carrier.
+        carriers: List[PayloadRecord] = []
+        carrier_seen: Set[Tuple[str, str]] = set()
+        for record in records:
+            key = (record.environment, record.context)
+            if key in carrier_seen:
+                continue
+            carrier_seen.add(key)
+            carriers.append(record)
+
+        results: List[Dict[str, Any]] = []
+        seen: Set[str] = set()
+        for meth in selected:
+            for record in carriers:
+                if not meth.applicable(record):
+                    continue
+                for probe in meth.build_probes(record, rng):
+                    if probe.payload in seen:
+                        continue
+                    seen.add(probe.payload)
+                    status, body, elapsed = self._fire(
+                        probe.payload, url, method, data, headers, url_location,
+                        resolved_body_location, timeout)
+                    obs = Observation(status=status, body=body, control_body=control_body,
+                                      elapsed=elapsed)
+                    verdict = meth.confirm(obs, probe)
+                    results.append({
+                        "verdict": verdict.status, "detail": verdict.evidence,
+                        "status": status, "payload": probe.payload,
+                        "method": meth.name, "tier": meth.tier,
+                        "environment": record.environment, "context": record.context,
+                        "category": "detection", "expected": probe.expected,
+                    })
+                    if delay:
+                        time.sleep(delay)
+                    if max_payloads and len(results) >= max_payloads:
+                        return results
         return results
 
     def run_verification_chain(self, records: Iterator[PayloadRecord], chain: Dict[str, Any],
@@ -1872,6 +1955,184 @@ class OOBListener:
         return True
 
 
+# ===========================================================================
+# Detection methods — multi-method, low-false-positive RCE *detection* engine
+#
+# A small, additive oracle abstraction layered on top of the existing verify
+# machinery. Each method turns a target response into a Verdict whose
+# ``confirmed`` tier means the target *computed or executed* a value RCEKit
+# chose at random — never a literal the payload already carried (the
+# confirmation invariant). Every confirmation is differenced against a
+# payload-free control, exactly as _evaluate_verify already does.
+#
+# Methods are opt-in via ``--methods``; the classic --verify-url path is
+# unchanged when no method is selected. Confirmed-tier (execution proven) and
+# needs-review-tier (candidate) verdicts are never merged.
+# ===========================================================================
+
+# Shell environments whose payloads ReflectedMath can force to compute a value.
+UNIX_SHELL_ENVIRONMENTS = {"unix", "docker", "kubernetes"}
+
+
+@dataclass
+class Probe:
+    """One request RCEKit will send, plus the values it computed *locally* to
+    decide the verdict. ``expected`` is the string only execution can produce
+    (an arithmetic result on random operands, tag-bracketed); ``forbidden``, if
+    present, is the literal that survives only when the target *reflected* the
+    payload instead of running it."""
+    payload: str
+    expected: str
+    forbidden: Optional[str] = None
+    followup: Optional[Dict[str, Any]] = None
+    delay_s: Optional[float] = None
+
+
+@dataclass
+class Verdict:
+    """A method's decision. ``status`` is one of ``confirmed`` (execution
+    proven), ``needs-review`` (candidate), ``negative`` (no evidence), or
+    ``inconclusive`` (evidence not attributable to execution)."""
+    status: str
+    evidence: str
+
+
+@dataclass
+class Observation:
+    """The target's response(s) to one probe, plus the payload-free control the
+    verdict is differenced against. ``status is None`` means the delivery
+    request errored or timed out."""
+    status: Optional[int]
+    body: str
+    control_body: str = ""
+    elapsed: float = 0.0
+    baseline: float = 0.0
+    followup_body: Optional[str] = None
+
+
+class DetectionMethod:
+    """Base oracle. Subclasses declare a ``name``/``tier``, decide which records
+    they apply to, build probes with locally-computed expected values, and turn
+    an Observation into a Verdict. Kept deliberately plain (no ABC) so it runs
+    unchanged on Python 3.8."""
+    name = "base"
+    tier = "confirmed"
+
+    def __init__(self, gen: "RCEKit"):
+        self.gen = gen
+
+    def applicable(self, record: "PayloadRecord") -> bool:
+        raise NotImplementedError
+
+    def build_probes(self, record: "PayloadRecord", rng: "random.Random") -> List[Probe]:
+        raise NotImplementedError
+
+    def confirm(self, obs: "Observation", probe: "Probe") -> Verdict:
+        raise NotImplementedError
+
+    def _search(self, literal: str, body: str) -> bool:
+        """Encoded-aware literal search. Reuse the generator's ``_encoded_search``
+        (additive: raw body first, then common output wrappers) so a sink that
+        base64/hex/url/html-encodes the output still confirms. ``literal`` is
+        matched verbatim, not as a regex."""
+        if not literal or not body:
+            return False
+        return self.gen._encoded_search(re.escape(literal), body)
+
+
+class ReflectedMath(DetectionMethod):
+    """Results-based confirmation (highest value). Force the target's shell to
+    compute an arithmetic value on random operands and collapse a nested
+    substitution, then confirm that value appears in the response and NOT in a
+    payload-free control.
+
+    Reflection cannot fake it: a target that merely echoes the payload returns
+    the literal ``$((a+b))``, never the sum. Two independent proofs ride in one
+    Unix probe — (1) arithmetic on random operands, and (2) a ``$(echo TAG)``
+    substitution collapse that proves the shell *ran* the substitution rather
+    than echoing it."""
+    name = "reflected"
+    tier = "confirmed"
+
+    def applicable(self, record: "PayloadRecord") -> bool:
+        return (record.environment in UNIX_SHELL_ENVIRONMENTS
+                or record.environment == "windows")
+
+    def build_probes(self, record: "PayloadRecord", rng: "random.Random") -> List[Probe]:
+        a = rng.randint(100000, 999999)
+        b = rng.randint(100000, 999999)
+        total = a + b
+        t1, t2, t3 = self._tag(rng), self._tag(rng), self._tag(rng)
+        probes: List[Probe] = []
+        if record.environment == "windows":
+            # `set /a` is cmd.exe's arithmetic builtin; `for /f` captures its
+            # output so the computed value lands in the response.
+            arith = f"set /a {a}+{b}"
+            core = f'for /f "delims=" %i in (\'{arith}\') do @echo {t1}%i{t2}'
+            probes.append(Probe(
+                payload=self._wrap(record, core, windows=True),
+                expected=f"{t1}{total}{t2}",
+                forbidden=arith,
+            ))
+        else:
+            # $(( )) arithmetic + $() substitution collapse, one probe.
+            arith = f"$(({a}+{b}))"
+            core = f"echo {t1}{arith}{t2}$(echo {t3}){t1}"
+            probes.append(Probe(
+                payload=self._wrap(record, core),
+                expected=f"{t1}{total}{t2}{t3}{t1}",
+                forbidden=arith,
+            ))
+            # Backtick variant: same proof via a different substitution syntax,
+            # so a sink that strips `$(` is still reached.
+            bt = f"`expr {a} + {b}`"
+            core_bt = f"echo {t1}{bt}{t2}"
+            probes.append(Probe(
+                payload=self._wrap(record, core_bt),
+                expected=f"{t1}{total}{t2}",
+                forbidden=bt,
+            ))
+        return probes
+
+    def confirm(self, obs: "Observation", probe: "Probe") -> Verdict:
+        if obs.status is None and not obs.body:
+            return Verdict("inconclusive", "no response from target (delivery error)")
+        if not self._search(probe.expected, obs.body):
+            return Verdict("negative", "computed value absent from the response")
+        if probe.forbidden and self._search(probe.forbidden, obs.body):
+            # The literal expression survived next to the value: the sink echoed
+            # the payload rather than running it cleanly. Refuse to confirm.
+            return Verdict("needs-review",
+                           "computed value present, but the literal expression was also reflected")
+        if obs.control_body and self._search(probe.expected, obs.control_body):
+            # Present without the payload too — not attributable to execution.
+            return Verdict("inconclusive",
+                           "computed value also present in the payload-free control")
+        return Verdict("confirmed",
+                       f"target computed {probe.expected!r} (random operands, absent from control)")
+
+    def _tag(self, rng: "random.Random") -> str:
+        """A distinctive letters-only boundary marker. Letters keep it from
+        blurring into the digit run of the arithmetic result."""
+        return "RK" + "".join(rng.choice(string.ascii_uppercase) for _ in range(5))
+
+    def _wrap(self, record: "PayloadRecord", core: str, windows: bool = False) -> str:
+        """Break out of the running command with a separator, then escape the
+        probe for the record's serialization context — reusing the same
+        context/escape machinery the generator uses for every other payload."""
+        ctx = self.gen.contexts.get(record.context, {"prefix": "", "suffix": "", "escape": "none"})
+        body = f"{' & ' if windows else '; '}{core}"
+        escaped = self.gen._escape_for_context(body, ctx.get("escape", "none"))
+        return f"{ctx.get('prefix', '')}{escaped}{ctx.get('suffix', '')}"
+
+
+# The detection methods RCEKit can run, keyed by their --methods name. Adding a
+# phase = adding a class above and an entry here.
+DETECTION_METHODS = {
+    ReflectedMath.name: ReflectedMath,
+}
+
+
 # Categories whose payloads have a real-world side effect when fired at a live
 # target (an outbound connection, a callback, credential access, a foothold),
 # as opposed to read-only enumeration. Surfaced in the verification plan and
@@ -1999,6 +2260,11 @@ def main():
                              "back reverse shells, download-execute, credential access, lateral movement, "
                              "container escape, cloud-metadata and OOB payloads; pass 'intrusive' to include "
                              "them. Independent of --max-safety, which only governs file output")
+    parser.add_argument("--methods", default=None,
+                        help="Comma-separated RCE detection methods to run against --verify-url instead of "
+                             "the classic per-payload oracle. Available: reflected (results-based execution "
+                             "proof via computed arithmetic). Opt-in and additive: when omitted, --verify-url "
+                             "keeps its existing behaviour unchanged.")
     parser.add_argument("--verify-chain", default=None,
                         help="Path to a JSON chain profile: deliver each payload through a multi-step, "
                              "session-aware flow (login/CSRF -> prerequisites -> payload delivery -> trigger) "
@@ -2252,6 +2518,45 @@ def main():
             print("[plan] low-impact (safe) payloads only; pass --verify-active-risk intrusive to also "
                   "fire reverse shells, download-execute, credential access, lateral movement and OOB.")
         print(f"[verify] {method} {args.verify_url}  (authorised target)")
+        # Opt-in, method-driven detection. Additive: without --methods the
+        # classic per-payload oracle below runs exactly as before. Confirmed and
+        # needs-review tiers are reported separately and never merged.
+        if args.methods:
+            method_names = [m.strip() for m in args.methods.split(",") if m.strip()]
+            unknown = [m for m in method_names if m not in DETECTION_METHODS]
+            if unknown:
+                print(f"[!] Unknown --methods: {', '.join(unknown)}. "
+                      f"Available: {', '.join(sorted(DETECTION_METHODS))}.")
+                return
+            results = generator.run_detection(
+                to_send, url=args.verify_url, methods=method_names, method=method,
+                data=args.verify_data, headers=args.verify_header, delay=args.verify_delay,
+                timeout=args.verify_timeout, max_payloads=args.max_payloads,
+                url_location=args.verify_url_location, body_location=args.verify_body_location,
+            )
+            by_verdict = {}
+            for result in results:
+                by_verdict[result["verdict"]] = by_verdict.get(result["verdict"], 0) + 1
+            print(f"[detect] methods: {', '.join(method_names)}")
+            print(f"[detect] sent {len(results)} probes: " +
+                  (", ".join(f"{v}={c}" for v, c in sorted(by_verdict.items())) or "none"))
+            confirmed = [r for r in results if r["verdict"] == "confirmed"]
+            if confirmed:
+                print(f"\n[detect] CONFIRMED execution ({len(confirmed)}):")
+                for result in confirmed:
+                    print(f"  [{result['method']}/{result['environment']}/{result['context']}] "
+                          f"{result['payload']}   ({result['detail']})")
+            needs_review = [r for r in results if r["verdict"] == "needs-review"]
+            if needs_review:
+                print(f"\n[detect] {len(needs_review)} NEEDS-REVIEW candidates "
+                      "(not proof of execution — review manually):")
+                for result in needs_review:
+                    print(f"  [{result['method']}/{result['environment']}/{result['context']}] "
+                          f"{result['payload']}   ({result['detail']})")
+            if not confirmed:
+                print("\n[detect] No execution confirmed. The target may be patched, or the probes "
+                      "may not fit its sink/context (try --environments/--contexts).")
+            return
         results = generator.run_verification(
             to_send, url=args.verify_url, method=method, data=args.verify_data,
             headers=args.verify_header, delay=args.verify_delay, timeout=args.verify_timeout,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -20,7 +20,13 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import rcekit  # noqa: E402
-from rcekit import OOBListener, PayloadRecord, RCEKit  # noqa: E402
+from rcekit import (  # noqa: E402
+    Observation,
+    OOBListener,
+    PayloadRecord,
+    RCEKit,
+    ReflectedMath,
+)
 
 
 def make_record(**overrides):
@@ -1463,6 +1469,129 @@ class VerifyChainTestCase(unittest.TestCase):
             self.assertIn("callback", results[0]["detail"])
         finally:
             server.shutdown(); server.server_close()
+
+
+class DetectionMethodTestCase(unittest.TestCase):
+    """Phase 1 — the ReflectedMath detection method and the method-driven engine.
+
+    The confirmation invariant: a ``confirmed`` verdict requires a value the
+    target *computed* (arithmetic on random operands), never a literal the
+    payload already carried. Proven end-to-end against a live ``/vuln`` sink
+    that executes vs a ``/reflect`` sink that only echoes — the direct
+    false-positive-resistance gate from the design brief.
+    """
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.method = ReflectedMath(self.gen)
+
+    def test_build_probes_carry_a_computed_expected_value(self):
+        import random as _random
+        rec = make_record(environment="unix", context="raw")
+        probes = self.method.build_probes(rec, _random.Random(1))
+        self.assertTrue(probes)
+        for probe in probes:
+            # The expected value is a sum the payload never spells out literally,
+            # so only execution can put it in the response.
+            self.assertNotIn(probe.expected, probe.payload)
+            # `forbidden` is the un-executed literal, which IS in the payload;
+            # its survival in a response means reflection, not execution.
+            self.assertIsNotNone(probe.forbidden)
+            self.assertIn(probe.forbidden, probe.payload)
+
+    def test_windows_probe_uses_cmd_arithmetic(self):
+        import random as _random
+        rec = make_record(environment="windows", context="raw")
+        probes = self.method.build_probes(rec, _random.Random(1))
+        self.assertTrue(probes)
+        self.assertIn("set /a", probes[0].payload)
+
+    def test_confirm_distinguishes_execution_reflection_and_control(self):
+        import random as _random
+        rec = make_record(environment="unix", context="raw")
+        probe = self.method.build_probes(rec, _random.Random(7))[0]
+        # Execution: the computed value is present, the literal is gone.
+        exec_body = f"output: {probe.expected} done"
+        self.assertEqual(
+            self.method.confirm(Observation(200, exec_body, control_body="idle"), probe).status,
+            "confirmed")
+        # Reflection: the target echoes the payload; the sum is never produced.
+        self.assertEqual(
+            self.method.confirm(Observation(200, probe.payload, control_body="idle"), probe).status,
+            "negative")
+        # Value also present without the payload -> not attributable to execution.
+        self.assertEqual(
+            self.method.confirm(Observation(200, exec_body, control_body=exec_body), probe).status,
+            "inconclusive")
+
+    def test_confirm_needs_review_when_literal_also_reflected(self):
+        import random as _random
+        rec = make_record(environment="unix", context="raw")
+        probe = self.method.build_probes(rec, _random.Random(9))[0]
+        # Computed value present, but so is the raw expression — the sink echoed
+        # the payload rather than running it cleanly, so it is not confirmed.
+        body = f"{probe.expected} but also {probe.forbidden}"
+        verdict = self.method.confirm(Observation(200, body, control_body="idle"), probe)
+        self.assertEqual(verdict.status, "needs-review")
+        self.assertEqual(self.method.tier, "confirmed")  # tier is the method's ceiling
+
+    def test_reflected_math_confirms_on_executing_target_only(self):
+        # /vuln runs the injected string through a shell (real execution);
+        # /reflect echoes it verbatim without executing. ReflectedMath must
+        # confirm on the former and never on the latter.
+        import http.server
+        import os
+        import socketserver
+        import threading
+        import urllib.parse as up
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_GET(self):
+                parsed = up.urlparse(self.path)
+                cmd = up.parse_qs(parsed.query).get("cmd", [""])[0]
+                self.send_response(200)
+                self.end_headers()
+                if parsed.path == "/vuln":
+                    pipe = os.popen("echo " + cmd + " 2>&1")  # command-injection sink
+                    out = pipe.read()
+                    pipe.close()
+                else:  # /reflect: echo input, never execute
+                    out = cmd
+                try:
+                    self.wfile.write(out.encode(errors="replace"))
+                except BrokenPipeError:
+                    pass
+
+        server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            rec = make_record(environment="unix", context="raw")
+            vuln = self.gen.run_detection(
+                [rec], url=f"http://127.0.0.1:{port}/vuln?cmd=FUZZ", methods=["reflected"])
+            confirmed = [r for r in vuln if r["verdict"] == "confirmed"]
+            self.assertTrue(confirmed, "ReflectedMath must confirm against an executing sink")
+            self.assertTrue(all(r["tier"] == "confirmed" and r["method"] == "reflected"
+                                for r in confirmed))
+
+            reflect = self.gen.run_detection(
+                [rec], url=f"http://127.0.0.1:{port}/reflect?cmd=FUZZ", methods=["reflected"])
+            self.assertFalse([r for r in reflect if r["verdict"] == "confirmed"],
+                             "a target that only echoes input must never be confirmed")
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_methods_flag_rejects_unknown_method(self):
+        # The CLI validates --methods before firing anything at the target.
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--verify-url", "http://127.0.0.1:9/x?q=FUZZ",
+             "--methods", "bogus", "--acknowledge-consent"],
+            cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120)
+        self.assertIn("Unknown --methods", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Phase 1 of the detection redesign: a small, additive detection-method abstraction and its first method, ReflectedMath, behind an opt-in `--methods` flag.

Confirmation now requires a value the target computed on random operands, differenced against a payload-free control — so a target that merely reflects the payload can never be reported as `confirmed`. The classic `--verify-url` oracle path is unchanged when `--methods` is omitted.

## What changed

- **Detection abstraction** — `Probe` / `Verdict` / `Observation` dataclasses and a plain `DetectionMethod` base class (no ABC; Python 3.8+, stdlib only), in a clearly separated section of `rcekit.py`.
- **ReflectedMath** — forces the target's shell to compute `$((a+b))` on random operands plus a `$(echo TAG)` substitution collapse (two independent proofs per probe); Windows via `set /a` through `for /f`. `confirm` requires the computed value present, the literal expression absent, and the value absent from the control.
- **Two tiers, never merged** — `confirmed` (execution proven) vs `needs-review` (candidate) are reported separately.
- **Shared delivery layer** — extracted `_fire` so `run_verification` and the new `run_detection` encode payloads identically per injection point; no behavioural change to the existing path.
- **CLI** — `--methods reflected` wired into the verify handler with tier-aware output and unknown-method validation before any request is fired.

## Testing

- New mock-target test: a `/vuln` endpoint that executes the injected string vs a `/reflect` endpoint that only echoes it. ReflectedMath must `confirm` on `/vuln` and stay unconfirmed on `/reflect` — the direct false-positive-resistance gate.
- Unit tests for probe shape and the execution / reflection / control verdicts, plus needs-review when the literal expression is also reflected.
- `python -m unittest discover -s tests` — 96 tests green, no third-party dependencies.

## Notes

- Version bumped to `2.10.0`; README (Highlights + Options + a results-based detection section) and CONTRIBUTING (how to add a detection method) updated.
- Scope is deliberately phase 1 only — `-r` input, FileBased, ParametricTime, EvalExpr and WAF handling follow as separate PRs.