### PR TITLE
fix: chain safety parity, cleartext warning, write failures, audit redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.17.2** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.18.0** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed
@@ -177,8 +177,12 @@ python rcekit.py --acknowledge-consent -r request.txt -p host --methods reflecte
 
 Mark the point inline with `FUZZ` or `*`, or select a parameter with `-p NAME`
 (searched query → body → header → cookie). Each injection point is still encoded
-for its own context. Scheme is inferred (`https` on `:443`, else `http`;
-`--request-scheme` to override) and `Host`/`Content-Length` are recomputed.
+for its own context. Scheme is inferred (`https` on `:443`, else `http` — a
+portless capture cannot say which, and `http` keeps lab and internal targets
+reachable); the inferred scheme is printed, and a capture carrying an
+`Authorization` or `Cookie` header over plain `http` is flagged so you can
+pass `--request-scheme https` (add `--insecure` for a self-signed cert).
+`Host`/`Content-Length` are recomputed.
 
 ### Blind and no-egress targets
 

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.17.2"
+__version__ = "2.18.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -1070,8 +1070,12 @@ class RCEKit:
                 logger.info("Metadata sidecar written to %s", metadata_path)
             if manifest:
                 logger.info("Correlation map (token -> payload) written to %s", map_path)
-        except Exception as e:
-            logger.error(f"Error writing to file {output_path}: {e}")
+        except Exception as exc:
+            # Never report a partial or absent wordlist as a successful run: the
+            # file IS the deliverable, so a write failure has to reach the
+            # caller and the process exit status, not just the log.
+            logger.error("Error writing to file %s: %s", output_path, exc)
+            raise
 
         return count
 
@@ -1158,6 +1162,7 @@ class RCEKit:
                         outdir, count, len(groups), hint)
         except Exception as exc:
             logger.error("Error writing Burp output to %s: %s", outdir, exc)
+            raise
         return count
 
     def _write_ffuf(self, output_path: Path, records: Iterator[PayloadRecord], max_payloads: Optional[int],
@@ -1203,6 +1208,7 @@ class RCEKit:
                     "so only wordlists were written to %s/.", outdir)
         except Exception as exc:
             logger.error("Error writing ffuf output to %s: %s", outdir, exc)
