### PR TITLE
fix: drop the optional YAML template path to stay stdlib-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.15.0** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.15.1** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just
@@ -82,7 +82,7 @@ nothing. Run `python rcekit.py --doctor` to check corpus integrity.
 | `--output-format` | `text`, `jsonl`, `burp`, `ffuf`, or `nuclei` | `text` |
 | `--max-payloads` | Cap the number of payloads (balanced round-robin sample across categories/environments) | Unlimited |
 | `--attacker-ip` / `--attacker-domain` | Substituted into reverse-shell / download payloads | `192.168.1.100` / `attacker.com` |
-| `--template-file` | Custom JSON/YAML payload templates | `templates/payloads.json` |
+| `--template-file` | Custom JSON payload templates | `templates/payloads.json` |
 | `--doctor` | Check corpus integrity (template found, parses, payload counts) and exit non-zero if missing/empty | Off |
 | `--detection-only` | Benign canary/timing probes for safe validation | Off |
 | `--include-metadata` | Write a `.meta.jsonl` sidecar (indicators, safety tiers, notes) | Off |
@@ -537,7 +537,7 @@ python -m unittest discover -s tests   # dependency-free test suite
 ```
 
 Contributions welcome — new sinks/categories, encodings, environments, bug fixes,
-and docs. Payload bases live in editable JSON/YAML templates
+and docs. Payload bases live in editable JSON templates
 (`templates/payloads.json`), so most coverage can be extended without touching the
 Python source.
 

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.15.0"
+__version__ = "2.15.1"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -168,9 +168,12 @@ class RCEKit:
         self.default_encodings = ["none", "url_encode", "double_url_encode", "random_case", "base64_decode_exec"]
 
     def _load_template_payloads(self) -> None:
-        """Load payload templates from JSON/YAML files. Records the reason in
+        """Load payload templates from a JSON file. Records the reason in
         ``self.template_error`` (``None`` on success) so callers can hard-fail
-        on a missing or corrupt corpus instead of silently generating nothing."""
+        on a missing or corrupt corpus instead of silently generating nothing.
+
+        Templates are JSON only: RCEKit is standard-library-only (no third-party
+        dependencies), and a YAML parser is not in the stdlib."""
         self.template_error: Optional[str] = None
         if not self.template_path.exists():
             message = f"template file not found: {self.template_path}"
@@ -180,21 +183,18 @@ class RCEKit:
             self.template_error = message
             return
 
+        if self.template_path.suffix in {".yml", ".yaml"}:
+            message = (f"YAML templates are not supported: {self.template_path}. RCEKit is "
+                       "stdlib-only (no third-party dependencies); convert the template to JSON.")
+            logger.error("%s", message)
+            self.payload_categories = {}
+            self.detection_payloads = {}
+            self.template_error = message
+            return
+
         try:
             with open(self.template_path, "r", encoding="utf-8") as template_file:
-                content = template_file.read()
-
-            if self.template_path.suffix in {".yml", ".yaml"}:
-                try:
-                    import yaml  # type: ignore
-
-                    data = yaml.safe_load(content)
-                except Exception as exc:  # pragma: no cover - optional dependency
-                    logger.error("Failed to parse YAML template %s: %s", self.template_path, exc)
-                    raise
-            else:
-                data = json.loads(content)
-
+                data = json.loads(template_file.read())
             self.payload_categories = data.get("payload_categories", {})
             self.detection_payloads = data.get("detection_payloads", {})
         except Exception as exc:
@@ -2629,7 +2629,7 @@ def main():
     parser.add_argument("--environments", nargs="+", default=None,
                        help="Environments to generate (default: all)")
     parser.add_argument("--template-file", type=str, default=None,
-                        help="Path to a custom payload template file (JSON or YAML)")
+                        help="Path to a custom JSON payload template file")
     parser.add_argument("--detection-only", action="store_true",
                         help="Generate benign payloads for detection and validation")
     parser.add_argument("--output-format", choices=["text", "jsonl", "burp", "ffuf", "nuclei"], default="text",

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -169,6 +169,17 @@ class GeneratorTestCase(unittest.TestCase):
         self.assertIn("basic_enum", self.gen.payload_categories)
         self.assertTrue(self.gen.detection_payloads, "detection payloads should load")
 
+    def test_yaml_template_is_rejected_without_a_third_party_parser(self):
+        # RCEKit is stdlib-only: a YAML template must fail with a clear error
+        # rather than attempting to import a third-party YAML parser.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "corpus.yaml"
+            path.write_text("payload_categories: {}\n", encoding="utf-8")
+            gen = RCEKit(template_path=path)
+            self.assertFalse(gen.payload_categories)
+            self.assertIsNotNone(gen.template_error)
+            self.assertIn("YAML templates are not supported", gen.template_error)
+
     def test_removed_encodings_are_gone(self):
         removed = {"rot13", "rot13_then_base64", "insert_special_chars",
                    "xor_polymorphic", "chunk_shuffle"}


### PR DESCRIPTION
## Summary

RCEKit advertises **stdlib-only / no third-party dependencies**, but the template loader imported **PyYAML** for `.yml`/`.yaml` templates. In a stdlib-only install that import failed anyway, so YAML templates never actually worked. This removes the latent third-party import so the code matches its stated invariant (I1).

This was the only third-party import in the whole repository; the tool and its entire test suite are otherwise pure standard library.

## What changed

- **JSON templates only** — a `.yaml`/`.yml` template path now fails with a clear, actionable error (`YAML templates are not supported … convert the template to JSON`) instead of attempting a third-party import.
- Updated the `--template-file` help and README to say JSON only.
- The `yaml` **serialization context** (escaping payloads for a YAML transport) is a separate feature and is unchanged.
- Added a test that a YAML template is rejected without any third-party parser.

## Versioning

Bumped to `2.15.1` (PATCH): default and advertised behaviour is unchanged — JSON templates work exactly as before, and YAML never worked in a stdlib-only install, so this only makes that failure explicit and removes the import attempt. Happy to make it a MINOR/MAJOR instead if you'd prefer to flag the dropped input format more loudly.

## Testing

- `python -m unittest discover -s tests` — 122 tests green, no third-party dependencies.