### PR TITLE
feat: add CHANGELOG.md and guard it with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,120 @@
+# Changelog
+
+All notable changes to RCEKit are recorded here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and RCEKit follows
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html): PATCH for fixes,
+MINOR for new capabilities, MAJOR for breaking changes to the CLI, output
+formats, or the template schema.
+
+## [Unreleased]
+
+## [2.21.1] — 2026-08-02
+
+First release since v2.15.2. The headline is not a new feature — it is that
+detection is now correct in cases where it previously was not.
+
+### ⚠️ Re-check findings from v2.15.2 and earlier
+
+**A reflection could be reported as `confirmed`.** The paired same-token control
+in `run_verification` was gated on a plain `re.search`, while the verdict itself
+used the encoding-aware search. A target that only echoes input but wraps its
+output — base64, hex, URL- or HTML-encoded — skipped the control entirely and was
+reported as proven execution: precisely the case the encoding-aware search was
+added for. If you ran an earlier version against a target that encodes its
+responses, a `confirmed` verdict from that run is worth re-testing.
+
+### Fixed — false negatives on exploitable targets
+
+- **Separator sweep.** Shell probes always broke out with a single hardcoded
+  `; `, so a sink that strips `;` — the most common partial mitigation there is,
+  and one that stops nothing on its own — defeated every probe. Measured against
+  nine deliberately vulnerable local sinks, detection was correct on 5 of 9;
+  three of the four misses were exploitable targets reported clean. Probes now
+  sweep `; `, `| `, `|| `, `&& ` and a newline, narrowable with `--separators`.
+- **Language runtimes.** An environment names what runs the application, not what
+  executes the injected command: PHP's `system()`, Python's `os.system()`,
+  Node's `child_process.exec()`, Ruby's `system()`, Perl's backticks and Go's
+  `os/exec` all hand the string to `/bin/sh`. Scoping a run to the language the
+  application is written in — the natural thing to do — used to send no shell
+  probes at all.
+- **Whole-command sinks.** `--sink-raw` sends probes as bare commands for sinks
+  that execute the input as the entire command (`qx/$input/`, `sh -c "$input"`),
+  where a leading `;` is a syntax error that guaranteed a false negative.
+- **Captured requests.** A trailing newline in a saved request body is no longer
+  sent as part of the body.
+
+### Fixed — a failed request is not a clean result
+
+- A request that never reached the target is reported `error`, not `negative`.
+- Runs that build no probes at all exit non-zero and say so, instead of ending
+  in silence and exit 0 — which read exactly like a target that came back clean.
+- The OOB DNS listener no longer dies on a malformed query, and write failures
+  surface instead of being swallowed.
+
+### Fixed — safety and audit
+
+- **Multi-step chains now carry the same safeguards as single requests.** The
+  chain path delivered to live targets without sink-shape filters, destructive
+  hold-back or a pre-flight plan, so `--verify-active-risk stateful` fired
+  persistence and irreversible file operations that `--verify-url` refuses to
+  send without `--verify-allow-destructive`. Both paths now share one hold-back
+  and print the same plan.
+- **The audit trail redacts credentials** — it records that a credential header
+  was sent, never its value.
+- A capture carrying `Authorization` or `Cookie` over plain `http` is flagged
+  before anything is sent.
+
+### Added
+
+- **The payload corpus is embedded in `rcekit.py`**, so the single file runs on
+  its own — a jump box, an air-gapped host, a bare `curl` of the raw script.
+  Resolution order is `--template-file` → `templates/payloads.json` beside the
+  script → the built-in copy, and falling back to the built-in copy is
+  announced. A corpus that exists but does not parse still hard-fails: that
+  check exists for truncated and tampered corpora. `tools/embed_corpus.py`
+  regenerates the embedded copy, and the test suite fails if the two drift.
+- **`--insecure`** skips TLS verification for internal targets with self-signed
+  or mismatched certificates — opt-in and explicit, like `curl -k`.
+- **`--sink-raw`** for whole-command injection sinks, also readable from a
+  target profile.
+- **`--separators`** to narrow the break-out sweep once the sink's shape is
+  known.
+- **Documentation split into a task-oriented tree.** The README is half its
+  former length and now leads with what RCEKit is for:
+  [field guide](docs/guide.md) (worked examples by situation),
+  [payload generation & exports](docs/generation.md), and
+  [reference](docs/reference.md) (every flag grouped by task, plus the full
+  taxonomies and exit codes).
+- **A "How RCEKit compares" section** covering commix, SSTImap, Nuclei and
+  interactsh, with every claim traceable to that project's own documentation.
+- Four confirmation demos against real, publicly documented CVEs (Webmin
+  CVE-2019-15107, Struts2 S2-001, Log4Shell CVE-2021-44228).
+
+### Changed
+
+- **Expect more requests per run.** The separator sweep and the language-runtime
+  fix both widen the probe set. Narrow with `--separators`, `--contexts` and
+  `--environments` once the sink's shape is known.
+- **`--doctor` output.** Its first line now names the corpus in use
+  (`corpus: …`) rather than a path (`template: …`), since the corpus is no
+  longer necessarily a file, and `[ok] file loaded and parsed` is now
+  `[ok] corpus loaded and parsed`.
+
+No breaking changes to the CLI, output formats, or the template schema.
+Standard library only, Python 3.8–3.13.
+
+## Earlier releases
+
+Release notes for these live on the
+[Releases page](https://github.com/kabiri-labs/rcekit/releases); they predate
+this file and have not been restated here.
+
+- **[2.15.2]** — Multi-method RCE detection &amp; confirmation
+- **[2.7.0]**
+- **[2.1.0]**
+
+[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.21.1...HEAD
+[2.21.1]: https://github.com/kabiri-labs/rcekit/compare/v2.15.2...v2.21.1
+[2.15.2]: https://github.com/kabiri-labs/rcekit/releases/tag/v2.15.2
+[2.7.0]: https://github.com/kabiri-labs/rcekit/releases/tag/v2.7.0
+[2.1.0]: https://github.com/kabiri-labs/rcekit/releases/tag/v2.1.0

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ what it sends, and how to read what comes back.
 | [**Field guide**](docs/guide.md) | Example-driven walkthrough of every real situation, from a first probe to multi-step chains. **Start here.** |
 | [**Payload generation &amp; exports**](docs/generation.md) | RCEKit as a payload generator: target profiles, and Burp / ffuf / Nuclei exports. |
 | [**Reference**](docs/reference.md) | Every flag, environment, category, context, encoding and code-execution sink. |
+| [**CHANGELOG.md**](CHANGELOG.md) | What changed in each release, and what to re-check when upgrading. |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to add sinks, categories, encodings and detection methods. |
 | [SECURITY.md](SECURITY.md) | Reporting a vulnerability in RCEKit itself. |
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -20,6 +20,7 @@ import rcekit
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = REPO_ROOT / "rcekit.py"
 README = REPO_ROOT / "README.md"
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
 DOCS_DIR = REPO_ROOT / "docs"
 
 FENCE_RE = re.compile(r"^\s*```", re.MULTILINE)
@@ -33,7 +34,7 @@ DECLARATION_RE = re.compile(r"^ {2}(-\S[^ ]*(?:[ ,][^ ]+)*?)(?: {2,}|$)")
 
 
 def markdown_files():
-    return [README] + sorted(DOCS_DIR.glob("*.md"))
+    return [README, CHANGELOG] + sorted(DOCS_DIR.glob("*.md"))
 
 
 def strip_code_fences(text):
@@ -77,6 +78,38 @@ class VersionBadgeTestCase(unittest.TestCase):
             rcekit.__version__,
             "README version badge is out of sync with rcekit.__version__",
         )
+
+
+class ChangelogTestCase(unittest.TestCase):
+    """A release with no changelog entry is a release nobody can read."""
+
+    RELEASE_RE = re.compile(r"^## \[(\d+\.\d+\.\d+)\]", re.MULTILINE)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = CHANGELOG.read_text(encoding="utf-8")
+
+    def test_has_an_unreleased_section(self):
+        self.assertIn("## [Unreleased]", self.text)
+
+    def test_latest_entry_matches_dunder_version(self):
+        releases = self.RELEASE_RE.findall(self.text)
+        self.assertTrue(releases, "CHANGELOG.md documents no released version")
+        self.assertEqual(
+            releases[0], rcekit.__version__,
+            "the newest CHANGELOG entry does not match rcekit.__version__ — "
+            "every version bump needs an entry",
+        )
+
+    def test_releases_are_in_descending_order(self):
+        releases = [tuple(int(p) for p in v.split(".")) for v in self.RELEASE_RE.findall(self.text)]
+        self.assertEqual(releases, sorted(releases, reverse=True),
+                         "CHANGELOG entries are not newest-first")
+
+    def test_every_release_has_a_link_definition(self):
+        defined = set(re.findall(r"^\[(\d+\.\d+\.\d+)\]:", self.text, re.MULTILINE))
+        missing = sorted(set(self.RELEASE_RE.findall(self.text)) - defined)
+        self.assertEqual(missing, [], f"versions with no link definition: {missing}")
 
 
 class DocLinkTestCase(unittest.TestCase):


### PR DESCRIPTION
## Why

Releases had drifted five versions behind the code, and there was nowhere a reader could see what changed between them. Someone upgrading from v2.15.2 had to read the commit log to discover that a reflection could previously be reported as `confirmed`.

## The file

`CHANGELOG.md`, following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).

