### PR TITLE
feat: apply shell detection methods to language runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.19.0** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.20.0** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed
@@ -129,6 +129,21 @@ One CLI, one `--methods` flag, covering the main paths to RCE:
 
 Mix them freely: `--methods reflected,eval,time` runs all three and reports each
 tier separately.
+
+The shell methods (`reflected`, `file`, `time`) apply to any environment whose
+runtime reaches a shell — the shell environments themselves plus the language
+runtimes, since PHP's `system()`, Python's `os.system()`, Node's
+`child_process.exec()`, Ruby's `system()`, Perl's backticks and Go's `os/exec`
+all hand the string to `/bin/sh`. So scoping a run to the language the
+application is written in (`--environments php`) still probes for command
+injection; a language runtime doesn't say which OS it runs on, so its probes
+take the Unix shape and `--environments windows` remains the way to get
+`cmd.exe` probes. The data-layer environments (`sql`, `graphql`, `mongodb`)
+are excluded: reaching a shell from those needs a different escalation, so
+`eval` is what applies there.
+
+If a combination builds no probes at all, RCEKit says so and exits non-zero —
+a run that tested nothing is never reported as a clean result.
 
 > **Honest scope.** RCEKit confirms RCE that is reachable by **injecting into a
 > request** and interpreted by a shell or an evaluator. It does **not** cover

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.19.0"
+__version__ = "2.20.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -2112,6 +2112,26 @@ class OOBListener:
 # Shell environments whose payloads ReflectedMath can force to compute a value.
 UNIX_SHELL_ENVIRONMENTS = {"unix", "docker", "kubernetes"}
 
+# Application runtimes that reach a shell. An ``environment`` names what runs
+# the application, not what executes the injected command: PHP's system(),
+# Python's os.system(), Node's child_process.exec(), Ruby's system(), Perl's
+# backticks and Go's os/exec all hand the string to /bin/sh. The corpus has
+# always modelled that -- it ships exec_system, os_system, child_process_exec
+# and kernel_system sinks for exactly these runtimes -- while the shell
+# detection methods gated on the shell environments alone, so scoping a run to
+# the language the application is written in (the natural thing to do) sent no
+# shell probes at all and reported a clean negative.
+#
+# A language runtime does not say which OS it runs on, so its probes take the
+# Unix shape; --environments windows remains the way to get cmd.exe probes.
+#
+# The data-layer environments (sql, graphql, mongodb) are deliberately absent:
+# reaching a shell from them needs a distinct escalation (xp_cmdshell, COPY
+# FROM PROGRAM, a resolver into a command sink) and so a distinct probe.
+SHELL_CAPABLE_ENVIRONMENTS = UNIX_SHELL_ENVIRONMENTS | {"windows"} | {
+    "php", "python", "nodejs", "java", "dotnet", "ruby", "perl", "go",
+}
+
 
 @dataclass
 class Probe:
@@ -2321,8 +2341,7 @@ class ReflectedMath(DetectionMethod):
     tier = "confirmed"
 
     def applicable(self, record: "PayloadRecord") -> bool:
-        return (record.environment in UNIX_SHELL_ENVIRONMENTS
-                or record.environment == "windows")
+        return record.environment in SHELL_CAPABLE_ENVIRONMENTS
 
     def build_probes(self, record: "PayloadRecord", rng: "random.Random") -> List[Probe]:
         a = rng.randint(100000, 999999)
@@ -2372,8 +2391,7 @@ class FileBased(DetectionMethod):
     def applicable(self, record: "PayloadRecord") -> bool:
         if not (self.config.get("webroot") and self.config.get("web_base_url")):
             return False
-        return (record.environment in UNIX_SHELL_ENVIRONMENTS
-                or record.environment == "windows")
+        return record.environment in SHELL_CAPABLE_ENVIRONMENTS
 
     def build_probes(self, record: "PayloadRecord", rng: "random.Random") -> List[Probe]:
         webroot = self.config["webroot"].rstrip("/")
@@ -2436,8 +2454,7 @@ class ParametricTime(DetectionMethod):
     aggregate = True
 
     def applicable(self, record: "PayloadRecord") -> bool:
-        return (record.environment in UNIX_SHELL_ENVIRONMENTS
-                or record.environment == "windows")
+        return record.environment in SHELL_CAPABLE_ENVIRONMENTS
 
     def build_probes(self, record: "PayloadRecord", rng: "random.Random") -> List[Probe]:
         base = float(self.config.get("time_base", 2.0))
@@ -3283,6 +3300,29 @@ def main():
             print(f"[detect] methods: {', '.join(method_names)}")
             print(f"[detect] sent {len(results)} probes: " +
                   (", ".join(f"{v}={c}" for v, c in sorted(by_verdict.items())) or "none"))
