### PR TITLE
feat(detection): ParametricTime hardened blind-timing method (phase 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.12.0** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.13.0** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just
@@ -27,6 +27,7 @@ auto-confirms a blind Log4Shell RCE via an OOB DNS callback:
 - **Raw request input** — `-r request.txt` injects into a captured HTTP request (proxy/Burp style) instead of a hand-built URL. Mark the point with `FUZZ`/`*` or pick a parameter with `-p NAME`; RCEKit reuses the request's method, path, headers, body and cookies and **encodes each injection point for the context it lands in** (query / form / JSON / header / cookie).
 - **Results-based detection** — `--methods reflected` confirms RCE by forcing the target's shell to compute an arithmetic value on **random operands** (`$((a+b))` plus a `$(echo TAG)` substitution collapse) and checking that value appears in the response but not in a payload-free control. A target that merely echoes the payload returns the literal `$((a+b))`, never the sum, so reflection cannot fake a `confirmed`. Confirmed (execution proven) and needs-review (candidate) verdicts are reported as **separate tiers, never merged**.
 - **No-egress detection** — `--methods file` confirms RCE on internal targets with **no outbound connectivity**: the probe writes a random token to a web-reachable file and a followup request fetches it back, proving execution *and* a write primitive through the target's own web server — no external listener. State-changing and gated on `--webroot` + `--web-base-url`; every finding prints a **cleanup command**.
+- **Hardened blind timing** — `--methods time` fires a controlled `0/N/2N` delay series and requires the response time to track the injected delay **linearly** (a monotonic increase whose extra latency matches the sleep within a noise margin), so jitter cannot fake it. Timing has no computed value, so it is reported `needs-review`, **never** `confirmed` on its own — pair it with `--methods reflected` for an execution proof it corroborates.
 - **Built-in OOB listener** — `--listen` receives HTTP/DNS callbacks and correlates each back to the exact payload, closing the blind-RCE loop without a separate interactsh/Collaborator.
 - **Tooling integrations** — export as context-split Burp wordlists, a ready-to-run ffuf attack (`request.txt` + `run.sh`) when a target profile is given, or runnable Nuclei templates with built-in OOB / time-based / reflection oracles.
 - **Safe by default** — a benign `--detection-only` canary mode, safety tiers, a consent gate, and audit logging.
@@ -100,6 +101,7 @@ nothing. Run `python rcekit.py --doctor` to check corpus integrity.
 | `--methods <list>` | Run named detection methods against `--verify-url`/`-r` instead of the classic per-payload oracle (`reflected`, `file`). Opt-in and additive | None |
 | `--webroot <path>` | (file-based) server-side directory the target can write to and serve | None |
 | `--web-base-url <url>` | (file-based) base URL that serves `--webroot` | None |
+| `--time-base <seconds>` | (time-based) base delay `N`; the regression fires `0/N/2N` and requires the response time to track it | `2.0` |
 | `--verify-active-risk` | Highest safety tier `--verify-url` may fire (`safe`/`intrusive`/`stateful`) | `safe` |
 | `--verify-allow-destructive` | Let verification fire destructive payloads (persistence/backdoors); skipped by default | Off |
 | `--verify-chain <profile.json>` | Deliver each payload through a multi-step, session-aware flow (login/CSRF → prerequisites → payload delivery → trigger) and confirm in-band or out-of-band | None |
@@ -370,6 +372,29 @@ gated on both `--webroot` (where the target can write) and `--web-base-url` (the
 URL that serves it), and every finding prints the exact `rm`/`del` command to
 undo the write. The random filename and token mean a stale file can never pass
 as a fresh confirmation.
+
+### Hardened blind timing (`--methods time`)
+
+When there is no output channel and no egress at all, the only signal left is
+*how long* the target takes to respond. Naive time-based checks false-positive on
+jitter; `--methods time` instead fires a **controlled series** — delays `0`, `N`,
+`2N` (set `N` with `--time-base`), each repeated — and requires the response
+time to track the injected delay **linearly**: monotonic, with the extra latency
+at each step matching the sleep within a noise margin. A random slow response
+fails that regression.
+
+```bash
+python rcekit.py --acknowledge-consent --environments unix \
+  --verify-url "https://target.example/lookup?host=FUZZ" \
+  --methods reflected,time --time-base 3
+```
+
+Because a delay proves only that the target *waited* — not a value it computed —
+timing is reported `needs-review`, **never** `confirmed` on its own. Run it
+alongside `--methods reflected`: if the results-based method confirms, you have an
+execution proof, and the linear timing response corroborates it. This keeps the
+two tiers honest — a blind timing candidate is never dressed up as proven
+execution.
 
 **Safe by default.** Verification fires only low-impact proofs (enumeration,
 file reads, code-execution and WAF-bypass signatures). Reverse shells,

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.12.0"
+__version__ = "2.13.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -1653,6 +1653,33 @@ class RCEKit:
             for record in carriers:
                 if not meth.applicable(record):
                     continue
+                if getattr(meth, "aggregate", False):
+                    # Fire the whole probe series (e.g. a timing regression) and
+                    # decide once. Each fire's timeout is stretched past its
+                    # intended delay so a genuine sleep completes instead of
+                    # timing out.
+                    series: List[Tuple[Probe, Observation]] = []
+                    for probe in meth.build_probes(record, rng):
+                        req_timeout = timeout + (probe.delay_s or 0.0) + 2.0
+                        status, body, elapsed = self._fire(
+                            probe.payload, url, method, data, headers, url_location,
+                            resolved_body_location, req_timeout)
+                        series.append((probe, Observation(
+                            status=status, body=body, control_body=control_body, elapsed=elapsed)))
+                        if delay:
+                            time.sleep(delay)
+                    verdict = meth.confirm_series(series)
+                    probe = series[-1][0] if series else Probe(payload="", expected="")
+                    results.append({
+                        "verdict": verdict.status, "detail": verdict.evidence,
+                        "status": None, "payload": probe.payload,
+                        "method": meth.name, "tier": meth.tier,
+                        "environment": record.environment, "context": record.context,
+                        "category": "detection", "expected": probe.expected,
+                    })
+                    if max_payloads and len(results) >= max_payloads:
+                        return results
+                    continue
                 for probe in meth.build_probes(record, rng):
                     if probe.payload in seen:
                         continue
@@ -2030,6 +2057,10 @@ class DetectionMethod:
     unchanged on Python 3.8."""
     name = "base"
     tier = "confirmed"
+    # Aggregate methods observe a whole *set* of probes together (e.g. a timing
+    # regression across several controlled delays) and decide once via
+    # confirm_series, instead of one Verdict per probe.
+    aggregate = False
 
     def __init__(self, gen: "RCEKit", config: Optional[Dict[str, Any]] = None):
         self.gen = gen
@@ -2042,6 +2073,11 @@ class DetectionMethod:
         raise NotImplementedError
 
     def confirm(self, obs: "Observation", probe: "Probe") -> Verdict:
+        raise NotImplementedError
+
+    def confirm_series(self, series: "List[Tuple[Probe, Observation]]") -> Verdict:
+        """Decide from all of this method's probe observations at once. Only
+        called for methods with ``aggregate = True``."""
         raise NotImplementedError
 
     def _search(self, literal: str, body: str) -> bool:
@@ -2191,11 +2227,76 @@ class FileBased(DetectionMethod):
                        f"target wrote and served token {probe.expected!r} (execution + write primitive)")
 
 
+class ParametricTime(DetectionMethod):
+    """Hardened blind timing. Instead of a single margin over one slow response,
+    fire a controlled series of delays (``d ∈ {0, N, 2N}``, each repeated) and
+    require the response time to track the injected delay **linearly** — a
+    monotonic increase whose extra latency at each step matches the intended
+    sleep within a noise margin. Jitter cannot fake a linear response to a
+    controlled delay.
+
+    Timing has no value the target *computed*, so by design this never confirms
+    on its own — its ceiling is ``needs-review``. Pair it with ``--methods
+    reflected`` for an execution proof; a linear timing response then corroborates
+    the results-based confirmation."""
+    name = "time"
+    tier = "needs-review"
+    aggregate = True
+
+    def applicable(self, record: "PayloadRecord") -> bool:
+        return (record.environment in UNIX_SHELL_ENVIRONMENTS
+                or record.environment == "windows")
+
+    def build_probes(self, record: "PayloadRecord", rng: "random.Random") -> List[Probe]:
+        base = float(self.config.get("time_base", 2.0))
+        repeats = max(1, int(self.config.get("time_repeats", 2)))
+        windows = record.environment == "windows"
+        probes: List[Probe] = []
+        for multiplier in (0, 1, 2):
+            delay = base * multiplier
+            for _ in range(repeats):
+                if windows:
+                    # `ping -n k` waits ~(k-1)s; +1 so d=0 is a single instant ping.
+                    core = f"ping 127.0.0.1 -n {int(round(delay)) + 1} >nul"
+                else:
+                    core = f"sleep {delay:g}"
+                probes.append(Probe(payload=self._wrap(record, core, windows=windows),
+                                    expected="", delay_s=delay))
+        return probes
+
+    def confirm_series(self, series: "List[Tuple[Probe, Observation]]") -> Verdict:
+        import statistics
+        by_delay: Dict[float, List[float]] = {}
+        for probe, obs in series:
+            by_delay.setdefault(probe.delay_s or 0.0, []).append(obs.elapsed)
+        delays = sorted(by_delay)
+        if len(delays) < 2:
+            return Verdict("negative", "insufficient timing samples for a regression")
+        median = {d: statistics.median(samples) for d, samples in by_delay.items()}
+        baseline = median[delays[0]]
+        spread0 = max(by_delay[delays[0]]) - min(by_delay[delays[0]])
+        noise = max(0.15, 3 * spread0)
+        summary = ", ".join(f"d={d:g}s→{median[d]:.2f}s" for d in delays)
+        previous = baseline
+        for delay in delays[1:]:
+            extra = median[delay] - baseline
+            tolerance = max(0.4, noise, 0.5 * delay)
+            if median[delay] <= previous:
+                return Verdict("negative", f"response time not monotonic in the delay ({summary})")
+            if abs(extra - delay) > tolerance:
+                return Verdict("negative", f"response time does not track the delay ({summary})")
+            previous = median[delay]
+        return Verdict("needs-review",
+                       f"response time tracks the controlled delay linearly ({summary}); blind timing "
+                       "candidate — pair with --methods reflected for an execution proof")
+
+
 # The detection methods RCEKit can run, keyed by their --methods name. Adding a
 # phase = adding a class above and an entry here.
 DETECTION_METHODS = {
     ReflectedMath.name: ReflectedMath,
     FileBased.name: FileBased,
+    ParametricTime.name: ParametricTime,
 }
 
 
@@ -2504,12 +2605,16 @@ def main():
     parser.add_argument("--web-base-url", default=None,
                         help="(file-based detection) base URL that serves --webroot, e.g. "
                              "https://target.example. Required with --methods file.")
+    parser.add_argument("--time-base", type=float, default=2.0,
+                        help="(time-based detection) base delay N in seconds; the regression fires "
+                             "0/N/2N and requires the response time to track it (default: 2.0).")
     parser.add_argument("--methods", default=None,
                         help="Comma-separated RCE detection methods to run against --verify-url/-r instead of "
                              "the classic per-payload oracle. Available: reflected (results-based execution "
                              "proof via computed arithmetic); file (self-OOB write+fetch, needs --webroot and "
-                             "--web-base-url). Opt-in and additive: when omitted, verification keeps its "
-                             "existing behaviour unchanged.")
+                             "--web-base-url); time (hardened blind-timing regression, needs-review only). "
+                             "Opt-in and additive: when omitted, verification keeps its existing behaviour "
+                             "unchanged.")
     parser.add_argument("--verify-chain", default=None,
                         help="Path to a JSON chain profile: deliver each payload through a multi-step, "
                              "session-aware flow (login/CSRF -> prerequisites -> payload delivery -> trigger) "
@@ -2799,7 +2904,8 @@ def main():
                 print(f"[!] Unknown --methods: {', '.join(unknown)}. "
                       f"Available: {', '.join(sorted(DETECTION_METHODS))}.")
                 return
-            detection_config = {"webroot": args.webroot, "web_base_url": args.web_base_url}
+            detection_config = {"webroot": args.webroot, "web_base_url": args.web_base_url,
+                                "time_base": args.time_base}
             if "file" in method_names:
                 if not (args.webroot and args.web_base_url):
                     print("[!] --methods file writes a file to the target and fetches it back, so it "

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -24,6 +24,7 @@ from rcekit import (  # noqa: E402
     FileBased,
     Observation,
     OOBListener,
+    ParametricTime,
     PayloadRecord,
     Probe,
     RCEKit,
@@ -1823,6 +1824,101 @@ class FileBasedTestCase(unittest.TestCase):
              "--methods", "file", "--acknowledge-consent"],
             cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120)
         self.assertIn("--webroot", result.stdout)
+
+
+class ParametricTimeTestCase(unittest.TestCase):
+    """Phase 4 — hardened blind timing. A controlled 0/N/2N delay series must
+    produce a linear response-time increase; jitter cannot fake it. Timing has
+    no computed value, so its ceiling is `needs-review` — it never confirms on
+    its own (I2/I3)."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.method = ParametricTime(self.gen, {"time_base": 2.0, "time_repeats": 2})
+
+    def _series(self, mapping):
+        series = []
+        for delay, elapseds in mapping.items():
+            for elapsed in elapseds:
+                series.append((Probe(payload="x", expected="", delay_s=delay),
+                               Observation(status=200, body="", elapsed=elapsed)))
+        return series
+
+    def test_tier_is_needs_review_and_method_is_aggregate(self):
+        self.assertEqual(self.method.tier, "needs-review")
+        self.assertTrue(self.method.aggregate)
+
+    def test_build_probes_cover_zero_n_and_two_n(self):
+        import random as _random
+        probes = self.method.build_probes(make_record(environment="unix", context="raw"),
+                                          _random.Random(1))
+        delays = sorted({p.delay_s for p in probes})
+        self.assertEqual(delays, [0.0, 2.0, 4.0])
+        self.assertTrue(all("sleep" in p.payload for p in probes))
+
+    def test_confirm_series_linear_response_is_needs_review(self):
+        verdict = self.method.confirm_series(
+            self._series({0: [0.10, 0.12], 2.0: [2.11, 2.09], 4.0: [4.12, 4.08]}))
+        self.assertEqual(verdict.status, "needs-review")
+
+    def test_confirm_series_rejects_flat_jitter_and_nonmonotonic(self):
+        flat = self.method.confirm_series(
+            self._series({0: [0.10, 0.12], 2.0: [0.11, 0.13], 4.0: [0.10, 0.12]}))
+        self.assertEqual(flat.status, "negative")
+        jitter = self.method.confirm_series(
+            self._series({0: [0.10, 0.12], 2.0: [3.9, 0.2], 4.0: [0.3, 0.25]}))
+        self.assertEqual(jitter.status, "negative")
+        nonmono = self.method.confirm_series(
+            self._series({0: [0.1, 0.1], 2.0: [4.1, 4.0], 4.0: [2.1, 2.0]}))
+        self.assertEqual(nonmono.status, "negative")
+
+    def test_end_to_end_sleeping_sink_is_needs_review_never_confirmed(self):
+        # The sink sleeps for the injected `sleep N`; a linear response must be
+        # reported needs-review, never confirmed.
+        import http.server
+        import re as _re
+        import socketserver
+        import threading
+        import time as _time
+        import urllib.parse as up
+
+        def make_handler(vulnerable):
+            class Handler(http.server.BaseHTTPRequestHandler):
+                def log_message(self, *a):
+                    pass
+
+                def do_GET(self):
+                    cmd = up.parse_qs(up.urlparse(self.path).query).get("host", [""])[0]
+                    match = _re.search(r"sleep ([0-9.]+)", cmd)
+                    if vulnerable and match:
+                        _time.sleep(float(match.group(1)))
+                    self.send_response(200)
+                    self.end_headers()
+                    self.wfile.write(b"ok")
+            return Handler
+
+        def run(vulnerable):
+            server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), make_handler(vulnerable))
+            port = server.server_address[1]
+            threading.Thread(target=server.serve_forever, daemon=True).start()
+            try:
+                rec = make_record(environment="unix", context="raw", expected_channel="timing")
+                return self.gen.run_detection(
+                    [rec], url=f"http://127.0.0.1:{port}/x?host=FUZZ", methods=["time"],
+                    config={"time_base": 0.6, "time_repeats": 2})
+            finally:
+                server.shutdown()
+                server.server_close()
+
+        vuln = run(vulnerable=True)
+        self.assertTrue(vuln)
+        self.assertEqual(vuln[0]["verdict"], "needs-review")
+        self.assertEqual(vuln[0]["tier"], "needs-review")
+        self.assertFalse([r for r in vuln if r["verdict"] == "confirmed"],
+                         "timing must never self-confirm")
+
+        flat = run(vulnerable=False)
+        self.assertEqual(flat[0]["verdict"], "negative")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Phase 4 of the detection redesign: **ParametricTime**, a hardened blind-timing method that replaces a single-margin timing check with a **regression**.