The **v2.21.1** entry covers everything since v2.15.2 — the 2.16–2.21 versions were never tagged, so a reader upgrading gets one coherent list rather than gaps. It opens with **⚠️ Re-check findings from v2.15.2 and earlier**: the reflection false positive, and the advice to re-test `confirmed` verdicts against targets that encode their responses.

That placement is deliberate. It would be easy to bury a fixed false positive among the other fixes, but for a tool whose entire claim is that `confirmed` means confirmed, disclosing it plainly is what makes the claim credible. The rest is grouped by what it means to a user — false negatives on exploitable targets, failed requests not being reported as clean results, safety and audit, then additions and behaviour changes.

Earlier releases (2.15.2, 2.7.0, 2.1.0) are listed as pointers to their GitHub release notes rather than restated from memory. This file starts here instead of inventing history it cannot verify.

## Tests

Four new tests keep the changelog from becoming decorative:

- the newest entry must match `__version__` — **a version bump cannot land without a changelog entry**;
- entries must be newest-first;
- every version needs a link definition, so the compare links stay usable;
- an `[Unreleased]` section must exist.

`CHANGELOG.md` also joins the existing relative-link and heading-anchor checks.

Verified non-vacuous: bumping `__version__` without adding an entry fails, and inserting an out-of-order entry fails.

Full suite: **204 tests, all passing** (was 200).

## On the version number

**No version bump in this PR**, which is a deliberate exception worth flagging.

This file documents the 2.21.1 release and ships as part of it. Bumping to 2.21.2 in order to describe 2.21.1 would leave the tagged release as the only one whose changelog entry is not contained in it. Nothing about the tool's behaviour changed here.

The new `test_latest_entry_matches_dunder_version` enforces the normal rule from now on: the next bump, whatever it is, cannot merge without its entry.

If you would rather keep the bump-on-every-change rule absolute, say so and I will make it `2.21.2` and retitle the release notes — the tag has not been created yet, so either is still open.
