### PR TITLE
feat(verify): -r raw HTTP request input (phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.10.0** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.11.0** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just
@@ -24,6 +24,7 @@ auto-confirms a blind Log4Shell RCE via an OOB DNS callback:
 - **Executable-only output** — every payload runs as-is on its channel/sink or carries its own decoder; non-runnable transforms are removed and decoder-required blobs are opt-in, so you never copy a payload that silently does nothing.
 - **Sink-aware target profiles** — describe the target once (denied characters, max length, needs-separator, blind, decodes-input) and emit only payloads that could actually fire.
 - **Auto-verification** — `--verify-url` fires payloads at an authorised target and reports which executed, using each payload's built-in oracle: a `match` regex, a reflected canary, or a timing delay. Confirmation is **differential**, so `confirmed` means execution and not coincidence: a timing hit must clear a noise-aware margin over a multi-sample baseline *and* reproduce on a re-fire, a reflected canary is re-checked against a paired same-token control so a target that merely echoes input is not mistaken for execution, and a command-output signature already present in the payload-free response is reported `inconclusive` instead of a false positive.
+- **Raw request input** — `-r request.txt` injects into a captured HTTP request (proxy/Burp style) instead of a hand-built URL. Mark the point with `FUZZ`/`*` or pick a parameter with `-p NAME`; RCEKit reuses the request's method, path, headers, body and cookies and **encodes each injection point for the context it lands in** (query / form / JSON / header / cookie).
 - **Results-based detection** — `--methods reflected` confirms RCE by forcing the target's shell to compute an arithmetic value on **random operands** (`$((a+b))` plus a `$(echo TAG)` substitution collapse) and checking that value appears in the response but not in a payload-free control. A target that merely echoes the payload returns the literal `$((a+b))`, never the sum, so reflection cannot fake a `confirmed`. Confirmed (execution proven) and needs-review (candidate) verdicts are reported as **separate tiers, never merged**.
 - **Built-in OOB listener** — `--listen` receives HTTP/DNS callbacks and correlates each back to the exact payload, closing the blind-RCE loop without a separate interactsh/Collaborator.
 - **Tooling integrations** — export as context-split Burp wordlists, a ready-to-run ffuf attack (`request.txt` + `run.sh`) when a target profile is given, or runnable Nuclei templates with built-in OOB / time-based / reflection oracles.
@@ -92,7 +93,10 @@ nothing. Run `python rcekit.py --doctor` to check corpus integrity.
 | `--verify-data` / `--verify-header` / `--verify-method` | Body (with `FUZZ`) / repeatable header / HTTP method | — |
 | `--verify-url-location` / `--verify-body-location` | How to encode the payload at the URL / body injection point | `query_value` / auto |
 | `--verify-delay` / `--verify-timeout` | Seconds between requests / per-request timeout | `0` / `8` |
-| `--methods <list>` | Run named detection methods against `--verify-url` instead of the classic per-payload oracle (phase 1: `reflected`). Opt-in and additive | None |
+| `-r`, `--request-file <path>` | Raw HTTP request to inject into (alternative to `--verify-url`); mark with `FUZZ`/`*` or select with `-p` | None |
+| `-p`, `--param <name>` | Parameter/field/header/cookie to inject into for `-r` (query > body > header > cookie) | None |
+| `--request-scheme {http,https}` | Scheme for the URL built from `-r` (default: https if Host is `:443`, else http) | auto |
+| `--methods <list>` | Run named detection methods against `--verify-url`/`-r` instead of the classic per-payload oracle (`reflected`). Opt-in and additive | None |
 | `--verify-active-risk` | Highest safety tier `--verify-url` may fire (`safe`/`intrusive`/`stateful`) | `safe` |
 | `--verify-allow-destructive` | Let verification fire destructive payloads (persistence/backdoors); skipped by default | Off |
 | `--verify-chain <profile.json>` | Deliver each payload through a multi-step, session-aware flow (login/CSRF → prerequisites → payload delivery → trigger) and confirm in-band or out-of-band | None |
@@ -283,6 +287,27 @@ is re-checked against a paired **same-token control** (the token in an inert,
 non-executing carrier at the same injection point), so a target that merely
 echoes input cannot pass as execution, and a command-output signature is checked
 against the payload-free baseline response.
+
+### Injecting into a captured request (`-r`)
+
+Point RCEKit at a raw HTTP request saved from a proxy instead of rebuilding the
+URL, body and headers by hand. Mark the injection point with `FUZZ` or `*`, or
+select a parameter with `-p NAME` (searched in this order: query → body →
+header → cookie):
+
+```bash
+# request.txt is a proxy-captured request; inject into the `host` parameter
+python rcekit.py --acknowledge-consent --environments unix \
+  -r request.txt -p host --methods reflected
+```
+
+The request's method, path, headers, body and cookies are reused as-is; only the
+chosen point carries the payload, encoded for **its** context — a query value is
+percent-encoded, a JSON field is JSON-escaped, a form field is form-encoded, a
+header/cookie value is kept single-line. The scheme defaults to `https` when the
+`Host` is on `:443` and `http` otherwise (override with `--request-scheme`); the
+`Host` and `Content-Length` headers are recomputed automatically. One injection
+point per run in this release — `--all-params` enumeration is planned.
 
 ### Results-based detection (`--methods reflected`)
 

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.10.0"
+__version__ = "2.11.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -2189,6 +2189,166 @@ def build_verification_plan(records: List[PayloadRecord], method: str, url: str,
     return lines, to_send
 
 
+# ===========================================================================
+# Raw HTTP request input (`-r`)
+#
+# Parse a captured HTTP request and place the FUZZ marker at a chosen injection
+# point, then hand the resulting (url, method, data, headers) to the existing
+# verify/detect engine. Each injection point is encoded downstream for the
+# context it lands in (query / form / JSON / header / cookie), reusing the same
+# per-location escaping every other payload goes through.
+# ===========================================================================
+
+def parse_raw_request(text: str) -> Dict[str, Any]:
+    """Split a raw HTTP request (request line, headers, blank line, optional
+    body) into its parts. Returns ``method``, ``target`` (path?query),
+    ``version``, ``headers`` (ordered ``[name, value]`` pairs), ``body``, and
+    ``host`` (from the Host header)."""
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    head, _, body = text.partition("\n\n")
+    lines = head.split("\n")
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    if not lines:
+        raise ValueError("empty request")
+    parts = lines[0].split()
+    if len(parts) < 2:
+        raise ValueError(f"malformed request line: {lines[0]!r}")
+    method, target = parts[0], parts[1]
+    version = parts[2] if len(parts) > 2 else "HTTP/1.1"
+    headers: List[List[str]] = []
+    host = ""
+    for line in lines[1:]:
+        if not line.strip():
+            continue
+        name, sep, value = line.partition(":")
+        if not sep:
+            continue
+        name, value = name.strip(), value.strip()
+        headers.append([name, value])
+        if name.lower() == "host":
+            host = value
+    return {"method": method, "target": target, "version": version,
+            "headers": headers, "body": body, "host": host}
+
+
+def _mark_urlencoded_param(blob: str, param: str, mark: str) -> Optional[str]:
+    """Replace ``param``'s value with ``mark`` in a ``a=1&b=2`` blob (query or
+    form body). Returns the rewritten blob, or None if ``param`` is absent."""
+    if not blob:
+        return None
+    found = False
+    out: List[str] = []
+    for pair in blob.split("&"):
+        key, _, _value = pair.partition("=")
+        if key == param:
+            out.append(f"{key}={mark}")
+            found = True
+        else:
+            out.append(pair)
+    return "&".join(out) if found else None
+
+
+def _mark_json_field(body: str, param: str, mark: str) -> Optional[str]:
+    """Set top-level JSON field ``param`` to ``mark``. Returns the re-serialised
+    body, or None if the body is not a JSON object containing ``param``."""
+    try:
+        obj = json.loads(body)
+    except (ValueError, TypeError):
+        return None
+    if isinstance(obj, dict) and param in obj:
+        obj[param] = mark
+        return json.dumps(obj)
+    return None
+
+
+def _mark_cookie(value: str, param: str, mark: str) -> Optional[str]:
+    """Replace cookie ``param``'s value with ``mark`` in a Cookie header value.
+    Returns the rewritten value, or None if ``param`` is absent."""
+    found = False
+    out: List[str] = []
+    for cookie in value.split(";"):
+        key, _, _value = cookie.strip().partition("=")
+        if key.strip() == param:
+            out.append(f"{key.strip()}={mark}")
+            found = True
+        else:
+            out.append(cookie.strip())
+    return "; ".join(out) if found else None
+
+
+def _place_param_marker(target, headers, body, param, mark):
+    """Insert ``mark`` at parameter ``param``, trying query > body > header >
+    cookie. Returns ``(target, headers, body, description)`` or raises if the
+    parameter is nowhere to be found."""
+    path, sep, query = target.partition("?")
+    if sep:
+        marked_query = _mark_urlencoded_param(query, param, mark)
+        if marked_query is not None:
+            return f"{path}?{marked_query}", headers, body, f"query param '{param}'"
+    stripped = body.strip()
+    if stripped[:1] in "{[":
+        marked = _mark_json_field(body, param, mark)
+        if marked is not None:
+            return target, headers, marked, f"JSON field '{param}'"
+    if "=" in body:
+        marked = _mark_urlencoded_param(body, param, mark)
+        if marked is not None:
+            return target, headers, marked, f"body param '{param}'"
+    for i, (name, _value) in enumerate(headers):
+        if name.lower() == param.lower() and name.lower() != "cookie":
+            new_headers = [list(h) for h in headers]
+            new_headers[i][1] = mark
+            return target, new_headers, body, f"header '{name}'"
+    for i, (name, value) in enumerate(headers):
+        if name.lower() == "cookie":
+            marked = _mark_cookie(value, param, mark)
+            if marked is not None:
+                new_headers = [list(h) for h in headers]
+                new_headers[i][1] = marked
+                return target, new_headers, body, f"cookie '{param}'"
+    raise ValueError(f"parameter '{param}' not found in query, body, headers, or cookies")
+
+
+def build_request_inputs(text: str, param: Optional[str] = None,
+                         scheme: Optional[str] = None, mark: str = "FUZZ"
+                         ) -> Tuple[str, str, Optional[str], List[str], str]:
+    """Build ``(url, method, data, headers, injection)`` from a raw HTTP request,
+    with ``mark`` placed at the injection point. Precedence: an inline ``FUZZ``
+    already in the request, then an inline ``*`` marker, then ``-p NAME``."""
+    inline = False
+    if mark in text:
+        inline = True
+    elif "*" in text:
+        # First `*` is the injection marker (commix-style). A request that
+        # legitimately contains `*` (e.g. `Accept: */*`) should use FUZZ or -p.
+        text = text.replace("*", mark, 1)
+        inline = True
+
+    req = parse_raw_request(text)
+    method, target, headers, body, host = (
+        req["method"], req["target"], req["headers"], req["body"], req["host"])
+    if not host:
+        raise ValueError("raw request has no Host header; cannot build an absolute URL")
+
+    if inline:
+        injection = "inline marker"
+    elif param:
+        target, headers, body, injection = _place_param_marker(target, headers, body, param, mark)
+    else:
+        raise ValueError("no injection point: add a FUZZ or * marker, or pass -p NAME")
+
+    if scheme is None:
+        scheme = "https" if host.endswith(":443") else "http"
+    url = f"{scheme}://{host}{target}"
+    # Drop Host and Content-Length: urllib recomputes both from the URL and the
+    # (marker-lengthened) body.
+    out_headers = [f"{name}: {value}" for name, value in headers
+                   if name.lower() not in {"host", "content-length"}]
+    data = body if body else None
+    return url, method, data, out_headers, injection
+
+
 def load_token_manifest(path: str) -> Dict[str, Dict[str, Any]]:
     """Load a .map.jsonl manifest into a token -> entry dict."""
     tokens: Dict[str, Dict[str, Any]] = {}
@@ -2260,6 +2420,18 @@ def main():
                              "back reverse shells, download-execute, credential access, lateral movement, "
                              "container escape, cloud-metadata and OOB payloads; pass 'intrusive' to include "
                              "them. Independent of --max-safety, which only governs file output")
