### PR TITLE
feat(detection): reach space-filtered sinks, and stop reporting blind ones as clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ formats, or the template schema.
 
 ## [Unreleased]
 
+## [2.23.0] — 2026-08-03
+
+The three sinks v2.22.0 still could not reach. One was a real gap in the probe
+set; the other two were a reporting problem, not a detection one. With both
+closed, a single `--methods reflected,eval,oob` run confirms **all fifteen**
+vulnerable sinks in the lab and still reports nothing on any of the five clean
+ones.
+
+### Added
+
+- **A space-free probe, sent at both probe depths.** Stripping spaces is a filter
+  of the same family as stripping `;` — it looks like it disarms command
+  injection and does not, because `${IFS}` is a space as far as the shell is
+  concerned. Every other probe carries a space, so that one filter silenced all
+  of them and the sink was only reachable if the operator thought to pass
+  `--evade low`. The separator's trailing space is trimmed with it (`;echo…`, not
+  `; echo…`); the newline separator is unaffected. It costs one shape, so it is
+  not part of the `--probe-depth` trade-off, and it is skipped under
+  `--evade low`, which already applies the same transform everywhere.
+- **Guidance when every in-band probe comes back negative.** A results-based
+  method cannot confirm a sink that returns no output — there is nowhere for the
+  computed value to appear — so that negative is not evidence the target is
+  clean. A run of `reflected`/`eval` alone that confirms nothing now says exactly
+  that and names the methods that could still reach a blind sink, with the flags
+  each one needs. It is suppressed once a blind-capable method has already run,
+  and the `file` line is dropped once a web root is known.
+
 ## [2.22.0] — 2026-08-03
 
 Detection coverage. Measured against a lab of twenty sinks — fifteen genuinely
@@ -174,7 +201,8 @@ this file and have not been restated here.
 - **[2.7.0]**
 - **[2.1.0]**
 
