### PR TITLE
docs: rewrite the comparison around what RCEKit does better

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.21.0** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.21.1** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed
@@ -132,44 +132,87 @@ blur together, "confirmed" loses its meaning — so RCEKit keeps them apart, by 
 
 ## How RCEKit compares
 
-The tools below are good at what they do, and RCEKit does not replace them. The
-difference is **where each one stops**:
+The other tools in this space are built to get you **in**. RCEKit is built so the
+finding **survives someone else's scrutiny** — the client's retest, the triage
+queue, the report review. That difference shows up three times.
 
-| | What it's built for | RCE classes it covers | Infrastructure | Ends at |
+### 1. One injection point, every class, one run
+
+You rarely know the class before you test. Covering an unknown sink with
+single-class tools means running each in turn and rebuilding the request for each
+one:
+
+| Can confirm | RCEKit | [commix](https://github.com/commixproject/commix) | [SSTImap](https://github.com/vladko312/SSTImap) | [Nuclei](https://github.com/projectdiscovery/nuclei) |
 |---|---|---|---|---|
-| [**commix**](https://github.com/commixproject/commix) | exploiting OS command injection | OS command injection (classic, eval-based, time-based, file-based, shellshock) | none | an interactive shell |
-| [**SSTImap**](https://github.com/vladko312/SSTImap) *(successor to the unmaintained [tplmap](https://github.com/epinna/tplmap))* | exploiting SSTI / code injection | SSTI + code injection, 30+ template engines | none | an interactive shell |
-| [**Nuclei**](https://github.com/projectdiscovery/nuclei) | scanning at scale for *known* issues | whatever a template already exists for | [interactsh](https://github.com/projectdiscovery/interactsh) for OAST templates | a template match |
-| **interactsh / Burp Collaborator** | providing an out-of-band channel | blind variants of any class | an external (or self-hosted) server | a callback |
-| **RCEKit** | **proving execution across classes** | **command injection + SSTI/eval + blind + no-egress** | **none** | **a proof-backed verdict** |
+| OS command injection | ✅ | ✅ *(its whole scope)* | — | per template |
+| Expression injection / SSTI | ✅ | via its eval-based technique | ✅ *(its whole scope)* | per template |
+| Blind — timing | ✅ *as a separate tier* | ✅ | ✅ | — |
+| Blind — out-of-band | ✅ *built-in listener* | — | — | via [interactsh](https://github.com/projectdiscovery/interactsh) |
+| No-egress — write &amp; fetch back | ✅ | ✅ | — | — |
+| **All of the above, one CLI, one run** | **✅** | — | — | — |
 
-**Use the other tool when:**
+<sub>Coverage per each project's own documented technique list. SSTImap is the
+maintained successor to <a href="https://github.com/epinna/tplmap">tplmap</a>,
+which its author has marked unmaintained.</sub>
 
-- **You want a shell.** commix and SSTImap take you from "vulnerable" to
-  post-exploitation. RCEKit deliberately stops at proof and will never hand you a
-  shell — that is a scope decision, not a missing feature.
-- **You are sweeping thousands of hosts for known CVEs.** That is Nuclei's job.
-  RCEKit is per-target — and it *exports* Nuclei templates
-  (`--output-format nuclei`), so the two compose rather than compete.
-- **You already run Burp Pro.** Then you already have Collaborator. RCEKit's
-  built-in listener matters when you don't, or when the engagement forbids
-  third-party OOB infrastructure.
+```bash
+# Command injection, expression injection and blind timing against the same
+# parameter, in one pass, with zero infrastructure
+python rcekit.py --acknowledge-consent -r request.txt -p host --methods reflected,eval,time
+```
 
-**Use RCEKit when:**
+### 2. It argues with its own results
 
-- **You don't yet know the class.** One run of `--methods reflected,eval,time`
-  covers command injection, expression injection and blind timing against the same
-  injection point, instead of reaching for a different tool per hypothesis.
-- **The finding has to survive triage.** Every confirmation is differenced against
-  a payload-free control, and timing evidence is reported in its own
-  `needs-review` tier — never merged into "vulnerable". commix pioneered
-  randomised results-based heuristics for command injection; RCEKit carries that
-  rigour across expression injection, blind and no-egress paths, and refuses to
-  let a timing signal masquerade as proof.
-- **There is no egress and no infrastructure to lean on.** The `file` method
-  proves execution through a write-and-fetch on the target's own web root, with no
-  listener at all — and the tool itself is one standard-library Python file you
-  can copy onto a locked-down host.
+A tool reports what it found. RCEKit also reports **what it refused to believe** —
+`inconclusive` is a verdict of its own, for evidence that showed up but could not
+be attributed to execution:
+
+```
+[detect] methods: reflected, eval
+[detect] sent 13 probes: confirmed=0, inconclusive=2, negative=11
+```
+
+Those two would have been someone else's finding. Four mechanisms produce that
+verdict, and they run on every confirmation:
+
+- **A payload-free control request.** Evidence must be present *with* the payload
+  and absent *without* it. Anything in both is `inconclusive`, not a finding.
+- **A same-token inert control.** A second request carries the identical random
+  token in a non-executing form. A target that merely echoes input fails here —
+  which is how a reflection is separated from an execution.
+- **Random operands, never fixed strings.** The oracle is a tag-wrapped sum or a
+  boundary-fenced product computed fresh each run. Echoing the payload returns
+  the literal `$((a+b))`; only execution returns the value.
+- **Encoding-aware evidence search.** A sink that base64-, hex-, URL-, HTML- or
+  unicode-escapes its output still confirms — the raw body is checked first, so
+  decoding only ever turns a missed hit into a hit, never the reverse.
+
+And timing **never self-confirms**: a linear `0/N/2N` regression is capped at
+`needs-review` and reported in its own tier, because it produces no computed
+value. `confirmed` and `maybe` are never merged into one word.
+
+### 3. It is built for an authorised engagement, not a lab
+
+The controls a client's rules of engagement actually ask about, in the tool
+rather than in your notes:
+
+| | |
+|---|---|
+| **Consent gate** | Nothing exploitative generates or fires without `--acknowledge-consent`. |
+| **Execution plan** | Prints the exact payload count, safety tiers and any outbound callback destinations **before** the first request goes out. |
+| **Safe by default** | Reverse shells, credential access, cloud metadata, lateral movement and container escape are held back until you raise `--verify-active-risk`; persistence and backdoors need a second flag on top. |
+| **Cleanup commands** | The `file` method changes target state, so every finding prints the exact `rm`/`del` to undo it — paste it into the report. |
+| **Redacted audit trail** | Every run lands in `exploit_audit.log`, recording that a credential header was sent, never its value. |
+| **Watermarking** | `--watermark` stamps a traceable token into each payload, so a payload found in the client's logs months later is attributable to your run. |
+| **No third-party callbacks** | The OOB listener is yours. Nothing is routed through a public interaction server, which some engagements forbid outright. |
+| **One stdlib file** | `rcekit.py` runs alone — jump box, air-gapped host, anywhere `pip install` is not an option. |
+
+### When to reach for something else
+
+Want a shell rather than a verdict? commix and SSTImap continue into
+post-exploitation; RCEKit stops at proof by design. Sweeping thousands of hosts
+for known CVEs? That is Nuclei's job — and RCEKit *writes* Nuclei templates
+(`--output-format nuclei`), so it feeds your scanner instead of competing with it.
 
 ---
 

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.21.0"
+__version__ = "2.21.1"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -124,6 +124,48 @@ class DocLinkTestCase(unittest.TestCase):
             )
 
 
+class ComparisonSectionTestCase(unittest.TestCase):
+    """The comparison names other people's tools, so it has to stay checkable."""
+
+    # Every project the section is allowed to name, and where a reader verifies it.
+    PROJECTS = {
+        "commix": "github.com/commixproject/commix",
+        "SSTImap": "github.com/vladko312/SSTImap",
+        "tplmap": "github.com/epinna/tplmap",
+        "Nuclei": "github.com/projectdiscovery/nuclei",
+        "interactsh": "github.com/projectdiscovery/interactsh",
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        text = README.read_text(encoding="utf-8")
+        start = text.find("## How RCEKit compares")
+        assert start != -1, "README has no 'How RCEKit compares' section"
+        end = text.find("\n## ", start + 1)
+        cls.section = text[start:end if end != -1 else len(text)]
+
+    def test_section_has_substance(self):
+        self.assertGreater(len(self.section.splitlines()), 30)
+
+    def test_named_projects_are_linked(self):
+        """A claim about someone else's tool must ship with a way to check it."""
+        unlinked = [
+            name for name, url in self.PROJECTS.items()
+            if name.lower() in self.section.lower() and url not in self.section
+        ]
+        self.assertEqual(
+            unlinked, [], f"named in the comparison without a link to the project: {unlinked}"
+        )
+
+    def test_no_unvetted_project_is_named(self):
+        """Adding a rival to the table means adding it here — and linking it."""
+        for rival in ("sqlmap", "metasploit", "burp suite", "acunetix", "tplmap2"):
+            self.assertNotIn(
+                rival, self.section.lower(),
+                f"'{rival}' appears in the comparison but is not in PROJECTS",
+            )
+
+
 class CLIDocumentationTestCase(unittest.TestCase):
     """Guard against the CLI and its reference page drifting apart."""
 


### PR DESCRIPTION
## The problem

The comparison section was factually fine and rhetorically backwards. It compared on axes that flattered the alternatives:

- The **"Ends at"** column read *"an interactive shell"* for commix against *"a proof-backed verdict"* for RCEKit — which states the tradeoff upside down. A reader scanning that row concludes commix does more.
- **"Use the other tool when"** got three concrete bullets; **"Use RCEKit when"** got three vaguer ones. The section spent more of its length recommending other projects than explaining this one.

Net effect: a reader finished it knowing the alternatives were good, and not why RCEKit exists.

The facts were right. The axes were wrong.

## What replaced it

Three subsections, each built on something RCEKit demonstrably does that a scope-limited exploiter does not.

**1. One injection point, every class, one run.** A capability matrix over command injection, expression injection, blind timing, out-of-band and no-egress — where only RCEKit fills every row, from one CLI against one injection point. The bottom row (*all of the above, one CLI, one run*) is the claim the section exists to make.

Cells describe each project's **own documented technique scope**, with a footnote saying so. That keeps every claim checkable and avoids asserting things about competitors' internals that cannot be verified from outside — a comparison that overreaches gets corrected in public, which costs more than the claim was worth.

**2. It argues with its own results.** `inconclusive` is a verdict RCEKit reports *against itself*, and the four mechanisms behind it are now spelled out: the payload-free control request, the same-token inert control that separates reflection from execution, the randomised operands, and the encoding-aware evidence search. Plus timing's hard `needs-review` ceiling.

**3. Built for an authorised engagement, not a lab.** The controls a client's rules of engagement actually ask about — consent gate, pre-flight execution plan, safe-by-default risk tiers, per-finding cleanup commands, an audit trail that records that a credential header was sent but never its value, watermarking, an OOB listener that routes no callbacks through a third party, and a single stdlib file that runs on a locked-down host.

Every item in that table was verified against the implementation before being written down, not assumed from the old docs.

**"When to reach for something else" stays** — a comparison that wins every column is not believable, and pointing at commix/SSTImap for a shell and Nuclei for scale is simply true. It is now one short paragraph instead of the section's centre of gravity.

## Accuracy fix

The illustrative output is the real `--methods` summary line:

```
[detect] sent 13 probes: confirmed=0, inconclusive=2, negative=11
```

An earlier draft showed a detailed `INCONCLUSIVE` block under `[detect]`. That block belongs to the `--verify-url` path (`rcekit.py:3413`); the `--methods` path surfaces inconclusive results in the verdict counts. Showing it would have been fiction in a section whose entire argument is that this tool does not overstate its evidence.

## Tests

`tests/test_docs.py` gains a guard for a section that makes claims about other people's projects:

- every project named in the comparison must be linked to its repository — a claim about someone else's tool ships with a way to check it;
- naming a project outside the vetted set fails, so adding a rival to the table is a deliberate act;
- the section must retain substance, so it cannot be quietly gutted by a later edit.

Verified non-vacuous by unlinking SSTImap and inserting an unvetted tool name — both tests fail.

Full suite: **200 tests, all passing** (was 197).

## Version

`2.21.0` → `2.21.1` (documentation only; no behaviour change).
