### PR TITLE
feat(detection): EvalExpr expression/template-injection method (phase 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.13.0** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.14.0** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just
@@ -27,6 +27,7 @@ auto-confirms a blind Log4Shell RCE via an OOB DNS callback:
 - **Raw request input** — `-r request.txt` injects into a captured HTTP request (proxy/Burp style) instead of a hand-built URL. Mark the point with `FUZZ`/`*` or pick a parameter with `-p NAME`; RCEKit reuses the request's method, path, headers, body and cookies and **encodes each injection point for the context it lands in** (query / form / JSON / header / cookie).
 - **Results-based detection** — `--methods reflected` confirms RCE by forcing the target's shell to compute an arithmetic value on **random operands** (`$((a+b))` plus a `$(echo TAG)` substitution collapse) and checking that value appears in the response but not in a payload-free control. A target that merely echoes the payload returns the literal `$((a+b))`, never the sum, so reflection cannot fake a `confirmed`. Confirmed (execution proven) and needs-review (candidate) verdicts are reported as **separate tiers, never merged**.
 - **No-egress detection** — `--methods file` confirms RCE on internal targets with **no outbound connectivity**: the probe writes a random token to a web-reachable file and a followup request fetches it back, proving execution *and* a write primitive through the target's own web server — no external listener. State-changing and gated on `--webroot` + `--web-base-url`; every finding prints a **cleanup command**.
+- **Expression / template injection** — `--methods eval` confirms SSTI / SpEL / OGNL / Groovy / raw-`eval` sinks by injecting `a*b` on **random operands** wrapped in each common syntax (`${…}`, `{{…}}`, `#{…}`, `%{…}`, `<%= … %>`, `@(…)`, bare) and checking the **product** appears while the literal `a*b` does not. Same computed-value invariant as results-based detection, for an expression evaluator instead of a shell.
 - **Hardened blind timing** — `--methods time` fires a controlled `0/N/2N` delay series and requires the response time to track the injected delay **linearly** (a monotonic increase whose extra latency matches the sleep within a noise margin), so jitter cannot fake it. Timing has no computed value, so it is reported `needs-review`, **never** `confirmed` on its own — pair it with `--methods reflected` for an execution proof it corroborates.
 - **Built-in OOB listener** — `--listen` receives HTTP/DNS callbacks and correlates each back to the exact payload, closing the blind-RCE loop without a separate interactsh/Collaborator.
 - **Tooling integrations** — export as context-split Burp wordlists, a ready-to-run ffuf attack (`request.txt` + `run.sh`) when a target profile is given, or runnable Nuclei templates with built-in OOB / time-based / reflection oracles.
@@ -98,7 +99,7 @@ nothing. Run `python rcekit.py --doctor` to check corpus integrity.
 | `-r`, `--request-file <path>` | Raw HTTP request to inject into (alternative to `--verify-url`); mark with `FUZZ`/`*` or select with `-p` | None |
 | `-p`, `--param <name>` | Parameter/field/header/cookie to inject into for `-r` (query > body > header > cookie) | None |
 | `--request-scheme {http,https}` | Scheme for the URL built from `-r` (default: https if Host is `:443`, else http) | auto |
-| `--methods <list>` | Run named detection methods against `--verify-url`/`-r` instead of the classic per-payload oracle (`reflected`, `file`). Opt-in and additive | None |
+| `--methods <list>` | Run named detection methods against `--verify-url`/`-r` instead of the classic per-payload oracle (`reflected`, `eval`, `file`, `time`). Opt-in and additive | None |
 | `--webroot <path>` | (file-based) server-side directory the target can write to and serve | None |
 | `--web-base-url <url>` | (file-based) base URL that serves `--webroot` | None |
 | `--time-base <seconds>` | (time-based) base delay `N`; the regression fires `0/N/2N` and requires the response time to track it | `2.0` |
@@ -344,6 +345,26 @@ input is reported `negative`, and a value that also appears without the payload 
 `confirmed` (execution proven) and `needs-review` (candidate), and never merged.
 Unix and Windows (`set /a`) shells are covered; the method is opt-in, so omitting
 `--methods` leaves the classic `--verify-url` behaviour unchanged.
+
+### Expression / template injection (`--methods eval`)
+
+The same computed-value idea, aimed at **expression evaluators** rather than a
+shell — server-side template injection (Jinja2, Twig, Freemarker, Thymeleaf),
+SpEL, OGNL/Struts, Groovy, and raw `eval()` sinks. It injects `a*b` on random
+operands wrapped in each common syntax and confirms only when the target returns
+the **product**:
+
+```bash
+python rcekit.py --acknowledge-consent --environments python \
+  --verify-url "https://target.example/render?name=FUZZ" --methods eval
+```
+
+Probes cover `${a*b}`, `{{a*b}}`, `#{a*b}`, `%{a*b}`, `<%= a*b %>`, `@(a*b)` and
+a bare `a*b`. A template that renders the payload verbatim echoes `a*b` and never
+the product, so reflection can't fake it; the product is matched on digit
+boundaries and differenced against the payload-free control, so a coincidental
+number in the page is reported `inconclusive`, not `confirmed`. Probe payloads
+depend only on the injection context, so each syntax is tried once per context.
 
 ### No-egress detection (`--methods file`)
 

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.13.0"
+__version__ = "2.14.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -2080,14 +2080,39 @@ class DetectionMethod:
         called for methods with ``aggregate = True``."""
         raise NotImplementedError
 
-    def _search(self, literal: str, body: str) -> bool:
+    def _search(self, literal: str, body: str, boundary: bool = False) -> bool:
         """Encoded-aware literal search. Reuse the generator's ``_encoded_search``
         (additive: raw body first, then common output wrappers) so a sink that
         base64/hex/url/html-encodes the output still confirms. ``literal`` is
-        matched verbatim, not as a regex."""
+        matched verbatim, not as a regex. With ``boundary=True`` the match is
+        fenced by non-digit boundaries, so a bare number (e.g. an arithmetic
+        product) does not spuriously match inside a longer digit run."""
         if not literal or not body:
             return False
-        return self.gen._encoded_search(re.escape(literal), body)
+        pattern = re.escape(literal)
+        if boundary:
+            pattern = r"(?<!\d)" + pattern + r"(?!\d)"
+        return self.gen._encoded_search(pattern, body)
+
+    def _confirm_computed(self, obs: "Observation", probe: "Probe",
+                          noun: str = "computed value", boundary: bool = False) -> Verdict:
+        """Shared confirmation for methods that make the target compute a value
+        on random inputs: the value must be present, the literal expression that
+        only reflection would echo must be absent, and the value must be absent
+        from the payload-free control."""
+        if obs.status is None and not obs.body:
+            return Verdict("inconclusive", "no response from target (delivery error)")
+        if not self._search(probe.expected, obs.body, boundary=boundary):
+            return Verdict("negative", f"{noun} absent from the response")
+        if probe.forbidden and self._search(probe.forbidden, obs.body):
+            # The literal expression survived next to the value: the sink echoed
+            # the payload rather than evaluating it. Refuse to confirm.
+            return Verdict("needs-review",
+                           f"{noun} present, but the literal expression was also reflected")
+        if obs.control_body and self._search(probe.expected, obs.control_body, boundary=boundary):
+            return Verdict("inconclusive", f"{noun} also present in the payload-free control")
+        return Verdict("confirmed",
+                       f"target computed {probe.expected!r} (random operands, absent from control)")
 
     def _tag(self, rng: "random.Random") -> str:
         """A distinctive letters-only boundary marker. Letters keep it from
@@ -2098,8 +2123,13 @@ class DetectionMethod:
         """Break out of the running command with a separator, then escape the
         probe for the record's serialization context — reusing the same
         context/escape machinery the generator uses for every other payload."""
+        return self._wrap_context(record, f"{' & ' if windows else '; '}{core}")
+
+    def _wrap_context(self, record: "PayloadRecord", body: str) -> str:
+        """Escape ``body`` for the record's serialization context and apply the
+        context break-out prefix/suffix — the same machinery the generator uses
+        for every other payload. No command separator is added."""
         ctx = self.gen.contexts.get(record.context, {"prefix": "", "suffix": "", "escape": "none"})
-        body = f"{' & ' if windows else '; '}{core}"
         escaped = self.gen._escape_for_context(body, ctx.get("escape", "none"))
         return f"{ctx.get('prefix', '')}{escaped}{ctx.get('suffix', '')}"
 
@@ -2159,21 +2189,7 @@ class ReflectedMath(DetectionMethod):
         return probes
 
     def confirm(self, obs: "Observation", probe: "Probe") -> Verdict:
-        if obs.status is None and not obs.body:
-            return Verdict("inconclusive", "no response from target (delivery error)")
-        if not self._search(probe.expected, obs.body):
-            return Verdict("negative", "computed value absent from the response")
-        if probe.forbidden and self._search(probe.forbidden, obs.body):
-            # The literal expression survived next to the value: the sink echoed
-            # the payload rather than running it cleanly. Refuse to confirm.
-            return Verdict("needs-review",
-                           "computed value present, but the literal expression was also reflected")
-        if obs.control_body and self._search(probe.expected, obs.control_body):
-            # Present without the payload too — not attributable to execution.
-            return Verdict("inconclusive",
-                           "computed value also present in the payload-free control")
-        return Verdict("confirmed",
-                       f"target computed {probe.expected!r} (random operands, absent from control)")
+        return self._confirm_computed(obs, probe)
 
 
 class FileBased(DetectionMethod):
@@ -2291,12 +2307,59 @@ class ParametricTime(DetectionMethod):
                        "candidate — pair with --methods reflected for an execution proof")
 
 
+class EvalExpr(DetectionMethod):
+    """Code / expression injection (SSTI, SpEL, OGNL, Groovy, raw eval). Inject
+    ``a*b`` on random operands wrapped in each common template/expression
+    syntax, and confirm the *product* appears in the response while the literal
+    ``a*b`` does not — the same computed-value invariant as ReflectedMath, but
+    for an expression evaluator rather than a shell.
+
+    A template that renders the payload verbatim echoes ``a*b``, never the
+    product, so reflection cannot fake it. Probe payloads depend only on the
+    injection context (not the environment), so the engine's per-payload
+    de-duplication fires each syntax once per context."""
+    name = "eval"
+    tier = "confirmed"
+
+    # Delimiters for the common expression/template evaluators, plus a bare form
+    # for raw eval() sinks. {expr} is substituted with the random arithmetic.
+    _FORMS = (
+        "{expr}",            # raw eval (Python/JS/Ruby eval, etc.)
+        "${{{expr}}}",       # Freemarker / JSP EL / SpEL  -> ${a*b}
+        "{{{{{expr}}}}}",    # Jinja2 / Twig / Nunjucks     -> {{a*b}}
+        "#{{{expr}}}",       # SpEL / Thymeleaf             -> #{a*b}
+        "%{{{expr}}}",       # OGNL / Struts                -> %{a*b}
+        "<%= {expr} %>",     # ERB / JSP scriptlet
+        "@({expr})",         # Razor
+    )
+
+    def applicable(self, record: "PayloadRecord") -> bool:
+        return True
+
+    def build_probes(self, record: "PayloadRecord", rng: "random.Random") -> List[Probe]:
+        a = rng.randint(1000, 9999)
+        b = rng.randint(1000, 9999)
+        expr = f"{a}*{b}"
+        expected = str(a * b)
+        probes: List[Probe] = []
+        for form in self._FORMS:
+            probes.append(Probe(payload=self._wrap_context(record, form.format(expr=expr)),
+                                expected=expected, forbidden=expr))
+        return probes
+
+    def confirm(self, obs: "Observation", probe: "Probe") -> Verdict:
+        # Digit boundaries: the product is a bare number, so fence it so it does
+        # not match inside a longer digit run in the page.
+        return self._confirm_computed(obs, probe, boundary=True)
+
+
 # The detection methods RCEKit can run, keyed by their --methods name. Adding a
 # phase = adding a class above and an entry here.
 DETECTION_METHODS = {
     ReflectedMath.name: ReflectedMath,
     FileBased.name: FileBased,
     ParametricTime.name: ParametricTime,
+    EvalExpr.name: EvalExpr,
 }
 
 
@@ -2611,7 +2674,8 @@ def main():
     parser.add_argument("--methods", default=None,
                         help="Comma-separated RCE detection methods to run against --verify-url/-r instead of "
                              "the classic per-payload oracle. Available: reflected (results-based execution "
-                             "proof via computed arithmetic); file (self-OOB write+fetch, needs --webroot and "
+                             "proof via computed arithmetic); eval (SSTI/SpEL/OGNL/Groovy/raw-eval via a "
+                             "computed product); file (self-OOB write+fetch, needs --webroot and "
                              "--web-base-url); time (hardened blind-timing regression, needs-review only). "
                              "Opt-in and additive: when omitted, verification keeps its existing behaviour "
                              "unchanged.")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import rcekit  # noqa: E402
 from rcekit import (  # noqa: E402
+    EvalExpr,
     FileBased,
     Observation,
     OOBListener,
@@ -1919,6 +1920,100 @@ class ParametricTimeTestCase(unittest.TestCase):
 
         flat = run(vulnerable=False)
         self.assertEqual(flat[0]["verdict"], "negative")
+
+
+class EvalExprTestCase(unittest.TestCase):
+    """Phase 5 — code/expression injection (SSTI, SpEL, OGNL, Groovy, raw eval).
+    Inject a*b on random operands in each common template syntax and confirm the
+    product appears while the literal a*b does not — the computed-value invariant
+    for an expression evaluator."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.method = EvalExpr(self.gen)
+
+    def test_build_probes_cover_common_expression_syntaxes(self):
+        import random as _random
+        probes = self.method.build_probes(make_record(environment="python", context="raw", sink="ssti"),
+                                          _random.Random(5))
+        joined = " ".join(p.payload for p in probes)
+        for delim in ("${", "{{", "#{", "%{", "<%=", "@("):
+            self.assertIn(delim, joined)
+        for probe in probes:
+            # expected is the product; forbidden is the literal expression, which
+            # is present in the payload but must be absent from a confirmed body.
+            self.assertNotIn(probe.expected, probe.payload)
+            self.assertIn(probe.forbidden, probe.payload)
+
+    def test_confirm_evaluation_vs_reflection_vs_boundary(self):
+        import random as _random
+        probe = self.method.build_probes(make_record(environment="python", context="raw"),
+                                         _random.Random(5))[1]
+        # Evaluated: product present, literal absent.
+        self.assertEqual(
+            self.method.confirm(Observation(200, f"= {probe.expected} =", control_body="x"), probe).status,
+            "confirmed")
+        # Reflected: literal echoed, product never produced.
+        self.assertEqual(
+            self.method.confirm(Observation(200, f"= {probe.forbidden} =", control_body="x"), probe).status,
+            "negative")
+        # Product embedded in a longer digit run must not match (digit boundary).
+        self.assertEqual(
+            self.method.confirm(Observation(200, f"id={probe.expected}00", control_body="x"), probe).status,
+            "negative")
+        # Present without the payload too -> inconclusive.
+        self.assertEqual(
+            self.method.confirm(Observation(200, probe.expected, control_body=probe.expected), probe).status,
+            "inconclusive")
+
+    def test_eval_end_to_end_against_evaluating_sink(self):
+        # /ssti evaluates a bare `a*b` (or one wrapped in ${...}/{{...}}/...);
+        # /reflect echoes input verbatim. EvalExpr must confirm on the former only.
+        import http.server
+        import re as _re
+        import socketserver
+        import threading
+        import urllib.parse as up
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_GET(self):
+                parsed = up.urlparse(self.path)
+                raw = up.parse_qs(parsed.query).get("q", [""])[0]
+                self.send_response(200)
+                self.end_headers()
+                if parsed.path == "/ssti":
+                    # Simulate an expression evaluator: strip common delimiters,
+                    # then evaluate a pure `int*int` expression.
+                    expr = _re.sub(r"^[\$#%@]?\(?\{*=?\s*|\s*\}*\)?%?>?\s*$", "", raw)
+                    expr = expr.strip("${}#%@()<>= ")
+                    match = _re.fullmatch(r"(\d+)\*(\d+)", expr)
+                    out = str(int(match.group(1)) * int(match.group(2))) if match else raw
+                else:
+                    out = raw
+                try:
+                    self.wfile.write(out.encode(errors="replace"))
+                except BrokenPipeError:
+                    pass
+
+        server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            rec = make_record(environment="python", context="raw", sink="ssti")
+            evaluated = self.gen.run_detection(
+                [rec], url=f"http://127.0.0.1:{port}/ssti?q=FUZZ", methods=["eval"])
+            self.assertTrue([r for r in evaluated if r["verdict"] == "confirmed"],
+                            "EvalExpr must confirm against an expression evaluator")
+            reflected = self.gen.run_detection(
+                [rec], url=f"http://127.0.0.1:{port}/reflect?q=FUZZ", methods=["eval"])
+            self.assertFalse([r for r in reflected if r["verdict"] == "confirmed"],
+                             "a target that only echoes input must never be confirmed")
+        finally:
+            server.shutdown()
+            server.server_close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Phase 5 of the detection redesign: **EvalExpr**, a detection method for code and expression injection — SSTI (Jinja2, Twig, Freemarker, Thymeleaf), SpEL, OGNL/Struts, Groovy, and raw `eval()` sinks.

It injects `a*b` on random operands wrapped in each common expression syntax and confirms only when the target returns the **product**, with the literal expression absent and the product absent from the payload-free control — the same computed-value invariant as ReflectedMath, aimed at an evaluator rather than a shell.

## What changed

- **`EvalExpr(DetectionMethod)`** — covers `${…}`, `{{…}}`, `#{…}`, `%{…}`, `<%= … %>`, `@(…)` and a bare form; the product is matched on **digit boundaries** so it never matches inside a longer number in the page.
- **Shared confirm** — factored the computed-value confirmation into `DetectionMethod._confirm_computed` (with an optional digit-boundary mode) and routed both ReflectedMath and EvalExpr through it. Split `_wrap` into the separator-adding variant and a context-only `_wrap_context` that EvalExpr reuses (no shell separator for an expression payload).
- **CLI** — `eval` registered in `--methods`. Probe payloads depend only on the injection context, so the engine's per-payload de-duplication fires each syntax once per context.

## Testing

- Unit tests for the syntax coverage and the evaluation / reflection / digit-boundary / control verdicts.
- End-to-end test against a mock that evaluates a wrapped `a*b` vs one that only echoes it — EvalExpr must confirm on the evaluator only.
- The ReflectedMath refactor is behaviour-preserving (its tests are unchanged and green).
- `python -m unittest discover -s tests` — 117 tests green, no third-party dependencies.

## Notes

- Version bumped to `2.14.0`; README updated (Highlights + Options + an expression/template usage section).
- One phase remains: WAF `--evade low`.