### PR TITLE
feat(detection): add --sink-raw for whole-command injection sinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.15.2** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.16.0** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed
@@ -170,6 +170,20 @@ shell probes. It is deliberately minimal, not noisy evasion.
 ```bash
 python rcekit.py --acknowledge-consent \
   --verify-url "https://target.example/ping?ip=FUZZ" --methods reflected --evade low
+```
+
+### Sink runs your input as the whole command?
+
+By default the shell probes break out of a surrounding command with a leading
+separator (`; …`), which fits the common `system("ping " + input)` sink. Some
+sinks instead execute the injected input *as the entire command* — a
+`qx/$input/` backdoor, a bare `sh -c "$input"` — where there is nothing to break
+out of and a leading `;` is a shell syntax error. Pass `--sink-raw` to send the
+probes as bare commands:
+
+```bash
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/run?cmd=FUZZ" --methods reflected --sink-raw
 ```
 
 ### Reading the results
@@ -379,6 +393,7 @@ Python (`os_system`, `subprocess`, `jinja2_ssti`, `exec_ast`), Postgres
 | `--webroot` / `--web-base-url` | (file method) server write dir / URL that serves it | None |
 | `--time-base <seconds>` | (time method) base delay `N`; regression fires `0/N/2N` | `2.0` |
 | `--evade {none,low}` | WAF posture; `low` = minimal `${IFS}`-for-spaces on shell probes | `none` |
+| `--sink-raw` | (`--methods`) Sink runs input as the whole command; send probes with no leading separator | Off |
 | `--verify-data` / `--verify-header` / `--verify-method` | Body (with `FUZZ`) / repeatable header / HTTP method | — |
 | `--verify-url-location` / `--verify-body-location` | Encode the payload at the URL / body point | `query_value` / auto |
 | `--verify-delay` / `--verify-timeout` | Seconds between requests / per-request timeout | `0` / `8` |

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.15.2"
+__version__ = "2.16.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -2129,13 +2129,22 @@ class DetectionMethod:
         probe for the record's serialization context — reusing the same
         context/escape machinery the generator uses for every other payload.
 