+    parser.add_argument("-r", "--request-file", default=None,
+                        help="Raw HTTP request file (as captured by a proxy) to inject into, as an "
+                             "alternative to --verify-url. Mark the injection point with FUZZ or *, or "
+                             "select a parameter with -p. The request's method, path, headers, body and "
+                             "cookies are reused, each encoded for the context it lands in.")
+    parser.add_argument("-p", "--param", action="append", default=None,
+                        help="Parameter/field/header/cookie to inject into for -r (precedence: query > body "
+                             "> header > cookie). One injection point per run in this release; --all-params "
+                             "enumeration is planned.")
+    parser.add_argument("--request-scheme", choices=["http", "https"], default=None,
+                        help="Scheme for the URL built from -r (default: https when the Host is on :443, "
+                             "otherwise http).")
     parser.add_argument("--methods", default=None,
                         help="Comma-separated RCE detection methods to run against --verify-url instead of "
                              "the classic per-payload oracle. Available: reflected (results-based execution "
@@ -2459,19 +2631,45 @@ def main():
             print("\n[verify-chain] No execution confirmed.")
         return
 
-    if args.verify_url:
+    if args.verify_url or args.request_file:
         if not args.acknowledge_consent:
-            print("[!] --verify-url actively sends payloads to the target. Re-run with "
+            print("[!] Verification actively sends payloads to the target. Re-run with "
                   "--acknowledge-consent to confirm you are authorised to test it.")
             return
-        if "FUZZ" not in args.verify_url and not (args.verify_data and "FUZZ" in args.verify_data) \
-                and not any("FUZZ" in h for h in (args.verify_header or [])):
-            print("[!] No FUZZ marker found in --verify-url/--verify-data/--verify-header; "
-                  "add FUZZ where the payload should be injected.")
-            return
-        method = args.verify_method or ("POST" if args.verify_data else "GET")
+        # Source the request from a raw capture (-r) or the --verify-* flags.
+        if args.request_file:
+            try:
+                with open(args.request_file, "r", encoding="utf-8") as request_fh:
+                    raw_request = request_fh.read()
+            except OSError as exc:
+                print(f"[!] Unable to read --request-file {args.request_file}: {exc}")
+                return
+            params = args.param or []
+            if len(params) > 1:
+                print("[!] -r supports a single injection point in this release; pass one -p "
+                      "(or a FUZZ/* marker). --all-params enumeration is not yet available.")
+                return
+            try:
+                verify_url, method, verify_data, verify_headers, injection = build_request_inputs(
+                    raw_request, param=(params[0] if params else None), scheme=args.request_scheme)
+            except ValueError as exc:
+                print(f"[!] Could not build a request from {args.request_file}: {exc}")
+                return
+            method = args.verify_method or method
+            print(f"[verify] loaded request from {args.request_file}: {method} {verify_url} "
+                  f"(injecting at {injection})")
+        else:
+            verify_url = args.verify_url
+            verify_data = args.verify_data
+            verify_headers = args.verify_header
+            if "FUZZ" not in verify_url and not (verify_data and "FUZZ" in verify_data) \
+                    and not any("FUZZ" in h for h in (verify_headers or [])):
+                print("[!] No FUZZ marker found in --verify-url/--verify-data/--verify-header; "
+                      "add FUZZ where the payload should be injected.")
+                return
+            method = args.verify_method or ("POST" if verify_data else "GET")
         verify_token = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8))
