### PR TITLE
fix: reflection false positive, error exit codes, DNS listener robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.17.1** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.17.2** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.17.1"
+__version__ = "2.17.2"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -1602,10 +1602,16 @@ class RCEKit:
             # execution, and _evaluate_verify downgrades it to inconclusive. Only
             # done when the primary actually matched, so it costs nothing on the
             # vast majority of payloads.
+            #
+            # The gate must use the SAME encoded-aware search the verdict uses:
+            # with a plain re.search here, a target that wraps its output (base64,
+            # hex, url, html) skipped the control entirely while _evaluate_verify
+            # still matched through the wrapper — so pure reflection was reported
+            # as 'confirmed', precisely in the case _encoded_search exists for.
             reflection_control = control_body
             if (record.token and record.match and not is_timing
                     and record.expected_channel != "interactsh"
-                    and status is not None and re.search(record.match, body)):
+                    and status is not None and self._encoded_search(record.match, body)):
                 _, reflection_control, _ = fire(f"rcekit-control-{record.token}")
             verdict, detail = self._evaluate_verify(
                 record, status, body, elapsed, baseline, margin, reflection_control, elapsed_confirm)
@@ -1902,9 +1908,32 @@ class OOBListener:
                  answer_ip: str = "127.0.0.1", log_path: Optional[str] = None):
         self.tokens = tokens or {}
         self.answer_ip = answer_ip
+        # Pack the A-record answer once, at construction: an unusable address is
+        # then rejected before the listener claims to be up, instead of raising
+        # inside the DNS thread on the first query and killing it.
+        self._answer_rdata = self._pack_ipv4(answer_ip)
         self.log_path = log_path
         self.hits: List[Dict[str, Any]] = []
         self._servers: List[Any] = []
+
+    @staticmethod
+    def _pack_ipv4(address: str) -> bytes:
+        """Pack a dotted-quad IPv4 address into a DNS A record's four rdata
+        bytes. Raises ``ValueError`` on anything else so the caller can reject
+        the address at startup."""
+        invalid = ValueError(
+            f"invalid IPv4 address for DNS answers: {address!r} "
+            "(expected a dotted quad such as 127.0.0.1)")
+        octets = address.split(".")
+        if len(octets) != 4:
+            raise invalid
+        # isascii() guards against non-ASCII digits, which int() would accept.
+        if not all(o.isascii() and o.isdigit() for o in octets):
+            raise invalid
+        values = [int(o) for o in octets]
+        if any(o > 255 for o in values):
+            raise invalid
+        return bytes(values)
 
     def _correlate(self, host: str, path: str):
         hay = f"{host} {path}".lower()
@@ -1980,8 +2009,8 @@ class OOBListener:
             i += 1 + query[i]
         i += 1 + 4  # null byte + qtype + qclass
         question = query[12:i]
-        rdata = bytes(int(o) for o in self.answer_ip.split("."))
-        answer = b"\xc0\x0c" + b"\x00\x01" + b"\x00\x01" + b"\x00\x00\x00\x1e" + b"\x00\x04" + rdata
+        answer = (b"\xc0\x0c" + b"\x00\x01" + b"\x00\x01" + b"\x00\x00\x00\x1e"
+                  + b"\x00\x04" + self._answer_rdata)
         return header + question + answer
 
     def start_dns(self, port: int) -> bool:
@@ -2002,12 +2031,21 @@ class OOBListener:
                     data, addr = sock.recvfrom(512)
                 except OSError:
                     break
-                name = self._parse_dns_qname(data)
+                # Record the callback BEFORE answering: the hit is the signal
+                # this listener exists for, so a query we cannot synthesise a
+                # reply to must still be reported rather than lost. Likewise,
+                # no single malformed query may kill the thread and silently
+                # drop every callback that follows.
+                try:
+                    name = self._parse_dns_qname(data)
+                except Exception as exc:
+                    logger.warning("Unparsable DNS query from %s: %s", addr[0], exc)
+                    continue
+                self.record("dns", addr[0], name)
                 try:
                     sock.sendto(self._dns_response(data), addr)
-                except OSError:
-                    pass
-                self.record("dns", addr[0], name)
+                except Exception as exc:
+                    logger.warning("DNS answer for %r not sent: %s", name, exc)
 
         threading.Thread(target=loop, daemon=True).start()
         return True
@@ -2655,6 +2693,12 @@ def load_token_manifest(path: str) -> Dict[str, Dict[str, Any]]:
 
 
 def main():
