### PR TITLE
fix: strip trailing newline from a captured request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.17.0** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.17.1** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.17.0"
+__version__ = "2.17.1"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -2488,6 +2488,12 @@ def parse_raw_request(text: str) -> Dict[str, Any]:
     ``host`` (from the Host header)."""
     text = text.replace("\r\n", "\n").replace("\r", "\n")
     head, _, body = text.partition("\n\n")
+    # A raw request saved to a file (an editor or a heredoc) almost always gains a
+    # trailing newline, which partition() leaves on the body — silently corrupting
+    # the last body parameter: `...&new2=test2\n` makes new2 != test2 and can break
+    # the submission. HTTP bodies never require a trailing newline, so drop any;
+    # internal newlines (multi-line / multipart bodies) are left untouched.
+    body = body.rstrip("\n")
     lines = head.split("\n")
     while lines and not lines[0].strip():
         lines.pop(0)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1765,6 +1765,19 @@ class RawRequestInputTestCase(unittest.TestCase):
         self.assertEqual(req["body"], '{"a":1}')
         self.assertIn(["Content-Type", "application/json"], req["headers"])
 
+    def test_trailing_newline_in_body_does_not_corrupt_last_param(self):
+        # A request saved to a file (editor/heredoc) gains a trailing newline;
+        # it must not attach to the last body parameter's value — that made
+        # e.g. new2 = "test2\n" != new1 and broke form submissions.
+        raw = ("POST /f HTTP/1.1\r\nHost: t.example\r\n"
+               "Content-Type: application/x-www-form-urlencoded\r\n\r\nnew1=t&new2=t\n")
+        self.assertEqual(parse_raw_request(raw)["body"], "new1=t&new2=t")
+        _, _, data, _, _ = build_request_inputs(raw, param="new2")
+        self.assertEqual(data, "new1=t&new2=FUZZ")
+        # Every trailing newline is dropped; internal newlines are preserved.
+        multi = "POST /a HTTP/1.1\r\nHost: t.example\r\n\r\nline1\nline2\n\n\n"
+        self.assertEqual(parse_raw_request(multi)["body"], "line1\nline2")
+
     def test_query_param_marker_preserves_other_params(self):
         raw = "GET /lookup?host=example.com&x=1 HTTP/1.1\r\nHost: t.example\r\n\r\n"
         url, method, data, headers, injection = build_request_inputs(raw, param="host")


### PR DESCRIPTION
## Problem

A raw HTTP request saved to a file (via an editor or a heredoc) almost always gains a trailing newline. `parse_raw_request` split headers from body on the blank line and kept everything after it verbatim, so that trailing newline became part of the **last body parameter's value**:

```
user=rootxx&...&new1=t&new2=t\n   →   new2 = "t\n"  !=  new1 = "t"
```

For a form submission whose logic compares fields (or is otherwise whitespace-sensitive) this silently changes behaviour — it sent the wrong body and made a real, exploitable target look non-vulnerable during testing.

## Fix

Drop any trailing newline(s) from the parsed body in `parse_raw_request`. HTTP bodies never require a trailing newline, so this is safe; internal newlines (multi-line / multipart bodies) are left untouched.

## Behaviour change

The bytes sent for a `-r` request whose file ended in a newline change: the last parameter no longer carries a stray `\n`. This is the intended, correct behaviour — flagged as a **PATCH** bump (`2.17.0 -> 2.17.1`, README badge synced).

## Tests

Added a test covering a single trailing newline (form body + clean last-param injection) and multiple trailing newlines with internal newlines preserved. Full suite: `python -m unittest discover -s tests` -> 131 passed.