-        generator.log_exploitation_usage(f"VERIFY:{verify_token} url={args.verify_url}", args)
+        generator.log_exploitation_usage(f"VERIFY:{verify_token} url={verify_url}", args)
         # Safe by default: verification fires only low-impact proofs unless the
         # operator explicitly raises the ceiling. This holds back reverse shells,
         # download-execute, credential access, lateral movement, container
@@ -2506,7 +2704,7 @@ def main():
         # execution plan before anything is fired.
         records = list(records)
         plan_lines, to_send = build_verification_plan(
-            records, method, args.verify_url,
+            records, method, verify_url,
             attacker_ip=generator.attacker_ip, attacker_domain=generator.attacker_domain,
             max_payloads=args.max_payloads)
         for line in plan_lines:
@@ -2517,7 +2715,7 @@ def main():
         if verify_max_safety == "safe":
             print("[plan] low-impact (safe) payloads only; pass --verify-active-risk intrusive to also "
                   "fire reverse shells, download-execute, credential access, lateral movement and OOB.")
-        print(f"[verify] {method} {args.verify_url}  (authorised target)")
+        print(f"[verify] {method} {verify_url}  (authorised target)")
         # Opt-in, method-driven detection. Additive: without --methods the
         # classic per-payload oracle below runs exactly as before. Confirmed and
         # needs-review tiers are reported separately and never merged.