+    """CLI entry point. Returns the process exit status: ``0`` when the
+    requested run completed (including a verification that confirmed nothing —
+    that is a result, not a failure) and ``1`` when RCEKit could not carry the
+    run out at all: unusable corpus or profile, missing consent, an unreadable
+    or unmarked request, or an invalid option combination. Scripts and CI can
+    therefore branch on the status instead of scraping stdout."""
     parser = argparse.ArgumentParser(description="Generate RCE payloads for penetration testing")
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     parser.add_argument("-o", "--output", default="rce_payloads.txt",
@@ -2798,7 +2842,12 @@ def main():
     if args.listen:
         import time
         tokens = load_token_manifest(args.correlate) if args.correlate else {}
-        listener = OOBListener(tokens=tokens, answer_ip=args.listen_answer_ip, log_path=args.listen_log)
+        try:
+            listener = OOBListener(tokens=tokens, answer_ip=args.listen_answer_ip,
+                                   log_path=args.listen_log)
+        except ValueError as exc:
+            print(f"[!] {exc}")
+            return 1
         listener.start_http(args.listen_http_port)
         dns_ok = listener.start_dns(args.listen_dns_port)
         print(f"[listen] OOB listener up — HTTP :{args.listen_http_port}"
@@ -2827,7 +2876,7 @@ def main():
                 profile = json.load(profile_file)
         except Exception as exc:
             print(f"[!] Unable to load target profile {args.target_profile}: {exc}")
-            return
+            return 1
         logger.info("Loaded target profile '%s' from %s", profile.get("name", "?"), args.target_profile)
 
     def from_profile(cli_value, key):
@@ -2887,7 +2936,7 @@ def main():
 
     if mode == "exploit" and not args.acknowledge_consent:
         print("[!] Exploitation mode requires explicit consent. Re-run with --acknowledge-consent after confirming authorization.")
-        return
+        return 1
 
     watermark_token = None
     if mode == "exploit":
@@ -2915,7 +2964,7 @@ def main():
         if not args.acknowledge_consent:
             print("[!] --verify-chain actively sends payloads to the target. Re-run with "
                   "--acknowledge-consent to confirm you are authorised to test it.")
-            return
+            return 1
         with open(args.verify_chain, "r", encoding="utf-8") as chain_file:
             chain = json.load(chain_file)
         verify_max_safety = args.verify_active_risk or "safe"
@@ -2951,7 +3000,7 @@ def main():
         if not args.acknowledge_consent:
             print("[!] Verification actively sends payloads to the target. Re-run with "
                   "--acknowledge-consent to confirm you are authorised to test it.")
-            return
+            return 1
         # Source the request from a raw capture (-r) or the --verify-* flags.
         if args.request_file:
             try:
@@ -2959,18 +3008,18 @@ def main():
                     raw_request = request_fh.read()
             except OSError as exc:
                 print(f"[!] Unable to read --request-file {args.request_file}: {exc}")
-                return
+                return 1
             params = args.param or []
             if len(params) > 1:
                 print("[!] -r supports a single injection point in this release; pass one -p "
                       "(or a FUZZ/* marker). --all-params enumeration is not yet available.")
-                return
+                return 1
             try:
                 verify_url, method, verify_data, verify_headers, injection = build_request_inputs(
                     raw_request, param=(params[0] if params else None), scheme=args.request_scheme)
             except ValueError as exc:
                 print(f"[!] Could not build a request from {args.request_file}: {exc}")
-                return
+                return 1
             method = args.verify_method or method
             print(f"[verify] loaded request from {args.request_file}: {method} {verify_url} "
                   f"(injecting at {injection})")
@@ -2982,7 +3031,7 @@ def main():
                     and not any("FUZZ" in h for h in (verify_headers or [])):
                 print("[!] No FUZZ marker found in --verify-url/--verify-data/--verify-header; "
                       "add FUZZ where the payload should be injected.")
-                return
+                return 1
             method = args.verify_method or ("POST" if verify_data else "GET")
         verify_token = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8))
         generator.log_exploitation_usage(f"VERIFY:{verify_token} url={verify_url}", args)
@@ -3041,7 +3090,7 @@ def main():
             if unknown:
                 print(f"[!] Unknown --methods: {', '.join(unknown)}. "
                       f"Available: {', '.join(sorted(DETECTION_METHODS))}.")
-                return
+                return 1
             detection_config = {"webroot": args.webroot, "web_base_url": args.web_base_url,
                                 "time_base": args.time_base, "evade": args.evade,
                                 "sink_raw": sink_raw}
@@ -3049,7 +3098,7 @@ def main():
                 if not (args.webroot and args.web_base_url):
                     print("[!] --methods file writes a file to the target and fetches it back, so it "
                           "needs both --webroot (server-side write dir) and --web-base-url (fetch base).")