+            raise
         return count
 
     def _write_nuclei(self, output_path: Path, records: Iterator[PayloadRecord], max_payloads: Optional[int],
@@ -1263,6 +1269,7 @@ class RCEKit:
             logger.info("Nuclei templates written to %s/ (%s templates, %s payloads)", outdir, len(groups), count)
         except Exception as exc:
             logger.error("Error writing Nuclei output to %s: %s", outdir, exc)
+            raise
         return count
 
     def _nuclei_template(self, env: str, oracle: str, payloads: List[str], canary: str,
@@ -1882,13 +1889,42 @@ class RCEKit:
                     result["detail"] = f"no callback received for token {result['token']}"
         return results
 
+    # Headers whose value is a credential rather than a detail worth auditing.
+    # The audit trail records that a header was sent, never its secret.
+    SENSITIVE_HEADERS = {
+        "authorization", "proxy-authorization", "authentication",
+        "cookie", "set-cookie", "x-api-key", "api-key",
+        "x-auth-token", "auth-token", "x-csrf-token", "x-session-token",
+    }
+
+    @classmethod
+    def redact_headers(cls, headers: Optional[List[str]]) -> Optional[List[str]]:
+        """Mask the value of every credential-bearing header, keeping its name.
+
+        Verification headers routinely carry the session that makes the target
+        reachable at all -- a bearer token or an authenticated cookie. Those
+        must not be persisted: the audit trail exists to record what was fired
+        and by whom, and a header's name carries that; its secret does not."""
+        if not headers:
+            return headers
+        masked: List[str] = []
+        for header in headers:
+            name, sep, _value = header.partition(":")
+            if sep and name.strip().lower() in cls.SENSITIVE_HEADERS:
+                masked.append(f"{name.strip()}: <redacted>")
+            else:
+                masked.append(header)
+        return masked
+
     def log_exploitation_usage(self, watermark_token: str, arguments: argparse.Namespace) -> None:
         audit_path = Path("exploit_audit.log")
         try:
+            recorded = dict(vars(arguments))
+            recorded["verify_header"] = self.redact_headers(recorded.get("verify_header"))
             with audit_path.open("a", encoding="utf-8") as audit_file:
                 timestamp = datetime.now(timezone.utc).isoformat()
                 audit_file.write(
-                    f"{timestamp} | token={watermark_token} | ip={self.attacker_ip} | domain={self.attacker_domain} | args={vars(arguments)}\n"
+                    f"{timestamp} | token={watermark_token} | ip={self.attacker_ip} | domain={self.attacker_domain} | args={recorded}\n"
                 )
         except Exception as exc:
             logger.error("Unable to log exploitation usage: %s", exc)
@@ -2463,6 +2499,27 @@ HIGH_RISK_CATEGORIES = {
 }
 
 
+def partition_destructive(records: Iterator[PayloadRecord],
+                          allow_destructive: bool) -> Tuple[List[PayloadRecord], int]:
+    """Materialise ``records``, holding back the ones that alter or damage the
+    target -- persistence, backdoors, security-control tampering, irreversible
+    file operations -- unless the operator opted in. Returns ``(to_send,
+    held_back)``.
+
+    Both live paths go through this. The single-request verifier held these
+    back while the multi-step chain did not, so a payload the one refused to
+    fire the other would install; the safety of a run must not depend on which
+    delivery path it took."""
+    to_send: List[PayloadRecord] = []
+    held_back = 0
+    for record in records:
+        if record.destructive and not allow_destructive:
+            held_back += 1
+            continue
+        to_send.append(record)
+    return to_send, held_back
+
+
 def build_verification_plan(records: List[PayloadRecord], method: str, url: str,
                             attacker_ip: Optional[str] = None,
                             attacker_domain: Optional[str] = None,
@@ -2636,6 +2693,26 @@ def _place_param_marker(target, headers, body, param, mark):
     raise ValueError(f"parameter '{param}' not found in query, body, headers, or cookies")
 
 
+def _infer_request_scheme(host: str) -> str:
+    """Pick the scheme for a raw request whose capture does not record one.
+
+    A ``Host`` header carries a port only when it is not the scheme's default,
+    so a portless capture is 80 or 443 and cannot say which. RCEKit keeps http
+    for that case, deliberately: its targets are lab ranges, CTF boxes and
+    internal applications, which are routinely plain http on a portless host,
+    and defaulting to https would leave those unreachable out of the box.
+
+    That default can send a captured session in cleartext, so the risk is
+    surfaced rather than silently defaulted away: the CLI reports the inferred
+    scheme, and warns outright when the request carries a credential header
+    that plain http would expose. ``--request-scheme`` settles it either way,
+    and an explicit port is authoritative."""
+    _, _, port = host.rpartition(":")
+    if not port.isdigit():
+        return "http"           # no port recorded; http keeps lab targets reachable
+    return "https" if port == "443" else "http"
+
+
 def build_request_inputs(text: str, param: Optional[str] = None,
                          scheme: Optional[str] = None, mark: str = "FUZZ"
                          ) -> Tuple[str, str, Optional[str], List[str], str]:
@@ -2665,7 +2742,7 @@ def build_request_inputs(text: str, param: Optional[str] = None,
         raise ValueError("no injection point: add a FUZZ or * marker, or pass -p NAME")
 
     if scheme is None:
-        scheme = "https" if host.endswith(":443") else "http"
+        scheme = _infer_request_scheme(host)
     url = f"{scheme}://{host}{target}"
     # Drop Host and Content-Length: urllib recomputes both from the URL and the
     # (marker-lengthened) body.
@@ -2767,7 +2844,9 @@ def main():
                              "enumeration is planned.")
     parser.add_argument("--request-scheme", choices=["http", "https"], default=None,
                         help="Scheme for the URL built from -r (default: https when the Host is on :443, "
-                             "otherwise http).")
+                             "otherwise http — a portless capture cannot record which, and http keeps "
+                             "lab and internal targets reachable). The inferred scheme is printed, and "
+                             "a request carrying credential headers over plain http is flagged.")
     parser.add_argument("--webroot", default=None,
                         help="(file-based detection) server-side directory the target can write to and "
                              "serve, e.g. /var/www/html. Required with --methods file.")
@@ -2974,9 +3053,29 @@ def main():
             mode=mode, watermark_token=watermark_token, max_safety=verify_max_safety,
             include_blocking=include_blocking, oob_domain=oob_domain,
         )
-        records = list(records)
+        # The chain delivers to a live target exactly as --verify-url does, so
+        # it goes through the same sink-shape filters, the same destructive
+        # hold-back and the same pre-flight plan. Anything less would make the
+        # blast radius of a run depend on which delivery path it took.
+        if deny_chars or max_length or needs_separator or blind:
+            records = generator._filter_by_profile(
+                records, deny_chars, max_length, needs_separator, blind)
+        records, skipped_destructive = partition_destructive(
+            records, args.verify_allow_destructive)
         verify_token = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8))
         generator.log_exploitation_usage(f"VERIFY-CHAIN:{verify_token} base={chain.get('base')}", args)
