### PR TITLE
fix(detection): confirm echo-back command injection instead of downgrading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — RCE Testing Toolkit
 
-**Version 2.15.1** · MIT · Python 3.8+ · no third-party dependencies
+**Version 2.15.2** · MIT · Python 3.8+ · no third-party dependencies
 
 RCEKit is an offensive **RCE testing toolkit** for authorised penetration
 testing, red teaming, and security research. It covers the full loop, not just

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.15.1"
+__version__ = "2.15.2"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -2096,23 +2096,27 @@ class DetectionMethod:
 
     def _confirm_computed(self, obs: "Observation", probe: "Probe",
                           noun: str = "computed value", boundary: bool = False) -> Verdict:
-        """Shared confirmation for methods that make the target compute a value
-        on random inputs: the value must be present, the literal expression that
-        only reflection would echo must be absent, and the value must be absent
-        from the payload-free control."""
+        """Shared confirmation for methods that make the target compute a value on
+        random inputs. The value RCEKit computed must be present in the response
+        and absent from the payload-free control — reflection cannot produce it
+        (a tag-bracketed sum / a boundary-fenced product on random operands is
+        unforgeable), so its presence is proof of execution.
+
+        A ``forbidden`` literal (the pre-execution expression, e.g. ``$((a+b))``)
+        may also appear when the target echoes the payload verbatim — the single
+        most common command-injection pattern (``PING <input> ...``). That is NOT
+        a reason to withhold confirmation: the computed value is already proof, so
+        the reflected literal is only noted, never a downgrade."""
         if obs.status is None and not obs.body:
             return Verdict("inconclusive", "no response from target (delivery error)")
         if not self._search(probe.expected, obs.body, boundary=boundary):
             return Verdict("negative", f"{noun} absent from the response")
-        if probe.forbidden and self._search(probe.forbidden, obs.body):
-            # The literal expression survived next to the value: the sink echoed
-            # the payload rather than evaluating it. Refuse to confirm.
-            return Verdict("needs-review",
-                           f"{noun} present, but the literal expression was also reflected")
         if obs.control_body and self._search(probe.expected, obs.control_body, boundary=boundary):
             return Verdict("inconclusive", f"{noun} also present in the payload-free control")