-                    return
+                    return 1
                 print(f"[detect] file-based method WRITES to {args.webroot} on the target and fetches via "
                       f"{args.web_base_url}; each confirmed finding lists a cleanup command.")
             results = generator.run_detection(

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -206,6 +206,54 @@ class OOBListenerTestCase(unittest.TestCase):
             server.shutdown()
             server.server_close()
 
+    def test_invalid_answer_ip_is_rejected_at_construction(self):
+        # An unusable answer IP used to raise inside the DNS thread on the first
+        # query, killing it and silently dropping every callback that followed —
+        # a false negative for the tool's whole OOB confirmation channel.
+        for bad in ("bogus-ip", "999.1.1.1", "1.2.3", "1.2.3.4.5", "", "::1"):
+            with self.subTest(answer_ip=bad):
+                with self.assertRaises(ValueError):
+                    OOBListener(answer_ip=bad)
+
+    def test_valid_answer_ip_is_packed_into_the_answer(self):
+        listener = OOBListener(tokens=self.tokens, answer_ip="10.11.12.13")
+        query = (b"\x12\x34" + b"\x01\x00" + b"\x00\x01" + b"\x00\x00" * 3
+                 + b"\x03abc\x04test\x00" + b"\x00\x01\x00\x01")
+        self.assertTrue(listener._dns_response(query).endswith(bytes([10, 11, 12, 13])))
+
+    def test_callback_is_recorded_even_when_the_answer_fails(self):
+        # The hit is the signal this listener exists for, so a query we cannot
+        # answer must still be reported, and must not take the thread down with
+        # it. Forcing the response to fail proves both.
+        import socket
+        import time
+
+        def explode(_data):
+            raise RuntimeError("synthetic response failure")
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+        sock.close()
+
+        listener = OOBListener(tokens=self.tokens)
+        listener._dns_response = explode
+        self.assertTrue(listener.start_dns(port))
+
+        client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            query = (b"\x12\x34" + b"\x01\x00" + b"\x00\x01" + b"\x00\x00" * 3
+                     + b"\x0babc123token\x03oob\x04test\x00" + b"\x00\x01\x00\x01")
+            for _ in range(2):
+                client.sendto(query, ("127.0.0.1", port))
+                time.sleep(0.3)
+        finally:
+            client.close()
+
+        # Both callbacks recorded: the first did not kill the listening thread.
+        correlated = [h for h in listener.hits if h["token"] == "abc123token"]
+        self.assertEqual(len(correlated), 2, listener.hits)
+
 
 class GeneratorTestCase(unittest.TestCase):
     def setUp(self):
@@ -2330,6 +2378,108 @@ class DetectionRobustnessTestCase(unittest.TestCase):
                              "random latency must never be confirmed")
             self.assertTrue(all(r["verdict"] == "negative" for r in results),
                             "a non-linear latency response is negative, not even a candidate")