+            if not results:
+                # Nothing was tested. Saying so is the whole point: a run that
+                # built no probes used to end here in silence and exit 0, which
+                # reads exactly like a target that came back clean.
+                selected_envs = sorted({record.environment for record in to_send})
+                print("[!] No probes were built, so NOTHING WAS TESTED — this is not a "
+                      "negative result.")
+                if not to_send:
+                    print("[!] No payloads matched the selection: widen --categories/--environments"
+                          "/--contexts, or raise --verify-active-risk.")
+                else:
+                    print(f"[!] None of the selected methods ({', '.join(method_names)}) apply to "
+                          f"environment(s): {', '.join(selected_envs)}.")
+                    shell_methods = sorted(
+                        set(method_names) & {ReflectedMath.name, FileBased.name, ParametricTime.name})
+                    if shell_methods and not set(selected_envs) & SHELL_CAPABLE_ENVIRONMENTS:
+                        verb = "needs" if len(shell_methods) == 1 else "need"
+                        print(f"[!] {', '.join(shell_methods)} {verb} an environment whose runtime "
+                              "reaches a shell. Add --environments unix if the sink shells out, or "
+                              f"use --methods {EvalExpr.name} for a template/expression sink.")
+                    if FileBased.name in method_names and not (args.webroot and args.web_base_url):
+                        print("[!] --methods file also needs --webroot and --web-base-url.")
+                return 1
             confirmed = [r for r in results if r["verdict"] == "confirmed"]
             if confirmed:
                 print(f"\n[detect] CONFIRMED execution ({len(confirmed)}):")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2804,5 +2804,100 @@ class SelfSeparatingContextTestCase(unittest.TestCase):
                         "shell_single_quoted must confirm on a single-quoted sink")
 
 
