### PR TITLE
feat(detection): --insecure for self-signed targets; report delivery errors as error, not negative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.16.0** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.17.0** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed
@@ -192,8 +192,11 @@ python rcekit.py --acknowledge-consent \
   target computed. Put it in the report.
 - **`needs-review`** — a candidate (e.g. a linear timing response). Worth manual
   follow-up; not proof.
-- **`negative`** / **`inconclusive`** — no evidence, or evidence that also appears
-  without the payload (so it isn't attributable to execution).
+- **`negative`** / **`inconclusive`** — reached the target but found no evidence, or
+  evidence that also appears without the payload (so it isn't attributable to execution).
+- **`error`** — the request never reached the target (a delivery/TLS failure). Kept
+  separate from `negative` on purpose: a connectivity problem must never read as
+  "not vulnerable". For a self-signed HTTPS cert, re-run with `--insecure`.
 
 <details>
 <summary><b>How a <code>confirmed</code> can't be a false positive</b></summary>
@@ -397,6 +400,7 @@ Python (`os_system`, `subprocess`, `jinja2_ssti`, `exec_ast`), Postgres
 | `--verify-data` / `--verify-header` / `--verify-method` | Body (with `FUZZ`) / repeatable header / HTTP method | — |
 | `--verify-url-location` / `--verify-body-location` | Encode the payload at the URL / body point | `query_value` / auto |
 | `--verify-delay` / `--verify-timeout` | Seconds between requests / per-request timeout | `0` / `8` |
+| `--insecure` | Skip TLS cert verification (self-signed internal targets), like `curl -k` | Off |
 | `--verify-active-risk` | Highest safety tier verification may fire (`safe`/`intrusive`/`stateful`) | `safe` |
 | `--verify-allow-destructive` | Allow destructive payloads (persistence/backdoors) | Off |
 | `--verify-chain <profile.json>` | Multi-step, session-aware verification | None |

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.16.0"
+__version__ = "2.17.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -1501,14 +1501,32 @@ class RCEKit:
         target, body, hdrs = self._build_verify_request(
             payload, url, data, headers, url_location, body_location)
         request = urllib.request.Request(target, data=body, headers=hdrs, method=method)
+        context = self._verify_ssl_context()
         start = time.time()
         try:
-            with urllib.request.urlopen(request, timeout=timeout) as response:
+            with urllib.request.urlopen(request, timeout=timeout, context=context) as response:
                 return response.status, response.read().decode(errors="replace"), time.time() - start
         except urllib.error.HTTPError as exc:
             return exc.code, exc.read().decode(errors="replace"), time.time() - start
         except Exception as exc:  # network error, timeout, etc.
             return None, str(exc), time.time() - start
+
+    def _verify_ssl_context(self):
+        """SSL context for verification/detection requests. Returns ``None``
+        (urllib's default, certificate-verifying) unless ``--insecure`` was set,
+        in which case certificate verification is disabled — self-signed or
+        hostname-mismatched certs are the norm on internal pentest targets, so
+        this is an explicit operator opt-in, not a default. Ignored for HTTP."""
+        if not getattr(self, "insecure", False):
+            return None
+        ctx = getattr(self, "_insecure_ctx", None)
+        if ctx is None:
+            import ssl
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            self._insecure_ctx = ctx
+        return ctx
 
     def run_verification(self, records: Iterator[PayloadRecord], url: str, method: str = "GET",
                          data: Optional[str] = None, headers: Optional[List[str]] = None,
@@ -2031,8 +2049,11 @@ class Probe:
 @dataclass
 class Verdict:
     """A method's decision. ``status`` is one of ``confirmed`` (execution
-    proven), ``needs-review`` (candidate), ``negative`` (no evidence), or
-    ``inconclusive`` (evidence not attributable to execution)."""
+    proven), ``needs-review`` (candidate), ``negative`` (reached the target, no
+    evidence), ``inconclusive`` (evidence not attributable to execution), or
+    ``error`` (the request never reached the target — a delivery/TLS failure,
+    which is deliberately NOT a ``negative`` so a connectivity problem is never
+    read as 'not vulnerable')."""
     status: str
     evidence: str
 
@@ -2107,8 +2128,8 @@ class DetectionMethod:
         most common command-injection pattern (``PING <input> ...``). That is NOT
         a reason to withhold confirmation: the computed value is already proof, so
         the reflected literal is only noted, never a downgrade."""
-        if obs.status is None and not obs.body:
-            return Verdict("inconclusive", "no response from target (delivery error)")
+        if obs.status is None:
+            return Verdict("error", f"request never reached the target ({obs.body[:120]})")
         if not self._search(probe.expected, obs.body, boundary=boundary):
             return Verdict("negative", f"{noun} absent from the response")
         if obs.control_body and self._search(probe.expected, obs.control_body, boundary=boundary):
@@ -2258,6 +2279,8 @@ class FileBased(DetectionMethod):
                       expected=token, forbidden=None, followup=followup)]
 
     def confirm(self, obs: "Observation", probe: "Probe") -> Verdict:
+        if obs.status is None:
+            return Verdict("error", f"write request never reached the target ({obs.body[:120]})")
         if obs.followup_body is None:
             return Verdict("negative",
                            "could not fetch the written file (no write, wrong web root, or blocked)")
@@ -2308,6 +2331,9 @@ class ParametricTime(DetectionMethod):
 
     def confirm_series(self, series: "List[Tuple[Probe, Observation]]") -> Verdict:
         import statistics
+        if any(obs.status is None for _, obs in series):
+            return Verdict("error", "one or more timing probes never reached the target "
+                                    "(delivery/TLS failure); regression not judged")
         by_delay: Dict[float, List[float]] = {}
         for probe, obs in series:
             by_delay.setdefault(probe.delay_s or 0.0, []).append(obs.elapsed)