-[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.22.0...HEAD
+[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.23.0...HEAD
+[2.23.0]: https://github.com/kabiri-labs/rcekit/compare/v2.22.0...v2.23.0
 [2.22.0]: https://github.com/kabiri-labs/rcekit/compare/v2.21.1...v2.22.0
 [2.21.1]: https://github.com/kabiri-labs/rcekit/compare/v2.15.2...v2.21.1
 [2.15.2]: https://github.com/kabiri-labs/rcekit/releases/tag/v2.15.2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.22.0** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.23.0** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -271,8 +271,15 @@ confirmation, lowest false positives — on the assumption of authorised, WAF-fr
 access. That default is a feature; noisy evasion buys blocked requests and muddy
 evidence.
 
+**A space filter is not a WAF, and you don't need this flag for it.** Stripping
+spaces looks like it disarms command injection and does not — `${IFS}` is a space
+as far as the shell is concerned. Since every other probe carries a space, that
+one filter used to silence all of them, so one space-free probe now ships at both
+probe depths and reaches such a sink on an ordinary run.
+
 When there is genuinely a WAF in the path, `--evade low` opts into a single
-low-touch transform (`${IFS}` for spaces on Unix) for the shell probes:
+low-touch transform — `${IFS}` for spaces, applied to *every* shell probe rather
+than the one dedicated shape:
 
 ```bash
 python rcekit.py --acknowledge-consent \
@@ -289,6 +296,21 @@ injection context or a different separator, not heavier obfuscation.
 No output channel at all? Reach for `oob` first — it is the only method that can
 *confirm* a blind sink (see [Out-of-band callbacks](#out-of-band-callbacks)).
 Timing is the fallback when the target has no egress either.
+
+**A results-based method cannot confirm a blind sink**, and that is not a
+limitation to route around — there is simply nowhere for the computed value to
+appear. A `reflected,eval` run against one is therefore *not* evidence the target
+is clean, so when every in-band probe comes back negative RCEKit now says so and
+names the methods that could still reach it:
+
+```
+[detect] A sink that returns NO OUTPUT cannot be confirmed by eval/reflected — there is
+nowhere for the computed value to appear, so a negative here does not rule out execution.
+Methods that reach a blind sink:
+[detect]   --methods oob --oob-host HOST      (needs egress from the target; confirms)
+[detect]   --methods file --webroot DIR --web-base-url URL   (needs a writable web root; confirms)
+[detect]   --methods time                     (no egress and no web root needed; needs-review only)
+```
 
 RCEKit screens each candidate separator with one cheap probe, then fires a
 controlled `0/N/2N` delay series through whichever one actually delayed, and

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -63,7 +63,16 @@ starting point — this page is for looking things up once you know what you wan
 
 ### Probe depth
 
-`full` sends three extra shapes per sink, each aimed at a filter that silences
+One extra shape is sent at **both** depths, because it costs a single shape and
+closes a whole filter class:
+
+- **space-free** (`echo${IFS}…`) — stripping spaces looks like it disarms
+  command injection and does not, since `${IFS}` is a space to the shell. Every
+  other probe carries a space, so this one filter silenced all of them. The
+  separator's trailing space is trimmed too (`;echo…`, not `; echo…`), and the
+  newline separator survives unchanged.
+
+`full` sends three further shapes per sink, each aimed at a filter that silences
 the canonical probes:
 
 - **substitution-free** (`awk`, bare `expr`) — both canonical probes route the

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.22.0"
+__version__ = "2.23.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -2469,6 +2469,25 @@ class DetectionMethod:
         a working break-out with broken ones and destroy the signal."""
         return self._wrap_variants(record, core, windows, evade)[0]
 
+    def _space_free_bodies(self, record: "PayloadRecord",
+                           core: str) -> List[Tuple[Optional[str], str]]:
+        """``(separator, body)`` pairs that contain no literal space at all.
+
+        The default separators carry a trailing space (``"; "``), which would
+        reintroduce the very character a space-stripping sink removes, so they
+        are trimmed here — no shell needs the space after ``;`` or ``&&``. The
+        newline separator is kept as-is: it is not a space, and a sink that
+        strips spaces still passes it through."""
+        if not self._needs_separator(record):
+            return [(None, core)]
+        pairs: List[Tuple[Optional[str], str]] = []
+        for separator in self._separators(windows=False):
+            trimmed = separator if separator == "\n" else separator.strip()
+            if " " in trimmed:
+                continue
+            pairs.append((separator, f"{trimmed}{core}"))
+        return pairs
+
     def _wrap_context(self, record: "PayloadRecord", body: str) -> str:
         """Escape ``body`` for the record's serialization context and apply the
         context break-out prefix/suffix — the same machinery the generator uses
@@ -2521,9 +2540,31 @@ class ReflectedMath(DetectionMethod):
             core_bt = f"echo {t1}{bt}{t2}"
             probes.extend(Probe(payload=payload, expected=f"{t1}{total}{t2}", forbidden=bt)
                           for payload in self._wrap_variants(record, core_bt))
+            probes.extend(self._space_free_probes(record, a, b, total, t1, t2))
             if self._depth() != "quick":
                 probes.extend(self._extended_probes(record, a, b, total, t1, t2, t3, core))
         return probes
+
+    def _space_free_probes(self, record: "PayloadRecord", a: int, b: int, total: int,
+                           t1: str, t2: str) -> List[Probe]:
+        """The same arithmetic proof with no literal space anywhere in it.
+
+        Stripping spaces is a filter of the same family as stripping ``;`` — it
+        looks like it disarms command injection and does not, because ``${IFS}``
+        is a space as far as the shell is concerned. Every other probe carries a
+        space, so this one filter silenced all of them and a target exploitable
+        by anyone who has met it reported clean.
+
+        Sent at both probe depths: it is one shape, and leaving a whole filter
+        class undetectable is not the kind of saving ``--probe-depth quick`` is
+        for. Skipped under ``--evade low``, which already applies the same
+        transform to every probe."""
+        if self.config.get("evade") == "low":
+            return []
+        core = f"echo${{IFS}}{t1}$(({a}+{b})){t2}"
+        return [Probe(payload=self._wrap_context(record, body), expected=f"{t1}{total}{t2}",
+                      forbidden=f"$(({a}+{b}))", separator=separator)
+                for separator, body in self._space_free_bodies(record, core)]
 
     def _extended_probes(self, record: "PayloadRecord", a: int, b: int, total: int,
                          t1: str, t2: str, t3: str, core: str) -> List[Probe]:
@@ -3049,6 +3090,34 @@ HIGH_RISK_CATEGORIES = {
     "reverse_shells", "download_execute", "credential_access",
     "lateral_movement", "container_escape", "cloud_metadata", "persistence",
 }
+
+
+def blind_sink_advice(method_names: List[str], args: Any) -> List[str]:
+    """What to run next when every in-band probe came back negative.
+
+    A sink that returns no output at all cannot be confirmed by a results-based
+    method — there is nowhere for the computed value to appear. That is not a
+    limitation to work around, it is what 'blind' means. But a run that only
+    prints "no execution confirmed" reads exactly like a clean target, and the
+    operator is left to remember unprompted which methods can still reach one.
+    So name them, and only the ones not already tried."""
+    in_band = {ReflectedMath.name, EvalExpr.name}
+    selected = set(method_names)
+    if not selected or not selected <= in_band:
+        # A blind-capable method already ran; its own verdict stands.
+        return []
+    lines = ["[detect] A sink that returns NO OUTPUT cannot be confirmed by "
+             f"{'/'.join(sorted(selected))} — there is nowhere for the computed value to "
+             "appear, so a negative here does not rule out execution. Methods that reach a "
+             "blind sink:"]
+    lines.append("[detect]   --methods oob --oob-host HOST      "
+                 "(needs egress from the target; confirms)")
+    if not (args.webroot and args.web_base_url):
+        lines.append("[detect]   --methods file --webroot DIR --web-base-url URL   "
+                     "(needs a writable web root; confirms)")
+    lines.append("[detect]   --methods time                     "
+                 "(no egress and no web root needed; needs-review only)")
+    return lines
 
 
 def partition_destructive(records: Iterator[PayloadRecord],
@@ -3872,6 +3941,8 @@ def main():
                 if len(errored) < len(results):
                     print("\n[detect] No execution confirmed. The target may be patched, or the probes "
                           "may not fit its sink/context (try --environments/--contexts).")
+                    for line in blind_sink_advice(method_names, args):
+                        print(line)
             return
         results = generator.run_verification(
             to_send, url=verify_url, method=method, data=verify_data,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2741,9 +2741,12 @@ class SeparatorSweepTestCase(unittest.TestCase):
         self.assertEqual(self.gen._encode_for_location(newline_probe, "query_value")[:3], "%0A")
 
     def test_separators_are_configurable(self):
+        # The space-free shape trims the separator's trailing space on purpose,
+        # so match the separator itself rather than the spelling.
         payloads = self._payloads({"separators": ["| "]})
         self.assertTrue(payloads)
-        self.assertTrue(all(p.startswith("| ") for p in payloads), payloads)
+        self.assertTrue(all(p.startswith("| ") or p.startswith("|e") for p in payloads),
+                        payloads)
 
     def test_sink_raw_still_sends_bare_commands(self):
         # With --sink-raw the input IS the whole command, so no probe may carry
@@ -2752,7 +2755,7 @@ class SeparatorSweepTestCase(unittest.TestCase):
         self.assertTrue(payloads)
         for payload in payloads:
             with self.subTest(payload=payload):
-                self.assertRegex(payload, r"^(echo|awk|expr) ")
+                self.assertRegex(payload, r"^(echo|awk|expr)(\s|\$\{IFS\})")
 
     def test_file_probes_get_a_distinct_target_file_per_separator(self):
         # Sharing one filename would make every probe's followup succeed as soon
@@ -3319,6 +3322,164 @@ class ProbeRoundsTestCase(unittest.TestCase):
             del rcekit.DETECTION_METHODS["endless"]
         self.assertEqual(len(results), 1)
         self.assertIn(f"{RCEKit.MAX_PROBE_ROUNDS} probes fired", results[0]["detail"])
+
+
+class SpaceFilterTestCase(unittest.TestCase):
+    """Stripping spaces is a filter of the same family as stripping ';' — it
+    looks like it disarms command injection and does not, because `${IFS}` is a
+    space as far as the shell is concerned. Every other probe carries a space,
+    so before this a target exploitable by anyone who has met the filter
+    reported clean unless the operator thought to pass `--evade low`."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.rec = make_record(environment="unix", context="raw")
+
+    def _payloads(self, config=None):
+        import random as _random
+        method = ReflectedMath(self.gen, config or {})
+        return [p.payload for p in method.build_probes(self.rec, _random.Random(1))]
+
+    def test_a_space_free_probe_is_sent_by_default(self):
+        space_free = [p for p in self._payloads() if " " not in p]
+        self.assertTrue(space_free, "every probe carries a space, so a space filter blocks all")
+        self.assertTrue(all("${IFS}" in p for p in space_free), space_free)
+
+    def test_the_separator_loses_its_trailing_space_too(self):
+        # "; echo…" would reintroduce the very character the sink strips. No
+        # shell needs the space after ';' or '&&'.
+        for payload in (p for p in self._payloads() if "${IFS}" in p):
+            with self.subTest(payload=payload):
+                self.assertNotIn(" ", payload)
+
+    def test_the_newline_separator_survives_the_space_free_shape(self):
+        # A newline is not a space, so a space-stripping sink passes it through.
+        self.assertTrue(any(p.startswith("\n") and "${IFS}" in p for p in self._payloads()))
+
+    def test_quick_depth_still_sends_the_space_free_shape(self):
+        # It costs one shape and closes a whole filter class, so it is not part
+        # of the depth trade-off.
+        self.assertTrue([p for p in self._payloads({"probe_depth": "quick"}) if " " not in p])
+
+    def test_evade_low_does_not_duplicate_it(self):
+        # --evade low already applies ${IFS} to every probe, so the dedicated
+        # variant would be a second copy of probes that are already space-free.
+        payloads = self._payloads({"evade": "low"})
+        self.assertTrue(all("${IFS}" in p for p in payloads))
+        self.assertEqual(len(payloads), len(set(payloads)))
+
+    def test_the_expected_value_is_still_unforgeable(self):
+        import random as _random
+        for probe in ReflectedMath(self.gen, {}).build_probes(self.rec, _random.Random(5)):
+            with self.subTest(payload=probe.payload):
+                self.assertNotIn(probe.expected, probe.payload)
+
+    def test_a_space_filtering_sink_is_confirmed_with_no_flags(self):
+        import os
+
+        def route(method, path, params, headers, body):
+            query = params.get("q", "").replace(" ", "")
+            pipe = os.popen("echo probing " + query + " 2>/dev/null")
+            out = pipe.read()
+            pipe.close()
+            return 200, out
+
+        with local_target(route) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/x?q=FUZZ", methods=["reflected"])
+        self.assertTrue([r for r in results if r["verdict"] == "confirmed"])
+
+    def test_a_space_filtering_sink_that_is_inert_stays_negative(self):
+        def route(method, path, params, headers, body):
+            return 200, "you searched for: " + params.get("q", "").replace(" ", "")
+
+        with local_target(route) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/x?q=FUZZ", methods=["reflected"])
+        self.assertTrue(results)
+        self.assertFalse([r for r in results if r["verdict"] == "confirmed"])
+
+
+class BlindSinkAdviceTestCase(unittest.TestCase):
+    """A sink that returns no output cannot be confirmed by a results-based
+    method — there is nowhere for the computed value to appear. That is what
+    'blind' means, not a limitation to route around. But a run that only says
+    "no execution confirmed" reads exactly like a clean target."""
+
+    class _Args:
+        def __init__(self, webroot=None, web_base_url=None):
+            self.webroot = webroot
+            self.web_base_url = web_base_url
+
+    def test_in_band_only_runs_get_the_advice(self):
+        lines = rcekit.blind_sink_advice(["reflected", "eval"], self._Args())
+        self.assertTrue(lines)
+        joined = "\n".join(lines)
+        for method in ("--methods oob", "--methods file", "--methods time"):
+            with self.subTest(method=method):
+                self.assertIn(method, joined)
+
+    def test_it_says_a_negative_does_not_rule_out_execution(self):
+        joined = "\n".join(rcekit.blind_sink_advice(["reflected"], self._Args()))
+        self.assertIn("does not rule out execution", joined)
+
+    def test_a_blind_capable_method_already_ran_so_no_advice(self):
+        for methods in (["oob"], ["time"], ["file"], ["reflected", "oob"],
+                        ["reflected", "eval", "time"]):
+            with self.subTest(methods=methods):
+                self.assertEqual(rcekit.blind_sink_advice(methods, self._Args()), [])
+
+    def test_no_methods_at_all_gets_no_advice(self):
+        self.assertEqual(rcekit.blind_sink_advice([], self._Args()), [])
+
+    def test_the_file_line_is_dropped_once_a_web_root_is_known(self):
+        args = self._Args(webroot="/var/www/html", web_base_url="https://t")
+        joined = "\n".join(rcekit.blind_sink_advice(["reflected"], args))
+        self.assertNotIn("--webroot DIR", joined)
+        self.assertIn("--methods oob", joined)
+
+    def test_time_is_marked_as_needs_review_only(self):
+        joined = "\n".join(rcekit.blind_sink_advice(["reflected"], self._Args()))
+        self.assertRegex(joined, r"--methods time.*needs-review only")
+
+
+class BlindSinkAdviceCLITestCase(unittest.TestCase):
+    """The advice has to reach the operator through the real CLI, and only when
+    it applies."""
+
+    def _detect(self, route, *extra):
+        with local_target(route) as base:
+            return subprocess.run(
+                [sys.executable, str(SCRIPT), "--acknowledge-consent",
+                 "--verify-url", f"{base}/x?q=FUZZ", "--environments", "unix",
+                 "--contexts", "raw", "--categories", "basic_enum", *extra],
+                capture_output=True, text=True, timeout=300)
+
+    def test_a_blind_sink_is_told_what_would_reach_it(self):
+        import os
+
+        def route(method, path, params, headers, body):
+            pipe = os.popen("echo probing " + params.get("q", "") + " >/dev/null 2>&1")
+            pipe.read()
+            pipe.close()
+            return 200, "queued"
+
+        result = self._detect(route, "--methods", "reflected,eval")
+        self.assertIn("NO OUTPUT", result.stdout)
+        self.assertIn("--methods oob", result.stdout)
+
+    def test_a_confirmed_run_is_not_lectured(self):
+        import os
+
+        def route(method, path, params, headers, body):
+            pipe = os.popen("echo probing " + params.get("q", "") + " 2>/dev/null")
+            out = pipe.read()
+            pipe.close()
+            return 200, out
+
+        result = self._detect(route, "--methods", "reflected")
+        self.assertIn("CONFIRMED execution", result.stdout)
+        self.assertNotIn("NO OUTPUT", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The three sinks v2.22.0 could not reach. They turned out to be two different problems: one was a real gap in the probe set, the other two were a **reporting** problem rather than a detection one.

With both closed, a single `--methods reflected,eval,oob` run confirms **15 of the 15** vulnerable sinks in the lab, with nothing reported on any of the five clean ones.

## The space filter was a real gap

Stripping spaces is a filter of the same family as stripping `;` — it looks like it disarms command injection and does not, because `${IFS}` is a space as far as the shell is concerned. Every probe RCEKit sends carries a space, so that single filter silenced all of them, and the sink was reachable only if the operator happened to think of `--evade low`.

One space-free shape now ships with the canonical probes:

```
;echo${IFS}RKABQXR$((487659+861729))RKKXUVT
```

The separator's trailing space is trimmed with it — `;echo…`, not `; echo…` — since reintroducing the exact character the sink strips would defeat the point, and no shell needs a space after `;` or `&&`. The newline separator is left alone: it is a separator, not a space, and a space-stripping sink passes it through.

It is deliberately **not** part of the `--probe-depth` trade-off. It costs one shape, and leaving a whole filter class undetectable is not the kind of saving `quick` is for — the space-filtering sink is confirmed at `quick` depth in 15 probes. It is skipped under `--evade low`, which already applies the same transform to every probe and would otherwise just produce duplicates.

## The two blind sinks were never a detection gap

A results-based method **cannot** confirm a sink that returns no output. There is nowhere for the computed value to appear. That is what "blind" means, not a limitation to route around, and no probe shape will change it.

What was wrong is that such a run printed the same `No execution confirmed` that a genuinely patched target prints — so a negative that proves nothing read exactly like a clean result. That is the same class of mistake as reporting a delivery error as `negative`, which this project already treats as a bug worth fixing.

A `reflected`/`eval`-only run that confirms nothing now says so, and names what would reach it:

```
[detect] A sink that returns NO OUTPUT cannot be confirmed by eval/reflected — there is
nowhere for the computed value to appear, so a negative here does not rule out execution.
Methods that reach a blind sink:
[detect]   --methods oob --oob-host HOST      (needs egress from the target; confirms)
[detect]   --methods file --webroot DIR --web-base-url URL   (needs a writable web root; confirms)
[detect]   --methods time                     (no egress and no web root needed; needs-review only)
```

Suppressed once a blind-capable method has already run — its own verdict stands — and the `file` line is dropped once a web root is known.

## Results

Same twenty-sink lab as v2.22.0.

| | v2.22.0 | this branch |
|---|---|---|
| One `reflected,eval,oob` run, vulnerable sinks | 12/15 | **15/15** |
| False positives on the clean five | 0 | **0** |
| Space-filtering sink, no flags | miss | confirmed (also at `quick`) |
| Blind sink, in-band methods only | silent negative | negative **plus** what to run next |

Precision re-checked after adding the shape: all three inert reflecting sinks stay negative across 130 probes each.

## Notes

- Version `2.22.0` to `2.23.0` (MINOR). README badge and `CHANGELOG.md` updated.
- Tests: **235 to 251, all green.** 16 new; two existing tests asserted the exact spelling of a separator prefix (`"| "`) and needed to match the separator rather than its spacing, now that one shape trims it on purpose.
- No flag changes. Existing invocations behave as before, plus the extra shape.