@@ -2529,8 +2727,8 @@ def main():
                       f"Available: {', '.join(sorted(DETECTION_METHODS))}.")
                 return
             results = generator.run_detection(
-                to_send, url=args.verify_url, methods=method_names, method=method,
-                data=args.verify_data, headers=args.verify_header, delay=args.verify_delay,
+                to_send, url=verify_url, methods=method_names, method=method,
+                data=verify_data, headers=verify_headers, delay=args.verify_delay,
                 timeout=args.verify_timeout, max_payloads=args.max_payloads,
                 url_location=args.verify_url_location, body_location=args.verify_body_location,
             )
@@ -2558,8 +2756,8 @@ def main():
                       "may not fit its sink/context (try --environments/--contexts).")
             return
         results = generator.run_verification(
-            to_send, url=args.verify_url, method=method, data=args.verify_data,
-            headers=args.verify_header, delay=args.verify_delay, timeout=args.verify_timeout,
+            to_send, url=verify_url, method=method, data=verify_data,
+            headers=verify_headers, delay=args.verify_delay, timeout=args.verify_timeout,
             max_payloads=args.max_payloads,
             url_location=args.verify_url_location, body_location=args.verify_body_location,
         )

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -26,6 +26,8 @@ from rcekit import (  # noqa: E402
     PayloadRecord,
     RCEKit,
     ReflectedMath,
+    build_request_inputs,
+    parse_raw_request,
 )
 
 