It fires a controlled `0/N/2N` delay series (each repeated) and requires the response time to track the injected delay **linearly** — monotonic, with the extra latency at each step matching the sleep within a noise margin. A random slow response (jitter) cannot satisfy a linear response across both `N` and `2N`.

## Tier decision

A delay proves only that the target waited, not a value it computed — so this method never confirms on its own. Its ceiling is `needs-review`. The operator pairs it with `--methods reflected`: the results-based method supplies the execution proof, and a linear timing response corroborates it. This keeps the two tiers honest — a blind timing candidate is never dressed up as proven execution.

## What changed

- **ParametricTime(DetectionMethod)** — `tier = needs-review`, `aggregate = True`; builds the `0/N/2N` series (Unix `sleep`, Windows `ping -n`) and decides via a `confirm_series` regression.
- **Engine** — new aggregate path in `run_detection`: fire a method's whole probe series, stretch each fire's timeout past its intended delay so a genuine sleep completes, and decide once. The per-probe methods (reflected, file) are unchanged.
- **CLI** — `--time-base` sets the base delay N; `--methods time` needs no extra gating.

## Testing

- Unit tests for the regression: linear response to needs-review; flat, jitter, and non-monotonic series to negative.
- End-to-end test against a mock sink that sleeps for the injected delay — asserts needs-review, tier needs-review, and never confirmed; a non-sleeping sink to negative.
- `python -m unittest discover -s tests` — 114 tests green, no third-party dependencies.

## Notes

- Version bumped to `2.13.0`; README updated (Highlights + Options + a blind-timing usage section).
- Remaining phases: EvalExpr (SSTI/SpEL) and WAF `--evade low`.