+        plan_lines, records = build_verification_plan(
+            records, "chain", chain.get("base", "?"),
+            attacker_ip=generator.attacker_ip, attacker_domain=generator.attacker_domain,
+            max_payloads=args.max_payloads)
+        for line in plan_lines:
+            print(line)
+        if skipped_destructive:
+            print(f"[plan] holding back {skipped_destructive} destructive payloads "
+                  "(persistence/backdoors/etc.); pass --verify-allow-destructive to include them.")
+        if verify_max_safety == "safe":
+            print("[plan] low-impact (safe) payloads only; pass --verify-active-risk intrusive to also "
+                  "fire reverse shells, download-execute, credential access, lateral movement and OOB.")
         print(f"[verify-chain] {chain.get('base')}  ({len(chain.get('steps', []))} steps, "
               f"{len(records)} payloads)  (authorised target)")
         results = generator.run_verification_chain(
@@ -3023,6 +3122,21 @@ def main():
             method = args.verify_method or method
             print(f"[verify] loaded request from {args.request_file}: {method} {verify_url} "
                   f"(injecting at {injection})")
+            if args.request_scheme is None:
+                resolved_scheme = verify_url.split("://", 1)[0]
+                print(f"[verify] the capture records no scheme; inferred {resolved_scheme} "
+                      "from the Host header — override with --request-scheme.")
+                # A capture replayed over plain http puts whatever session it
+                # carries on the wire. That is fine against a lab target and a
+                # leak against a real one, and only the operator knows which,
+                # so name the headers at risk instead of guessing for them.
+                exposed = [name for name in
+                           (h.partition(":")[0].strip() for h in verify_headers)
+                           if name.lower() in RCEKit.SENSITIVE_HEADERS]
+                if resolved_scheme == "http" and exposed:
+                    print(f"[!] This request carries {', '.join(sorted(set(exposed)))} and will be "
+                          "replayed over plain HTTP. If the target is HTTPS, pass --request-scheme "
+                          "https (with --insecure for a self-signed or mismatched certificate).")
         else:
             verify_url = args.verify_url
             verify_data = args.verify_data
@@ -3049,33 +3163,23 @@ def main():
         )
         if deny_chars or max_length or needs_separator or blind:
             records = generator._filter_by_profile(records, deny_chars, max_length, needs_separator, blind)