@@ -1592,6 +1594,116 @@ class DetectionMethodTestCase(unittest.TestCase):
              "--methods", "bogus", "--acknowledge-consent"],
             cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120)
         self.assertIn("Unknown --methods", result.stdout)
+
+
+class RawRequestInputTestCase(unittest.TestCase):
+    """Phase 2 — the `-r` raw HTTP request input layer. Each injection point is
+    marked with FUZZ and routed into the existing verify/detect engine, which
+    encodes it for the context it lands in."""
+
+    def test_parse_raw_request_splits_line_headers_and_body(self):
+        raw = "POST /api HTTP/1.1\r\nHost: t.example\r\nContent-Type: application/json\r\n\r\n{\"a\":1}"
+        req = parse_raw_request(raw)
+        self.assertEqual(req["method"], "POST")
+        self.assertEqual(req["target"], "/api")
+        self.assertEqual(req["host"], "t.example")
+        self.assertEqual(req["body"], '{"a":1}')
+        self.assertIn(["Content-Type", "application/json"], req["headers"])
+
+    def test_query_param_marker_preserves_other_params(self):
+        raw = "GET /lookup?host=example.com&x=1 HTTP/1.1\r\nHost: t.example\r\n\r\n"
+        url, method, data, headers, injection = build_request_inputs(raw, param="host")
+        self.assertEqual(url, "http://t.example/lookup?host=FUZZ&x=1")
+        self.assertEqual(method, "GET")
+        self.assertIsNone(data)
+        self.assertIn("query param", injection)
+
+    def test_json_field_marker(self):
+        raw = ("POST /api HTTP/1.1\r\nHost: t.example\r\nContent-Type: application/json\r\n\r\n"
+               '{"host": "a", "y": 2}')
+        url, method, data, headers, injection = build_request_inputs(raw, param="host")
+        self.assertEqual(method, "POST")
+        self.assertIn('"host": "FUZZ"', data)
+        self.assertIn('"y": 2', data)
+
+    def test_form_body_and_cookie_and_header_markers(self):
+        form = "POST /f HTTP/1.1\r\nHost: t.example\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\na=1&b=2"
+        _, _, data, _, inj = build_request_inputs(form, param="b")
+        self.assertEqual(data, "a=1&b=FUZZ")
+        self.assertIn("body param", inj)
+
+        cookie = "GET / HTTP/1.1\r\nHost: t.example\r\nCookie: sid=abc; role=user\r\n\r\n"
+        _, _, _, headers, inj = build_request_inputs(cookie, param="role")
+        self.assertIn("Cookie: sid=abc; role=FUZZ", headers)
+        self.assertIn("cookie", inj)
+
+        header = "GET / HTTP/1.1\r\nHost: t.example\r\nX-Api: key123\r\n\r\n"
+        _, _, _, headers, inj = build_request_inputs(header, param="X-Api")
+        self.assertIn("X-Api: FUZZ", headers)
+
+    def test_inline_marker_and_scheme_inference(self):
+        # `*` marks the point; Host on :443 infers https; Host/Content-Length dropped.
+        raw = ("POST /api HTTP/1.1\r\nHost: t.example:443\r\nContent-Type: application/json\r\n"
+               "Content-Length: 12\r\n\r\n{\"host\": \"*\"}")
+        url, method, data, headers, injection = build_request_inputs(raw)
+        self.assertTrue(url.startswith("https://t.example:443/api"))
+        self.assertEqual(data, '{"host": "FUZZ"}')
+        self.assertEqual(injection, "inline marker")
+        self.assertFalse(any(h.lower().startswith(("host:", "content-length:")) for h in headers))
+
+    def test_existing_fuzz_marker_is_respected(self):
+        raw = "GET /q?a=FUZZ HTTP/1.1\r\nHost: t.example\r\n\r\n"
+        url, _, _, _, injection = build_request_inputs(raw)
+        self.assertEqual(url, "http://t.example/q?a=FUZZ")
+        self.assertEqual(injection, "inline marker")
+
+    def test_missing_marker_and_missing_param_raise(self):
+        with self.assertRaises(ValueError):
+            build_request_inputs("GET /q?a=1 HTTP/1.1\r\nHost: t.example\r\n\r\n")
+        with self.assertRaises(ValueError):
+            build_request_inputs("GET /q?a=1 HTTP/1.1\r\nHost: t.example\r\n\r\n", param="nope")
+        with self.assertRaises(ValueError):
+            build_request_inputs("GET /q?a=* HTTP/1.1\r\n\r\n")  # no Host
+
+    def test_raw_request_drives_detection_end_to_end(self):
+        # A raw request marked with -p, routed through run_detection, confirms
+        # against an executing sink — proving the -r layer feeds the engine.
+        import http.server
+        import os
+        import socketserver
+        import threading
+        import urllib.parse as up
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_GET(self):
+                cmd = up.parse_qs(up.urlparse(self.path).query).get("host", [""])[0]
+                out = os.popen("echo " + cmd + " 2>&1").read()
+                self.send_response(200)
+                self.end_headers()
+                try:
+                    self.wfile.write(out.encode(errors="replace"))
+                except BrokenPipeError:
+                    pass
+
+        server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            raw = (f"GET /vuln?host=example.com HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\n\r\n")
+            url, method, data, headers, injection = build_request_inputs(raw, param="host")
+            self.assertEqual(injection, "query param 'host'")
+            gen = RCEKit()
+            rec = make_record(environment="unix", context="raw")
+            results = gen.run_detection([rec], url=url, methods=["reflected"],
+                                        method=method, data=data, headers=headers)
+            self.assertTrue([r for r in results if r["verdict"] == "confirmed"],
+                            "the -r request must reach the sink and confirm execution")
+        finally:
+            server.shutdown()
+            server.server_close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Phase 2 of the detection redesign: accept a proxy-captured HTTP request (`-r request.txt`) as an alternative to a hand-built `--verify-url`. The request's method, path, headers, body and cookies are reused; the `FUZZ` marker is placed at a chosen injection point and encoded downstream for the context it lands in, reusing the same per-location escaping every other payload goes through.