+class ShellCapableEnvironmentTestCase(unittest.TestCase):
+    """An ``environment`` names what runs the application, not what executes the
+    injected command. PHP's system(), Python's os.system() and Node's
+    child_process.exec() all hand the string to /bin/sh, and the corpus has
+    always shipped those sinks — but the shell methods gated on the shell
+    environments alone, so scoping a run to the language the application is
+    written in sent no shell probes and reported a clean negative."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.config = {"webroot": "/var/www/html", "web_base_url": "http://t"}
+
+    def _rec(self, env):
+        return make_record(environment=env, context="raw")
+
+    def test_language_runtimes_get_shell_probes(self):
+        for env in ("php", "python", "nodejs", "java", "dotnet", "ruby", "perl", "go"):
+            for cls in (ReflectedMath, FileBased, ParametricTime):
+                with self.subTest(environment=env, method=cls.name):
+                    self.assertTrue(cls(self.gen, self.config).applicable(self._rec(env)))
+
+    def test_shell_environments_still_apply(self):
+        for env in ("unix", "docker", "kubernetes", "windows"):
+            with self.subTest(environment=env):
+                self.assertTrue(ReflectedMath(self.gen).applicable(self._rec(env)))
+
+    def test_data_layer_environments_stay_out(self):
+        # Reaching a shell from these needs a distinct escalation (xp_cmdshell,
+        # COPY FROM PROGRAM, a resolver into a command sink) and so a distinct
+        # probe; claiming applicability would only send probes that cannot fire.
+        for env in ("sql", "graphql", "mongodb"):
+            with self.subTest(environment=env):
+                self.assertFalse(ReflectedMath(self.gen).applicable(self._rec(env)))
+
+    def test_language_runtime_probes_take_the_unix_shape(self):
+        # A language runtime does not say which OS it runs on; --environments
+        # windows stays the way to get cmd.exe probes.
+        import random as _random
+        probe = ReflectedMath(self.gen).build_probes(self._rec("php"), _random.Random(1))[0]
+        self.assertIn("$((", probe.payload)
+        self.assertNotIn("set /a", probe.payload)
+
+    def test_php_system_sink_is_confirmed_under_its_own_environment(self):
+        import os
+
+        def route(method, path, params, headers, body):
+            pipe = os.popen("echo pinging " + params.get("q", "") + " 2>&1")
+            out = pipe.read()
+            pipe.close()
+            return 200, out
+
+        with local_target(route) as base:
+            results = self.gen.run_detection(
+                [self._rec("php")], url=f"{base}/x?q=FUZZ", methods=["reflected"])
+        self.assertTrue([r for r in results if r["verdict"] == "confirmed"],
+                        "a system() sink must confirm under --environments php")
+
+
+class NoProbesBuiltTestCase(unittest.TestCase):
+    """A run that built no probes tested nothing, and used to end in silence and
+    exit 0 — indistinguishable from a target that came back clean."""
+
+    def _run(self, *args, cwd=None):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            cwd=str(cwd or REPO_ROOT), capture_output=True, text=True, timeout=120)
+
+    def _detect(self, *extra):
+        return self._run("--acknowledge-consent", "--contexts", "raw", "--max-payloads", "3",
+                         "--verify-url", "http://127.0.0.1:9/?q=FUZZ", *extra)
+
+    def test_zero_probes_is_reported_and_exits_non_zero(self):
+        result = self._detect("--environments", "mongodb", "--categories", "nosql_injection",
+                              "--methods", "reflected")
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("NOTHING WAS TESTED", result.stdout)
+        self.assertIn("not a negative result", result.stdout)
+
+    def test_the_message_names_the_environment_and_the_way_out(self):
+        result = self._detect("--environments", "mongodb", "--categories", "nosql_injection",
+                              "--methods", "reflected")
+        self.assertIn("mongodb", result.stdout)
+        self.assertIn("--environments unix", result.stdout)
+        self.assertIn("--methods eval", result.stdout)
+
+    def test_a_run_that_did_send_probes_is_unaffected(self):
+        # Nothing listens on port 9, so every probe errors — but probes were
+        # built, so this stays the ordinary reporting path.
+        result = self._detect("--environments", "unix", "--categories", "basic_enum",
+                              "--methods", "reflected")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertNotIn("NOTHING WAS TESTED", result.stdout)
+        self.assertIn("NEVER REACHED THE TARGET", result.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Two related fixes: shell probes never ran for language environments, and a run that built no probes reported nothing at all. Version 2.20.0.

## 1. An environment names the runtime, not the executor

`ReflectedMath`, `FileBased` and `ParametricTime` gated on the shell environments alone (`unix`, `docker`, `kubernetes`, `windows`). But an `environment` names what runs the *application* — and PHP's `system()`, Python's `os.system()`, Node's `child_process.exec()`, Ruby's `system()`, Perl's backticks and Go's `os/exec` all hand the string to `/bin/sh`.

The corpus has always modelled this. `templates/payloads.json` ships exactly these sinks:

```
php      sink=exec_system          system('whoami')
python   sink=os_system            os.system('whoami')
nodejs   sink=child_process_exec   require('child_process').exec('whoami')
ruby     sink=kernel_system        system('whoami')
perl     sink=system_backticks     system('whoami')
```

So the corpus said these runtimes reach a shell while the detection methods said they do not. One of the two had to be wrong, and it was not the corpus.

**Measured against one `system("ping " . $_GET['ip'])` sink**, changing only the environment selection:

| selection | probes built | result (before) | result (after) |
|---|---|---|---|
| `--environments php` | 7, all `eval` | nothing found | **confirmed** (17 probes) |
| `--environments python` | 7, all `eval` | nothing found | **confirmed** (17 probes) |
| `--environments nodejs` | 7, all `eval` | nothing found | **confirmed** (17 probes) |
| `--environments unix` | 17 | confirmed | confirmed |

Same sink in every row. Scoping a run to the language the application is written in — the natural, correct-looking thing to do — was the thing that broke it.

The three methods now share one `SHELL_CAPABLE_ENVIRONMENTS` set. A language runtime does not say which OS it runs on, so its probes take the Unix shape; `--environments windows` remains the way to get `cmd.exe` probes. The data-layer environments (`sql`, `graphql`, `mongodb`) stay out deliberately: reaching a shell from those needs a distinct escalation — `xp_cmdshell`, `COPY FROM PROGRAM`, a resolver into a command sink — and so a distinct probe. Claiming applicability there would only send probes that cannot fire.

## 2. Zero probes was silent

A run that built no probes ended like this, and exited 0:

```
[detect] methods: reflected
[detect] sent 0 probes: none
```

Not even the "No execution confirmed" line, since that only prints when there are results to speak of. Nothing was tested, and it read exactly like a target that came back clean.

That case survives fix 1 — `--methods reflected` with `--environments mongodb` still builds nothing — so it is now reported outright and exits 1:

```
[detect] sent 0 probes: none
[!] No probes were built, so NOTHING WAS TESTED — this is not a negative result.
[!] None of the selected methods (reflected) apply to environment(s): mongodb.
[!] reflected needs an environment whose runtime reaches a shell. Add --environments unix if the
    sink shells out, or use --methods eval for a template/expression sink.
```

It also distinguishes the other way to get here — no payloads matched the selection at all — and reminds you when `--methods file` is missing `--webroot`/`--web-base-url`.

## Precision and cost

Precision is unchanged: every confirmation still requires a value the target computed on random operands and absent from the payload-free control. Widening applicability adds carriers, which can only add confirmations, never weaken one.

The cost is real and worth a reviewer's eye: an unscoped run goes from 13 to 23 shell-capable carriers, so `reflected` probes go from 130 to 230 — roughly 1.8×, on top of the separator sweep in #41. Scoping with `--environments`/`--contexts`, narrowing with `--separators`, or capping with `--max-payloads` all still apply.

## Tests

8 new tests (27 sub-cases) across `ShellCapableEnvironmentTestCase` and `NoProbesBuiltTestCase`; 171 to 179, all green with no external dependencies. Reverting both fixes fails all 27.