-        skipped_destructive = [0]
-        if not args.verify_allow_destructive:
-            # Never install backdoors / tamper with a live target unless asked.
-            def _drop_destructive(source):
-                for record in source:
-                    if record.destructive:
-                        skipped_destructive[0] += 1
-                        continue
-                    yield record
-
-            records = _drop_destructive(records)
+        # Never install backdoors / tamper with a live target unless asked.
+        records, skipped_destructive = partition_destructive(
+            records, args.verify_allow_destructive)
         # When capping, interleave so --max-payloads fires a balanced sample
         # across categories/environments instead of exhausting the first bucket.
         if args.max_payloads:
-            records = generator._interleave(
-                records, key=lambda r: (r.category, r.environment, r.sink))
-        # Materialise (this also tallies the destructive skips) and show an
-        # execution plan before anything is fired.
-        records = list(records)
+            records = list(generator._interleave(
+                records, key=lambda r: (r.category, r.environment, r.sink)))
+        # Show an execution plan before anything is fired.
         plan_lines, to_send = build_verification_plan(
             records, method, verify_url,
             attacker_ip=generator.attacker_ip, attacker_domain=generator.attacker_domain,
             max_payloads=args.max_payloads)
         for line in plan_lines:
             print(line)
-        if skipped_destructive[0]:
-            print(f"[plan] holding back {skipped_destructive[0]} destructive payloads "
+        if skipped_destructive:
+            print(f"[plan] holding back {skipped_destructive} destructive payloads "
                   "(persistence/backdoors/etc.); pass --verify-allow-destructive to include them.")
         if verify_max_safety == "safe":
             print("[plan] low-impact (safe) payloads only; pass --verify-active-risk intrusive to also "
@@ -3187,26 +3291,30 @@ def main():
                 "self-contained shell payload."
             )
 
-    count = generator.save_payloads_to_file(
-        file_path=args.output,
-        max_payloads=args.max_payloads,
-        output_format=args.output_format,
-        include_metadata=args.include_metadata or args.output_format == "jsonl",
-        deny_chars=deny_chars,
-        max_length=max_length,
-        needs_separator=needs_separator,
-        blind=blind,
-        request_template=request_template,
-        selected_contexts=selected_contexts,
-        selected_categories=selected_categories,
-        selected_encodings=selected_encodings,
-        selected_environments=selected_environments,
-        mode=mode,
-        watermark_token=watermark_token,
-        max_safety=max_safety,
-        include_blocking=include_blocking,
-        oob_domain=oob_domain,
-    )
+    try:
+        count = generator.save_payloads_to_file(
+            file_path=args.output,
+            max_payloads=args.max_payloads,
+            output_format=args.output_format,
+            include_metadata=args.include_metadata or args.output_format == "jsonl",
+            deny_chars=deny_chars,
+            max_length=max_length,
+            needs_separator=needs_separator,
+            blind=blind,
+            request_template=request_template,
+            selected_contexts=selected_contexts,
+            selected_categories=selected_categories,
+            selected_encodings=selected_encodings,
+            selected_environments=selected_environments,
+            mode=mode,
+            watermark_token=watermark_token,
+            max_safety=max_safety,
+            include_blocking=include_blocking,
+            oob_domain=oob_domain,
+        )
+    except OSError as exc:
+        print(f"[!] Unable to write output to {args.output}: {exc}")
+        return 1
 
     print(f"Generated {count} payloads to {args.output} in {mode} mode")
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -32,6 +32,7 @@ from rcekit import (  # noqa: E402
     ReflectedMath,
     build_request_inputs,
     parse_raw_request,
+    partition_destructive,
 )
 
 
@@ -1873,6 +1874,29 @@ class RawRequestInputTestCase(unittest.TestCase):
         self.assertEqual(url, "http://t.example/q?a=FUZZ")
         self.assertEqual(injection, "inline marker")
 
+    def test_portless_host_stays_http_so_lab_targets_keep_working(self):
+        # Lab ranges, CTF boxes and internal apps are routinely plain http on a
+        # portless host. Defaulting those to https would leave the tool unable
+        # to reach its most common targets out of the box, so the default holds
+        # and the cleartext risk is surfaced by the CLI instead.
+        raw = ("GET /q?a=FUZZ HTTP/1.1\r\nHost: dvwa.local\r\n"
+               "Cookie: PHPSESSID=abc\r\n\r\n")
+        url, _, _, _, _ = build_request_inputs(raw)
+        self.assertTrue(url.startswith("http://"), url)
+
+    def test_explicit_port_decides_the_scheme(self):
+        for host, expected in (("t.example:443", "https"), ("t.example:80", "http"),
+                               ("t.example:8080", "http"), ("10.0.0.5:8000", "http")):
+            with self.subTest(host=host):
+                raw = f"GET /q?a=FUZZ HTTP/1.1\r\nHost: {host}\r\n\r\n"
+                url, _, _, _, _ = build_request_inputs(raw)
+                self.assertTrue(url.startswith(expected + "://"), url)
+
+    def test_request_scheme_override_wins_over_inference(self):
+        raw = "GET /q?a=FUZZ HTTP/1.1\r\nHost: t.example\r\n\r\n"
+        url, _, _, _, _ = build_request_inputs(raw, scheme="https")
+        self.assertTrue(url.startswith("https://"), url)
+
     def test_missing_marker_and_missing_param_raise(self):
         with self.assertRaises(ValueError):
             build_request_inputs("GET /q?a=1 HTTP/1.1\r\nHost: t.example\r\n\r\n")
@@ -2480,6 +2504,161 @@ class CLIExitCodeTestCase(unittest.TestCase):
             out = Path(tmp) / "d.txt"
             result = self._run("--detection-only", "--environments", "unix", "-o", str(out))
             self.assertEqual(result.returncode, 0)
+
+
+class DestructiveHoldBackTestCase(unittest.TestCase):
+    """A payload that installs a backdoor or destroys data must be held back by
+    default on EVERY live path. The single-request verifier did this and the
+    multi-step chain did not, so the blast radius of a run depended on which
+    delivery path it took."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+
+    def _records(self, max_safety):
+        return list(self.gen.generate_payload_records(
+            mode="exploit", max_safety=max_safety, include_blocking=False))
+
+    def test_destructive_payloads_are_held_back_by_default(self):
+        records = self._records("stateful")
+        destructive = [r for r in records if r.destructive]
+        self.assertTrue(destructive, "corpus should contain destructive payloads to exercise this")
+        to_send, held = partition_destructive(records, allow_destructive=False)
+        self.assertEqual(held, len(destructive))
+        self.assertFalse([r for r in to_send if r.destructive])
+
+    def test_opt_in_lets_them_through(self):
+        records = self._records("stateful")
+        to_send, held = partition_destructive(records, allow_destructive=True)
+        self.assertEqual(held, 0)
+        self.assertEqual(len(to_send), len(records))
+
+    def test_chain_run_holds_back_destructive_payloads(self):
+        # End-to-end through the CLI: the chain path must print the same
+        # pre-flight plan and hold-back notice as --verify-url. Raising the risk
+        # tier is what surfaces destructive payloads at all.
+        with local_target(lambda *a: (200, "ok")) as base, tempfile.TemporaryDirectory() as tmp:
+            chain = Path(tmp) / "chain.json"
+            chain.write_text(json.dumps({
+                "base": base,
+                "steps": [{"name": "deliver", "method": "POST", "path": "/run",
+                           "form": {"cmd": "FUZZ"}}],
+            }))
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--acknowledge-consent",
+                 "--categories", "file_operations", "--environments", "unix",
+                 "--verify-active-risk", "stateful", "--max-payloads", "3",
+                 "--verify-chain", str(chain)],
+                cwd=tmp, capture_output=True, text=True, timeout=120)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("[plan]", result.stdout)
+        self.assertIn("holding back", result.stdout)
+        self.assertIn("--verify-allow-destructive", result.stdout)
+
+
+class CleartextCaptureWarningTestCase(unittest.TestCase):
+    """A portless capture stays http so lab and internal targets keep working,
+    so the cleartext risk is surfaced instead of defaulted away: the inferred
+    scheme is always reported, and a captured session about to go out in the
+    clear is named."""
+
+    def _run_with_request(self, raw, *extra):
+        with tempfile.TemporaryDirectory() as tmp:
+            req = Path(tmp) / "req.txt"
+            req.write_text(raw)
+            return subprocess.run(
+                [sys.executable, str(SCRIPT), "--acknowledge-consent",
+                 "--categories", "basic_enum", "--environments", "unix",
+                 "--max-payloads", "1", "-r", str(req), *extra],
+                cwd=tmp, capture_output=True, text=True, timeout=120)
+
+    def test_credential_header_over_plain_http_is_flagged(self):
+        result = self._run_with_request(
+            "GET /q?a=FUZZ HTTP/1.1\r\nHost: 127.0.0.1:1\r\n"
+            "Authorization: Bearer secret\r\nCookie: session=abc\r\n\r\n")
+        self.assertIn("inferred http", result.stdout)
+        self.assertIn("replayed over plain HTTP", result.stdout)
+        self.assertIn("Authorization", result.stdout)
+        self.assertIn("Cookie", result.stdout)
+        self.assertIn("--request-scheme", result.stdout)
+        self.assertNotIn("secret", result.stdout)  # names the header, never its value
+
+    def test_no_warning_without_credential_headers(self):
+        result = self._run_with_request(
+            "GET /q?a=FUZZ HTTP/1.1\r\nHost: 127.0.0.1:1\r\nAccept: */*\r\n\r\n")
+        self.assertIn("inferred http", result.stdout)
+        self.assertNotIn("replayed over plain HTTP", result.stdout)
+
+    def test_no_warning_when_the_scheme_was_given_explicitly(self):
+        result = self._run_with_request(
+            "GET /q?a=FUZZ HTTP/1.1\r\nHost: 127.0.0.1:1\r\n"
+            "Authorization: Bearer secret\r\n\r\n",
+            "--request-scheme", "http")
+        self.assertNotIn("inferred http", result.stdout)
+        self.assertNotIn("replayed over plain HTTP", result.stdout)
+
+
+class OutputFailureTestCase(unittest.TestCase):
+    """The generated file IS the deliverable, so a write that failed must not be
+    reported as a successful run."""
+
+    def test_unwritable_output_path_exits_non_zero(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--detection-only", "--environments", "unix",
+             "-o", "/no/such/directory/out.txt"],
+            cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Unable to write output", result.stdout)
+        self.assertNotIn("Generated", result.stdout)
+
+    def test_write_failure_propagates_to_the_caller(self):
+        gen = RCEKit()
+        with self.assertRaises(OSError):
+            gen.save_payloads_to_file(
+                file_path="/no/such/directory/out.txt", mode="detection",
+                selected_environments=["unix"])
+
+
+class AuditRedactionTestCase(unittest.TestCase):
+    """The audit trail records what was fired and by whom. Verification headers
+    routinely carry the session that makes the target reachable at all, and a
+    credential must not be persisted to disk just to record that a header was
+    sent."""
+
+    def test_sensitive_header_values_are_masked(self):
+        masked = RCEKit.redact_headers([
+            "Authorization: Bearer SUPERSECRET",
+            "Cookie: session=SUPERSECRET",
+            "X-Api-Key: SUPERSECRET",
+            "Content-Type: application/json",
+        ])
+        self.assertEqual(masked[:3], ["Authorization: <redacted>",
+                                      "Cookie: <redacted>",
+                                      "X-Api-Key: <redacted>"])
+        self.assertEqual(masked[3], "Content-Type: application/json")
+
+    def test_header_names_survive_so_the_trail_stays_useful(self):
+        masked = RCEKit.redact_headers(["Authorization: Bearer x"])
+        self.assertIn("Authorization", masked[0])
+
+    def test_no_headers_is_passed_through(self):
+        self.assertIsNone(RCEKit.redact_headers(None))
+        self.assertEqual(RCEKit.redact_headers([]), [])
+
+    def test_credentials_never_reach_the_audit_log_on_disk(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "p.txt"
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--acknowledge-consent",
+                 "--categories", "basic_enum", "--environments", "unix",
+                 "--max-payloads", "1", "-o", str(out),
+                 "--verify-header", "Authorization: Bearer SUPERSECRET"],
+                cwd=tmp, capture_output=True, text=True, timeout=120)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            audit = (Path(tmp) / "exploit_audit.log").read_text()
+        self.assertNotIn("SUPERSECRET", audit)
+        self.assertIn("Authorization", audit)
+        self.assertIn("redacted", audit)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Four issues from the same review pass, all in how a run reaches or records a live target. Version bumped to 2.18.0, README kept in sync. No target that worked before stops working.

## 1. The chain path fired what --verify-url refuses to send

`--verify-chain` delivers to a live target exactly as `--verify-url` does, but skipped every safeguard the verifier applies: no sink-shape filters, no destructive hold-back, and no pre-flight plan. With `--verify-active-risk stateful`, 1475 destructive payloads went out through the chain with no `--verify-allow-destructive` gate — persistence and irreversible file operations that the single-request path holds back by default.

The hold-back is now a shared `partition_destructive()` that both paths call, and the chain prints the same plan and hold-back notice. The safety of a run no longer depends on which delivery path it took.

Worth noting for reviewers: with the shipped corpus at the default `safe` tier, no destructive payload passes the safety filter, so this was a latent gap rather than something firing today. It became reachable through a custom `--template-file` or a raised risk tier.

## 2. A captured session replayed in cleartext, unremarked

A raw request captured without a scheme is replayed over `http`, putting whatever session it carries — bearer tokens, authenticated cookies — on the wire in the clear, with nothing said about it.

**The `http` default is kept.** RCEKit's targets are lab ranges, CTF boxes and internal applications, which are routinely plain http on a portless `Host`; defaulting those to `https` would leave the tool unable to reach its most common targets out of the box, and self-signed or non-standard lab setups would fail before the operator saw why. Reachability in exactly those environments is a feature, not an oversight.

So the risk is surfaced rather than defaulted away. The CLI reports the inferred scheme, and names the credential headers a plain-http replay would expose:

```
[verify] loaded request from lab.txt: GET http://dvwa.local/vulnerabilities/exec/?ip=FUZZ (injecting at inline marker)
[verify] the capture records no scheme; inferred http from the Host header — override with --request-scheme.
[!] This request carries Cookie and will be replayed over plain HTTP. If the target is HTTPS, pass
    --request-scheme https (with --insecure for a self-signed or mismatched certificate).
```

The warning names headers, never their values, and is suppressed when `--request-scheme` was given explicitly or no credential header is present. An explicit port still decides the scheme as before.

## 3. Write failures were reported as successful runs

`save_payloads_to_file` logged any write error and returned its count anyway, so a run that produced nothing still printed `Generated N payloads to ...` and exited 0. The generated file is the deliverable, so the failure now propagates and `main()` reports it and exits 1. The Burp, ffuf and Nuclei writers do the same.

```
[!] Unable to write output to /no/such/dir/x.txt: [Errno 2] No such file or directory
exit=1
```

## 4. Credentials were persisted to the audit log

`log_exploitation_usage` recorded `vars(args)` verbatim, so whatever `--verify-header` carried — an `Authorization: Bearer ...`, an authenticated `Cookie` — was written to `exploit_audit.log` in cleartext. `.gitignore` already keeps that file out of history, but it still sat unredacted on disk.

Credential-bearing header values are now masked while the header name is kept, so the trail still records what was sent without persisting the secret.

## Tests

15 new tests across `DestructiveHoldBackTestCase`, `CleartextCaptureWarningTestCase`, `OutputFailureTestCase`, `AuditRedactionTestCase` and the raw-request suite; 144 to 159, all green with no external dependencies. Each was checked against the unfixed code and confirmed to fail there.
