### PR TITLE
docs: note the -p alternative to a FUZZ marker in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ git clone https://github.com/kabiri-labs/rcekit.git
 cd rcekit                    # Python 3.8+, standard library only — nothing to install
 ```
 
-Put a `FUZZ` marker where your input lands, and ask RCEKit to prove RCE:
+Put a `FUZZ` marker where your input lands (or select a parameter with `-p` when
+using a captured request — see [`-r`](#point-at-a-captured-request--r) below), and
+ask RCEKit to prove RCE:
 
 ```bash
 python rcekit.py --acknowledge-consent \


### PR DESCRIPTION
## Summary

The quick-start line read as if a literal `FUZZ` marker is the only way to mark the injection point. For a captured request (`-r`) the idiomatic route is `-p NAME`, which places the marker at that parameter for you (`build_request_inputs` precedence: inline `FUZZ` -> inline `*` -> `-p NAME`). Someone reading the quick start and then using `-p` could think the two are inconsistent.

## Change
- **README.md** — add a half-sentence to the quick-start line pointing to the `-r` section and the `-p` option. Wording only; no behaviour change, no version bump.

Both entry points were already documented in the `Point at a captured request (-r)` section; this just cross-references them from the quick start.