@@ -2661,6 +2687,10 @@ def main():
                         help="Seconds to wait between verification requests (rate limiting)")
     parser.add_argument("--verify-timeout", type=float, default=8.0,
                         help="Per-request timeout for verification (seconds)")
+    parser.add_argument("--insecure", action="store_true",
+                        help="Skip TLS certificate verification for verification/detection requests "
+                             "(self-signed or hostname-mismatched certs on internal targets). Opt-in, "
+                             "like curl -k; ignored for HTTP targets")
     parser.add_argument("--verify-url-location", choices=["query_value", "url_path", "raw"], default="query_value",
                         help="How to encode the payload where FUZZ appears in --verify-url "
                              "(default query_value: percent-encoded, as a query parameter)")
@@ -2821,6 +2851,7 @@ def main():
         attacker_domain=args.attacker_domain,
         template_path=template_path,
     )
+    generator.insecure = args.insecure
 
     if args.doctor:
         ok, report = generator.check_integrity()
@@ -3044,8 +3075,14 @@ def main():
                     print(f"  [{result['method']}/{result['environment']}/{result['context']}] "
                           f"{result['payload']}   ({result['detail']})")
             if not confirmed:
-                print("\n[detect] No execution confirmed. The target may be patched, or the probes "
-                      "may not fit its sink/context (try --environments/--contexts).")
+                errored = [r for r in results if r["verdict"] == "error"]
+                if errored:
+                    print(f"\n[detect] {len(errored)} of {len(results)} probe(s) NEVER REACHED THE TARGET "
+                          f"(a delivery error is not a negative): {errored[0]['detail']}")
+                    print("[detect] check connectivity/auth; for a self-signed HTTPS cert add --insecure.")
+                if len(errored) < len(results):
+                    print("\n[detect] No execution confirmed. The target may be patched, or the probes "
+                          "may not fit its sink/context (try --environments/--contexts).")
             return
         results = generator.run_verification(
             to_send, url=verify_url, method=method, data=verify_data,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1627,6 +1627,35 @@ class DetectionMethodTestCase(unittest.TestCase):
         self.assertTrue(file_probe.payload.startswith("echo "))
         self.assertFalse(file_probe.payload.lstrip().startswith(";"))
 
+    def test_delivery_error_is_error_not_negative(self):
+        # status=None means the request never reached the target (delivery/TLS
+        # failure). Reporting that as `negative` would read as "not vulnerable",
+        # so every method must return `error` instead.
+        import random as _random
+        rec = make_record(environment="unix", context="raw")
+        probe = self.method.build_probes(rec, _random.Random(5))[0]
+        self.assertEqual(
+            self.method.confirm(Observation(None, "<urlopen error ...>"), probe).status,
+            "error")
+        fb = FileBased(self.gen, {"webroot": "/var/www", "web_base_url": "http://t"})
+        fprobe = fb.build_probes(rec, _random.Random(5))[0]
+        self.assertEqual(
+            fb.confirm(Observation(None, "err", followup_body=None), fprobe).status, "error")
+        pt = ParametricTime(self.gen, {"time_base": 1})
+        series = [(p, Observation(None, "err", elapsed=0.0))
+                  for p in pt.build_probes(rec, _random.Random(5))]
+        self.assertEqual(pt.confirm_series(series).status, "error")
+
+    def test_insecure_is_opt_in(self):
+        # Default keeps certificate verification (context None = urllib default);
+        # --insecure disables it, like curl -k, only when the operator opts in.
+        import ssl
+        self.assertIsNone(self.gen._verify_ssl_context())
+        self.gen.insecure = True
+        ctx = self.gen._verify_ssl_context()
+        self.assertEqual(ctx.verify_mode, ssl.CERT_NONE)
+        self.assertFalse(ctx.check_hostname)
+
     def test_reflected_math_confirms_on_executing_target_only(self):
         # /vuln runs the injected string through a shell (real execution);
         # /reflect echoes it verbatim without executing. ReflectedMath must


### PR DESCRIPTION
## Summary

Follow-up to the `--sink-raw` work (already on `main` via #33). Two real-world gaps surfaced while confirming RCE against an internal HTTPS target with a self-signed certificate:

1. **No way to skip TLS verification.** `urllib` verifies certificates by default and the `PYTHONHTTPSVERIFY=0` env hack is not honoured on every build, so every request to a target with a self-signed or hostname-mismatched cert failed. Adds `--insecure` (opt-in, like `curl -k`): `_fire` uses an unverified SSL context only when the operator sets it; HTTP targets are unaffected.

2. **A delivery failure was reported as `negative`.** When a request never reached the target (`status=None`) the computed-value oracle fell through to `negative`, so a connectivity/TLS problem read as "not vulnerable" — the most dangerous mislabel for a detection tool. Adds an `error` verdict that every method returns on `status=None`, counts it separately, and prints a distinct hint (add `--insecure` for self-signed certs) instead of the "target may be patched" line.

## Changes
- `rcekit.py`: `--insecure` flag + `_verify_ssl_context()`; `error` verdict in `_confirm_computed`, `FileBased.confirm`, `ParametricTime.confirm_series`; delivery-error reporting in the detection summary.
- `tests/test_generator.py`: opt-in TLS context, and the `error` verdict across reflected/file/time.
- `README.md`: `--insecure` documented, `error` verdict explained, version badge.

## Versioning
`__version__` and README badge bumped **2.16.0 → 2.17.0** (MINOR, new `--insecure` feature).

## Testing
`python -m unittest discover -s tests` → 130 passed. Both features validated end-to-end against a self-signed HTTPS whole-command sink: `error` verdicts without `--insecure`, `confirmed` with it.