-        return Verdict("confirmed",
-                       f"target computed {probe.expected!r} (random operands, absent from control)")
+        evidence = f"target computed {probe.expected!r} (random operands, absent from control)"
+        if probe.forbidden and self._search(probe.forbidden, obs.body):
+            evidence += "; target also reflects the payload verbatim"
+        return Verdict("confirmed", evidence)
 
     def _tag(self, rng: "random.Random") -> str:
         """A distinctive letters-only boundary marker. Letters keep it from

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1541,16 +1541,18 @@ class DetectionMethodTestCase(unittest.TestCase):
             self.method.confirm(Observation(200, exec_body, control_body=exec_body), probe).status,
             "inconclusive")
 
-    def test_confirm_needs_review_when_literal_also_reflected(self):
+    def test_confirm_holds_when_target_also_echoes_the_payload(self):
         import random as _random
         rec = make_record(environment="unix", context="raw")
         probe = self.method.build_probes(rec, _random.Random(9))[0]
-        # Computed value present, but so is the raw expression — the sink echoed
-        # the payload rather than running it cleanly, so it is not confirmed.
+        # The computed value AND the raw expression are both present — the classic
+        # command-injection sink that echoes the input (e.g. "PING <input>") while
+        # also executing it. The computed value is unforgeable proof of execution,
+        # so this must stay `confirmed`; the reflection is only noted.
         body = f"{probe.expected} but also {probe.forbidden}"
         verdict = self.method.confirm(Observation(200, body, control_body="idle"), probe)
-        self.assertEqual(verdict.status, "needs-review")
-        self.assertEqual(self.method.tier, "confirmed")  # tier is the method's ceiling
+        self.assertEqual(verdict.status, "confirmed")
+        self.assertIn("reflects the payload verbatim", verdict.evidence)
 
     def test_reflected_math_confirms_on_executing_target_only(self):
         # /vuln runs the injected string through a shell (real execution);
@@ -1598,6 +1600,42 @@ class DetectionMethodTestCase(unittest.TestCase):
                 [rec], url=f"http://127.0.0.1:{port}/reflect?cmd=FUZZ", methods=["reflected"])
             self.assertFalse([r for r in reflect if r["verdict"] == "confirmed"],
                              "a target that only echoes input must never be confirmed")
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_confirms_echo_back_command_injection(self):
+        # Regression for the most common real-world sink: a tool that echoes the
+        # input back (e.g. "PING <input> ...") AND executes it. The reflected
+        # literal `$((a+b))` must NOT downgrade the genuine RCE — the tag-wrapped
+        # computed value is still unforgeable proof of execution.
+        import http.server
+        import os
+        import socketserver
+        import threading
+        import urllib.parse as up
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_GET(self):
+                ip = up.parse_qs(up.urlparse(self.path).query).get("ip", [""])[0]
+                out = os.popen("ping -c 1 " + ip + " 2>&1").read()  # injection sink
+                self.send_response(200)
+                self.end_headers()
+                # Echoes the raw input verbatim next to the executed output.
+                self.wfile.write(f"PING {ip}\n{out}".encode(errors="replace"))
+
+        server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            rec = make_record(environment="unix", context="raw")
+            results = self.gen.run_detection(
+                [rec], url=f"http://127.0.0.1:{port}/ping?ip=FUZZ", methods=["reflected"])
+            confirmed = [r for r in results if r["verdict"] == "confirmed"]
+            self.assertTrue(confirmed, "echo-back command injection must be confirmed, not downgraded")
         finally:
             server.shutdown()
             server.server_close()


### PR DESCRIPTION
## Summary

Local validation against a VulnHub-class range surfaced a **false negative**. A command-injection tool that **echoes the input back while executing it** — the very common `PING <input> ...` pattern seen on countless real boxes — was downgraded from `confirmed` to `needs-review`, because the literal `$((a+b))` also appeared in the reflected input.

That downgrade was wrong. The value RCEKit checks for is a **tag-wrapped sum / boundary-fenced product on random operands** — reflection cannot produce it, so its presence (and absence from the payload-free control) is already unforgeable proof of execution. The literal appearing alongside it is just the app echoing input; it does not weaken the proof.

## What changed

- Drop the `forbidden`-literal to `needs-review` downgrade in `_confirm_computed`. When the computed value is present and absent from the control, **confirm** — and note in the evidence when the target also reflects the payload verbatim.
- Update the ReflectedMath unit test to expect `confirmed` (not `needs-review`) when both the value and the literal are present.
- Add an end-to-end regression against an echo-back `ping` sink.

## False-positive resistance is unchanged

A reflection-only target never produces the tag-wrapped / boundary-fenced computed value, so it stays `negative`. This is still covered by the existing `/reflect` and echo-only tests, plus the new ones.

## Validation (local VulnHub-class range, non-OOB methods)

| Scenario | Class | Method | Before | After |
|---|---|---|---|---|
| `/ping` echo-back | OS command injection | `reflected` | needs-review | confirmed |
| `/calc` `eval()` | code injection (CWE-94) | `eval` | confirmed | confirmed |
| `/ssti` | SSTI | `eval` | confirmed | confirmed |
| `/blind` | blind command injection | `time` | needs-review | needs-review |
| `/ping` + write | command injection + write | `file` | confirmed | confirmed |
| `/ping` + WAF | command injection | `reflected --evade low` | confirmed | confirmed |
| `/echo` reflection-only | FP control | `reflected,eval` | no false confirm | no false confirm |
| `/safe` patched | FP control | `reflected` | no false confirm | no false confirm |

## Testing

- `python -m unittest discover -s tests` — 123 tests green, no third-party dependencies.
- Bumped to `2.15.2` (PATCH — fixes a false negative; no interface change).