+        With ``--sink-raw`` (``config['sink_raw']``) the injected input is
+        executed as the *whole* command — a ``qx/$input/``-style sink with no
+        surrounding command to break out of — so no separator is prepended; a
+        leading ``;``/``&`` would be a shell syntax error there. The probe is
+        sent as a bare command instead.
+
         With ``--evade low`` and ``evade=True``, apply a single low-touch WAF
         transform to Unix command probes — substitute ``${IFS}`` for spaces —
         drawn from the existing shell-bypass vocabulary. It is deliberately
         minimal, not aggressive/noisy evasion. Callers whose command uses a
         redirect (``>``) pass ``evade=False``: ``${IFS}`` around ``>`` yields an
         ambiguous redirect, so those stay canonical."""
-        body = f"{' & ' if windows else '; '}{core}"
+        if self.config.get("sink_raw"):
+            body = core
+        else:
+            body = f"{' & ' if windows else '; '}{core}"
         if evade and not windows and self.config.get("evade") == "low":
             body = body.replace(" ", "${IFS}")
         return self._wrap_context(record, body)
@@ -2739,6 +2748,10 @@ def main():
                         help="Drop payloads longer than this many characters")
     parser.add_argument("--sink-needs-separator", action="store_true", default=None,
                         help="Sink concatenates input mid shell command: keep only separator-led payloads")
+    parser.add_argument("--sink-raw", action="store_true", default=None,
+                        help="(--methods) Sink runs the injected input as the whole command "
+                             "(no surrounding command to break out of, e.g. a qx/$input/ sink): "
+                             "send shell probes as bare commands without a leading separator")
     parser.add_argument("--sink-blind", action="store_true", default=None,
                         help="Sink returns no output: keep only out-of-band confirmable payloads (timing/OOB)")
     parser.add_argument("--sink-decodes", nargs="+", default=None,
@@ -2795,6 +2808,7 @@ def main():
 
     # Sink-shape awareness: narrow generation to what this sink could execute.
     needs_separator = bool(from_profile(args.sink_needs_separator, "sink_needs_separator"))
+    sink_raw = bool(from_profile(args.sink_raw, "sink_raw"))
     blind = bool(from_profile(args.sink_blind, "sink_blind"))
     sink_decodes = from_profile(args.sink_decodes, "sink_decodes") or []
     # A profile `request` block shapes the exported Burp/Nuclei requests.
@@ -2992,7 +3006,8 @@ def main():
                       f"Available: {', '.join(sorted(DETECTION_METHODS))}.")
                 return
             detection_config = {"webroot": args.webroot, "web_base_url": args.web_base_url,
-                                "time_base": args.time_base, "evade": args.evade}
+                                "time_base": args.time_base, "evade": args.evade,
+                                "sink_raw": sink_raw}
             if "file" in method_names:
                 if not (args.webroot and args.web_base_url):
                     print("[!] --methods file writes a file to the target and fetches it back, so it "

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1601,6 +1601,32 @@ class DetectionMethodTestCase(unittest.TestCase):
         self.assertEqual(verdict.status, "confirmed")
         self.assertIn("reflects the payload verbatim", verdict.evidence)
 
+    def test_sink_raw_omits_leading_separator(self):
+        # A sink that runs the injected input as the *whole* command (e.g. a
+        # qx/$input/ backdoor) has no surrounding command to break out of, so a
+        # leading `;` would be a shell syntax error. `--sink-raw` must send the
+        # shell probes as bare commands while keeping the computed-value invariant.
+        import random as _random
+        rec = make_record(environment="unix", context="raw")
+        default_probe = ReflectedMath(self.gen).build_probes(rec, _random.Random(3))[0]
+        self.assertTrue(default_probe.payload.startswith("; "))
+        raw = ReflectedMath(self.gen, {"sink_raw": True}).build_probes(rec, _random.Random(3))
+        for probe in raw:
+            self.assertFalse(probe.payload.lstrip().startswith(";"))
+            # The expected sum is still absent from the payload, so only execution
+            # can place it in the response — the invariant is untouched.
+            self.assertNotIn(probe.expected, probe.payload)
+        self.assertTrue(raw[0].payload.startswith("echo "))
+        # The other shell-based methods drop the separator too.
+        timing = ParametricTime(self.gen, {"sink_raw": True, "time_base": 2}).build_probes(
+            rec, _random.Random(3))
+        self.assertTrue(any(p.payload.startswith("sleep ") for p in timing))
+        self.assertFalse(any(p.payload.lstrip().startswith(";") for p in timing))
+        file_cfg = {"sink_raw": True, "webroot": "/var/www", "web_base_url": "http://t"}
+        file_probe = FileBased(self.gen, file_cfg).build_probes(rec, _random.Random(3))[0]
+        self.assertTrue(file_probe.payload.startswith("echo "))
+        self.assertFalse(file_probe.payload.lstrip().startswith(";"))
+
     def test_reflected_math_confirms_on_executing_target_only(self):
         # /vuln runs the injected string through a shell (real execution);
         # /reflect echoes it verbatim without executing. ReflectedMath must


### PR DESCRIPTION
The --methods detection engine always prepended a command separator ("; ") to its shell probes, which fits the common mid-command sink (system("ping " + input)) but breaks on sinks that execute the injected input as the entire command (a qx/$input/ backdoor, sh -c "$input"): there a leading ";" is a shell syntax error, so every probe comes back negative even though the target is exploitable.

Add --sink-raw so _wrap emits the probe as a bare command with no leading separator, covering reflected/file/time in one place. Default behaviour is unchanged. The flag is also read from a --target-profile for parity with the other --sink-* options.