This layer sits under every verify/detect method — the classic `--verify-url` oracle and `--methods reflected` both work with `-r` unchanged.

## What changed

- **Raw request parsing** — `parse_raw_request` splits the request line, headers, blank line and optional body; `build_request_inputs` returns `(url, method, data, headers)` for the engine with the marker placed.
- **Injection-point selection** — precedence: an inline `FUZZ`, then an inline `*` marker, then `-p NAME` searched query → body (form/JSON) → header → cookie. Each lands in its correct context (query value / form value / JSON string / header / cookie).
- **Scheme and headers** — scheme inferred (`https` on `:443`, else `http`; override with `--request-scheme`); `Host` and `Content-Length` dropped so urllib recomputes them from the URL and the marker-lengthened body.
- **One code path** — the verify handler now sources its inputs from either `--verify-url` or `-r`; `--verify-url` behaviour is unchanged.
- **New flags** — `-r`/`--request-file`, `-p`/`--param`, `--request-scheme`.

## Testing

- Unit tests for the parser and for every injection type (query, form body, JSON field, header, cookie, inline `*`, existing `FUZZ`), plus the missing-marker / missing-param / missing-Host error paths.
- End-to-end test that builds a request with `-r`/`-p` and drives `run_detection` through it against an executing mock sink — confirming the layer feeds the engine.
- `python -m unittest discover -s tests` — 104 tests green, no third-party dependencies.

## Notes

- Version bumped to `2.11.0`; README updated (Highlights + Options + a `-r` usage section).
- Scope is deliberately minimal: a single injection point per run. `--all-params` enumeration is planned as a follow-up. FileBased, ParametricTime, EvalExpr and WAF handling remain as later phases.