+
+
+class ReflectionControlTestCase(unittest.TestCase):
+    """The paired same-token control decides reflection from execution, so it
+    must fire whenever the verdict's own encoded-aware search matched. Gating it
+    on a plain regex let a target that wraps its output (base64/hex/url/html)
+    skip the control entirely and be reported 'confirmed' on pure reflection —
+    exactly the case _encoded_search exists for."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.token = "AB12CD"
+        self.record = make_record(
+            payload="; echo " + self.token, mode="detection", category="detection",
+            safety="safe", token=self.token, match=re.escape(self.token))
+
+    def test_encoded_reflection_is_inconclusive_not_confirmed(self):
+        import base64
+
+        def route(method, path, params, headers, body):
+            # Echoes the parameter back, base64-wrapped. Nothing is ever executed.
+            return 200, base64.b64encode(("you sent " + params.get("q", "")).encode()).decode()
+
+        with local_target(route) as base:
+            results = self.gen.run_verification([self.record], url=f"{base}/echo?q=FUZZ")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["verdict"], "inconclusive", results[0])
+
+    def test_genuine_execution_still_confirms_through_an_encoded_wrapper(self):
+        import base64
+
+        def route(method, path, params, headers, body):
+            # Stands in for a real sink: only a command break-out yields output,
+            # so the inert same-token control comes back empty-handed.
+            query = params.get("q", "")
+            echoed = query.split("echo ", 1)[1] if query.startswith("; echo ") else ""
+            out = f"command output follows: {echoed}" if echoed else "nothing executed here"
+            return 200, base64.b64encode(out.encode()).decode()
+
+        with local_target(route) as base:
+            results = self.gen.run_verification([self.record], url=f"{base}/sink?q=FUZZ")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["verdict"], "confirmed", results[0])
+
+
+class CLIExitCodeTestCase(unittest.TestCase):
+    """Every refusal to run must exit non-zero so CI and wrapper scripts can
+    branch on the status instead of scraping stdout. A completed run exits 0
+    even when it confirmed nothing — that is a result, not a failure."""
+
+    def _run(self, *args):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120,
+        )
+
+    def test_missing_consent_exits_non_zero(self):
+        result = self._run("--categories", "basic_enum", "--environments", "unix")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("consent", result.stdout.lower())
+
+    def test_unloadable_target_profile_exits_non_zero(self):
+        result = self._run("--acknowledge-consent", "--target-profile", "/no/such/profile.json")
+        self.assertEqual(result.returncode, 1)
+
+    def test_verify_without_fuzz_marker_exits_non_zero(self):
+        result = self._run("--acknowledge-consent", "--verify-url", "http://127.0.0.1:1/nomarker")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("FUZZ", result.stdout)
+
+    def test_unknown_detection_method_exits_non_zero(self):
+        result = self._run("--acknowledge-consent", "--categories", "basic_enum",
+                           "--environments", "unix", "--max-payloads", "1",
+                           "--methods", "nosuchmethod",
+                           "--verify-url", "http://127.0.0.1:1/?q=FUZZ")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Unknown --methods", result.stdout)
+
+    def test_file_method_without_webroot_exits_non_zero(self):
+        result = self._run("--acknowledge-consent", "--categories", "basic_enum",
+                           "--environments", "unix", "--max-payloads", "1",
+                           "--methods", "file",
+                           "--verify-url", "http://127.0.0.1:1/?q=FUZZ")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("--webroot", result.stdout)
+
+    def test_unreadable_request_file_exits_non_zero(self):
+        result = self._run("--acknowledge-consent", "-r", "/no/such/request.txt")
+        self.assertEqual(result.returncode, 1)
+
+    def test_request_file_without_injection_point_exits_non_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            req = Path(tmp) / "req.txt"
+            req.write_text("GET /a=1 HTTP/1.1\nHost: target.example\n\n")
+            result = self._run("--acknowledge-consent", "-r", str(req))
+            self.assertEqual(result.returncode, 1)
+
+    def test_completed_generation_exits_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "d.txt"
+            result = self._run("--detection-only", "--environments", "unix", "-o", str(out))
+            self.assertEqual(result.returncode, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Three defects found while reviewing the verification and OOB paths. Version bumped to 2.17.2 (patch), README badge kept in sync.

## 1. Pure reflection reported as confirmed execution

`run_verification` gated the paired same-token control on a plain `re.search`, while the verdict in `_evaluate_verify` uses `_encoded_search`. A target that merely echoes input but wraps its output — base64, hex, url, html — therefore skipped the control re-fire entirely and came back `confirmed`. That is reflection presented as proof of execution, in precisely the case `_encoded_search` was added for.

Reproduction against a target that echoes its input base64-wrapped and executes nothing:

```
plain re.search finds token?  False   <- control re-fire skipped
_encoded_search finds token?  True    <- verdict issued anyway
verdict -> confirmed
```

The gate now uses the same encoded-aware search as the verdict, so this case is correctly reported `inconclusive`.

## 2. Every error path exited 0

`main()` is wired to `sys.exit(main())`, but ten refusal paths returned `None`. A missing FUZZ marker, an unloadable target profile, absent consent, an unreadable request file, an unknown `--methods` value and an incomplete `--methods file` invocation all exited 0, so CI and wrapper scripts read them as passing runs. `--doctor` and the corpus check already returned 1, so the contract was inconsistent with itself.

Those paths now return 1, and `main()` documents the contract: 0 for a completed run — including one that confirmed nothing, which is a result rather than a failure — and 1 when the run could not be carried out at all.

## 3. DNS listener died silently on an invalid answer IP

`--listen-answer-ip` was never validated. A non-dotted-quad value made `bytes(int(o) for o in ...)` raise `ValueError` inside the DNS thread on the first query; the surrounding handler only caught `OSError`, so the exception escaped the loop and killed the thread. The CLI had already printed that the listener was up, and every subsequent callback was lost with no indication. For a tool whose OOB confirmation channel is the product, that is a silent false negative:

```
dns started: True     <- CLI reports "DNS :5335" up
hits recorded: 0      <- no callback ever recorded
live threads: []      <- thread dead after the first query
```

The address is now packed once at construction, so an unusable value is rejected before the listener claims to be running. Two further hardening changes in the same loop: hits are recorded before the answer is sent, since the callback is the signal and the reply is not, and a failed response is logged instead of taking the thread down.

## Tests

13 new tests across `ReflectionControlTestCase`, `CLIExitCodeTestCase` and `OOBListenerTestCase`; suite goes from 131 to 144, all green with no external dependencies. Each new test was checked against the unfixed code and confirmed to fail there — reverting fix 1 fails 1 of 2, fix 2 fails 2 of 8, fix 3 fails 8 of 8.

No behaviour change for valid input: previously working invocations keep their exit status, and a valid `--listen-answer-ip` is unaffected.
