### PR TITLE
fix(detection): honour the safety tier, screen every separator, name the live channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ formats, or the template schema.
 
 ## [Unreleased]
 
+## [2.23.2] — 2026-08-04
+
+Three findings from a review of the detection work in 2.22.0 and 2.23.0. All
+three are the same shape: the run said something that was not true — about what
+it had done, about what it had looked for, or about which channel was live.
+
+### Fixed
+
+- **`--methods oob` ignored `--verify-active-risk`.** Detection methods build
+  their own probes and so bypass every corpus-level safety filter. That was
+  harmless while every method was inert, but this one makes the target open
+  outbound connections — and the same run printed *"low-impact (safe) payloads
+  only; pass `--verify-active-risk intrusive` to also fire … OOB"* and then fired
+  OOB anyway. It now needs `--verify-active-risk intrusive`, the same tier that
+  holds back the corpus OOB payloads, and refuses before the listener binds.
+- **`--probe-depth quick` silently narrowed the timing separator screen to
+  `; `.** That put back the exact blind spot the screen was added to remove, so
+  a sink that merely filters `;` reported negative — and only for the operator
+  who chose `quick` to be gentle on a rate-limited target. Both depths now screen
+  every candidate separator; `--probe-depth` governs probe *shapes* only, and
+  `--separators` remains the way to narrow break-outs deliberately.
+- **The DNS out-of-band probes could not call back on the default port, and
+  nothing said so.** A DNS callback travels the real resolver hierarchy, so it
+  only arrives if the listener *is* the authority for the OOB domain — port 53
+  plus NS delegation. On `--listen-dns-port 5335` the DNS shapes were still sent,
+  never fired, and the startup line reported `DNS :5335` with no caveat. Since
+  most of the shapes are DNS ones — a resolver is often the only egress a
+  hardened target has — the silence was expensive. RCEKit now says which channel
+  is live.
+- The blind-sink advice added in 2.23.0 suggested an `oob` command without the
+  risk flag, which the gate above would refuse. Naming a command the tool then
+  declines to run is a small version of the same problem, so it now spells out
+  `--verify-active-risk intrusive`.
+
 ## [2.23.1] — 2026-08-03
 
 ### Added
@@ -219,7 +253,8 @@ this file and have not been restated here.
 - **[2.7.0]**
 - **[2.1.0]**
 
-[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.23.1...HEAD
+[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.23.2...HEAD
+[2.23.2]: https://github.com/kabiri-labs/rcekit/compare/v2.23.1...v2.23.2
 [2.23.1]: https://github.com/kabiri-labs/rcekit/compare/v2.23.0...v2.23.1
 [2.23.0]: https://github.com/kabiri-labs/rcekit/compare/v2.22.0...v2.23.0
 [2.22.0]: https://github.com/kabiri-labs/rcekit/compare/v2.21.1...v2.22.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.23.1** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.23.2** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -178,6 +178,11 @@ shapes use `awk` and a bare `expr`, and one set comments out whatever the
 application appends after the injection point. Pass `--probe-depth quick` on a
 rate-limited target to halve the requests and send only the canonical probes.
 
+It governs probe *shapes* only — never which break-outs are tried. Both depths
+sweep every separator, and both screen every separator in `--methods time`,
+because dropping one is not a saving in requests but a blind spot. Narrow that
+deliberately with `--separators`.
+
 **Scope the environments to cut noise.** The shell methods (`reflected`, `file`,
 `time`) apply to any environment whose runtime reaches a shell — the shell
 environments themselves *plus* the language runtimes, because PHP's `system()`,
@@ -307,7 +312,7 @@ names the methods that could still reach it:
 [detect] A sink that returns NO OUTPUT cannot be confirmed by eval/reflected — there is
 nowhere for the computed value to appear, so a negative here does not rule out execution.
 Methods that reach a blind sink:
-[detect]   --methods oob --oob-host HOST      (needs egress from the target; confirms)
+[detect]   --methods oob --oob-host HOST --verify-active-risk intrusive   (needs egress from the target; confirms)
 [detect]   --methods file --webroot DIR --web-base-url URL   (needs a writable web root; confirms)
 [detect]   --methods time                     (no egress and no web root needed; needs-review only)
 ```
@@ -381,8 +386,13 @@ nothing and has no writable web root.
 ```bash
 python rcekit.py --acknowledge-consent \
   --verify-url "https://target.example/ping?ip=FUZZ" \
-  --methods reflected,oob --oob-host oob.example.com --listen-dns-port 53
+  --methods reflected,oob --oob-host oob.example.com \
+  --verify-active-risk intrusive --listen-dns-port 53
 ```
+
+It makes the target open outbound connections, so it sits behind the same safety
+tier as the corpus OOB payloads: `--verify-active-risk intrusive`, on top of
+`--oob-host`.
 
 `--oob-host` must be something the **target** can reach that arrives at your
 listener: a domain whose NS records are delegated to this host, or a routable IP.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -88,6 +88,11 @@ the canonical probes:
 `quick` sends only the canonical probes — roughly half the requests, for
 rate-limited targets or when the sink's shape is already known.
 
+`--probe-depth` governs probe *shapes* only. It does not narrow the separator
+sweep, and it does not narrow the separator screen `--methods time` runs: both
+depths try every candidate break-out, because dropping one is not a saving in
+requests but a blind spot. Use `--separators` to narrow that deliberately.
+
 ### Out-of-band detection
 
 `--methods oob` starts the built-in HTTP+DNS listener in-process and asks the
@@ -109,8 +114,16 @@ delegated here. With a bare IP the token rides in the URL path instead of a DNS
 label, and the DNS shapes are skipped rather than sent as probes that could
 never call back.
 
-This makes the target open outbound connections, so it never runs unless you
-name the host.
+**The DNS shapes need port 53.** A DNS callback travels the real resolver
+hierarchy, so it only arrives if this listener *is* the authority for the OOB
+domain — `--listen-dns-port 53` (needs root) plus NS records delegating the
+domain here. On any other port the DNS probes are still sent and can never call
+back; RCEKit says so at startup rather than leaving you to infer it from
+silence.
+
+This makes the target open outbound connections, so it is held back at the
+default safety tier — the same tier that holds back the corpus OOB payloads —
+and needs `--verify-active-risk intrusive` as well as `--oob-host`.
 
 ## Sink shape
 

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.23.1"
+__version__ = "2.23.2"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -2724,9 +2724,14 @@ class ParametricTime(DetectionMethod):
         self._rng = rng
         base = float(self.config.get("time_base", 2.0))
         windows = record.environment == "windows"
+        # Every candidate separator is screened at both probe depths. Narrowing
+        # this to the first one is the cheapest-looking saving here and the most
+        # expensive: it puts back the ';'-only blind spot the screen exists to
+        # remove, so a sink that merely filters ';' reports negative -- silently,
+        # and only for the operator who chose 'quick' to be gentle on a
+        # rate-limited target. --probe-depth trades probe *shapes* for requests;
+        # it does not trade away a break-out this method cannot detect without.
         separators = (self._separators(windows) if self._needs_separator(record) else (None,))
-        if self._depth() == "quick":
-            separators = separators[:1]
         probes = [Probe(payload=self._payload(record, 0.0, sep, windows), expected="",
                         delay_s=0.0, separator=sep, phase="screen")
                   for sep in separators]
@@ -3092,6 +3097,33 @@ HIGH_RISK_CATEGORIES = {
 }
 
 
+def oob_channel_warnings(args: Any, dns_up: bool) -> List[str]:
+    """Which of the OOB probe shapes can actually reach this listener.
+
+    A DNS callback travels the real resolver hierarchy: the target's resolver
+    asks the authoritative name server for ``--oob-host``, which has to *be*
+    this listener. That needs the listener on port 53 and NS records delegated
+    to it. On any other port the DNS probes are still sent and can never call
+    back, and the startup line reported ``DNS :5335`` with no hint of it — so
+    the operator read 'DNS covered' from a channel that was structurally dead.
+    Most of the shapes are DNS ones, precisely because a resolver is often the
+    only egress a hardened target has, which makes the silence expensive.
+
+    An address literal for ``--oob-host`` carries its token in the URL path
+    instead, so it never builds DNS probes and has nothing to warn about."""
+    if OobCallback._is_ip_literal(str(args.oob_host).strip().rstrip(".")):
+        return []
+    if not dns_up:
+        return ["[!] The DNS probes cannot call back: the DNS port could not be bound. "
+                "Only the HTTP shapes are live."]
+    if args.listen_dns_port != 53:
+        return [f"[!] The DNS probes cannot call back on port {args.listen_dns_port}: a resolver "
+                f"reaches the authority for {args.oob_host} on port 53 only. Run with "
+                "--listen-dns-port 53 (needs root) and NS records delegating that domain here, "
+                "or the DNS shapes are sent and silently never fire — only the HTTP ones are live."]
+    return []
+
+
 def blind_sink_advice(method_names: List[str], args: Any) -> List[str]:
     """What to run next when every in-band probe came back negative.
 
@@ -3110,7 +3142,9 @@ def blind_sink_advice(method_names: List[str], args: Any) -> List[str]:
              f"{'/'.join(sorted(selected))} — there is nowhere for the computed value to "
              "appear, so a negative here does not rule out execution. Methods that reach a "
              "blind sink:"]
-    lines.append("[detect]   --methods oob --oob-host HOST      "
+    # Spell the risk flag out. Advice that names a command the tool then refuses
+    # to run is its own small version of the problem this function exists for.
+    lines.append("[detect]   --methods oob --oob-host HOST --verify-active-risk intrusive   "
                  "(needs egress from the target; confirms)")
     if not (args.webroot and args.web_base_url):
         lines.append("[detect]   --methods file --webroot DIR --web-base-url URL   "
@@ -3862,6 +3896,20 @@ def main():
                           "--oob-host: an address the target can reach that arrives here (an IP on "
                           "a routable interface, or a domain delegated to this host).")
                     return 1
+                # Same gate the corpus OOB payloads have always had. Detection
+                # methods build their own probes and so bypass every corpus-level
+                # safety filter, which was fine while every method was inert --
+                # but this one makes the target open outbound connections. The
+                # plan printed 'low-impact (safe) payloads only ... pass
+                # --verify-active-risk intrusive to also fire ... OOB' and then
+                # fired OOB anyway: the run contradicted itself, and the tier the
+                # operator chose did not mean what it said.
+                if verify_max_safety == "safe":
+                    print("[!] --methods oob makes the TARGET open outbound connections, which is an "
+                          "active technique held back at the default safety tier — the same tier that "
+                          "holds back the corpus OOB payloads. Pass --verify-active-risk intrusive to "
+                          "allow it.")
+                    return 1
                 listener = OOBListener(answer_ip=args.listen_answer_ip, log_path=args.listen_log)
                 try:
                     listener.start_http(args.listen_http_port)
@@ -3874,6 +3922,8 @@ def main():
                       f"{f', DNS :{args.listen_dns_port}' if dns_up else ' (DNS port unavailable)'}; "
                       f"probes call back to {args.oob_host}. The target will open outbound "
                       "connections.")
+                for line in oob_channel_warnings(args, dns_up):
+                    print(line)
             if "file" in method_names:
                 if not (args.webroot and args.web_base_url):
                     print("[!] --methods file writes a file to the target and fetches it back, so it "

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -3423,6 +3423,14 @@ class BlindSinkAdviceTestCase(unittest.TestCase):
         joined = "\n".join(rcekit.blind_sink_advice(["reflected"], self._Args()))
         self.assertIn("does not rule out execution", joined)
 
+    def test_the_suggested_oob_command_is_one_the_tool_will_accept(self):
+        # oob is gated on the intrusive tier, so advice that omitted the flag
+        # would name a command the tool then refuses to run.
+        joined = "\n".join(rcekit.blind_sink_advice(["reflected"], self._Args()))
+        oob_line = next(line for line in joined.splitlines() if "--methods oob" in line)
+        self.assertIn("--oob-host", oob_line)
+        self.assertIn("--verify-active-risk intrusive", oob_line)
+
     def test_a_blind_capable_method_already_ran_so_no_advice(self):
         for methods in (["oob"], ["time"], ["file"], ["reflected", "oob"],
                         ["reflected", "eval", "time"]):
@@ -3480,6 +3488,134 @@ class BlindSinkAdviceCLITestCase(unittest.TestCase):
         result = self._detect(route, "--methods", "reflected")
         self.assertIn("CONFIRMED execution", result.stdout)
         self.assertNotIn("NO OUTPUT", result.stdout)
+
+
+class OobSafetyGateTestCase(unittest.TestCase):
+    """Detection methods build their own probes and so bypass every corpus-level
+    safety filter. That was harmless while every method was inert, but `oob`
+    makes the target open outbound connections — and the run printed 'pass
+    --verify-active-risk intrusive to also fire ... OOB' and then fired OOB
+    anyway, so the tier the operator chose did not mean what it said."""
+
+    def _run(self, *extra):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--acknowledge-consent",
+             "--verify-url", "http://127.0.0.1:9/x?q=FUZZ", "--environments", "unix",
+             "--contexts", "raw", "--categories", "basic_enum",
+             "--methods", "oob", "--oob-host", "oob.example.com", *extra],
+            capture_output=True, text=True, timeout=300)
+
+    def test_the_default_tier_refuses_and_exits_non_zero(self):
+        result = self._run()
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("--verify-active-risk intrusive", result.stdout)
+
+    def test_the_refusal_happens_before_the_listener_starts(self):
+        # Binding a port and telling the operator the listener is up, only to
+        # refuse afterwards, would be its own small lie.
+        result = self._run()
+        self.assertNotIn("OOB listener up", result.stdout)
+
+    def test_intrusive_allows_it(self):
+        result = self._run("--verify-active-risk", "intrusive",
+                           "--listen-http-port", "0")
+        self.assertIn("OOB listener up", result.stdout)
+
+    def test_the_plan_no_longer_contradicts_the_run(self):
+        # The 'held back ... and OOB' line is printed only at the safe tier, and
+        # the safe tier now refuses, so the two can never appear together.
+        allowed = self._run("--verify-active-risk", "intrusive", "--listen-http-port", "0")
+        self.assertNotIn("low-impact (safe) payloads only", allowed.stdout)
+        refused = self._run()
+        self.assertNotIn("[detect] sent", refused.stdout)
+
+    def test_other_methods_are_unaffected_by_the_gate(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--acknowledge-consent",
+             "--verify-url", "http://127.0.0.1:9/x?q=FUZZ", "--environments", "unix",
+             "--contexts", "raw", "--categories", "basic_enum", "--methods", "reflected"],
+            capture_output=True, text=True, timeout=300)
+        self.assertEqual(result.returncode, 0, result.stdout)
+
+
+class OobChannelWarningTestCase(unittest.TestCase):
+    """A DNS callback travels the real resolver hierarchy, so it only arrives if
+    this listener is the authority for the OOB domain — port 53 plus NS
+    delegation. On any other port the DNS probes are still sent and can never
+    call back, and the startup line said `DNS :5335` with no hint of it."""
+
+    class _Args:
+        def __init__(self, oob_host="oob.example.com", listen_dns_port=5335):
+            self.oob_host = oob_host
+            self.listen_dns_port = listen_dns_port
+
+    def test_a_non_standard_dns_port_is_called_out(self):
+        lines = rcekit.oob_channel_warnings(self._Args(), dns_up=True)
+        self.assertTrue(lines)
+        self.assertIn("port 53", lines[0])
+        self.assertIn("--listen-dns-port 53", lines[0])
+
+    def test_port_53_with_a_domain_is_silent(self):
+        self.assertEqual(
+            rcekit.oob_channel_warnings(self._Args(listen_dns_port=53), dns_up=True), [])
+
+    def test_a_failed_dns_bind_is_called_out(self):
+        lines = rcekit.oob_channel_warnings(self._Args(listen_dns_port=53), dns_up=False)
+        self.assertTrue(lines)
+        self.assertIn("cannot call back", lines[0])
+
+    def test_an_ip_host_has_no_dns_probes_to_warn_about(self):
+        # With an address literal the token rides in the URL path and no DNS
+        # shape is ever built, so there is nothing to warn about.
+        for host in ("10.0.0.1", "127.0.0.1"):
+            with self.subTest(host=host):
+                self.assertEqual(
+                    rcekit.oob_channel_warnings(self._Args(oob_host=host), dns_up=False), [])
+
+    def test_the_warning_reaches_the_operator(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--acknowledge-consent",
+             "--verify-url", "http://127.0.0.1:9/x?q=FUZZ", "--environments", "unix",
+             "--contexts", "raw", "--categories", "basic_enum", "--methods", "oob",
+             "--oob-host", "oob.example.com", "--verify-active-risk", "intrusive",
+             "--listen-http-port", "0"],
+            capture_output=True, text=True, timeout=300)
+        self.assertIn("DNS probes cannot call back", result.stdout)
+
+
+class TimingScreenDepthTestCase(unittest.TestCase):
+    """`--probe-depth quick` trades probe *shapes* for requests. Narrowing the
+    timing screen to the first separator looked like the same kind of saving and
+    was not: it put back the ';'-only blind spot the screen exists to remove, so
+    a sink that merely filters ';' reported negative — silently, and only for the
+    operator who chose 'quick' to be gentle on a rate-limited target."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.rec = make_record(environment="unix", context="raw")
+
+    def _separators(self, depth):
+        import random as _random
+        probes = ParametricTime(self.gen, {"time_base": 1.0, "probe_depth": depth}).build_probes(
+            self.rec, _random.Random(1))
+        return {p.separator for p in probes}
+
+    def test_both_depths_screen_every_separator(self):
+        expected = {"; ", "| ", "|| ", "&& ", "\n"}
+        self.assertEqual(self._separators("quick"), expected)
+        self.assertEqual(self._separators("full"), expected)
+
+    def test_the_two_depths_screen_identically(self):
+        self.assertEqual(self._separators("quick"), self._separators("full"))
+
+    def test_an_explicit_separator_list_still_narrows_it(self):
+        # Cutting the request count by naming the sink's shape stays available;
+        # it is just no longer a silent side effect of --probe-depth.
+        import random as _random
+        probes = ParametricTime(
+            self.gen, {"time_base": 1.0, "separators": ["| "]}).build_probes(
+            self.rec, _random.Random(1))
+        self.assertEqual({p.separator for p in probes}, {"| "})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Three findings from reviewing the detection work in 2.22.0 and 2.23.0. All three are the same shape: **the run said something that was not true** — about what it had done, about what it had looked for, or about which channel was live.

## 1. `--methods oob` ignored `--verify-active-risk`

Detection methods build their own probes and so bypass every corpus-level safety filter. That was harmless while every method was inert — `echo`, `awk`, `sleep`. This one makes the target open outbound connections, and the same run printed:

```
[plan] low-impact (safe) payloads only; pass --verify-active-risk intrusive to also fire
       reverse shells, download-execute, credential access, lateral movement and OOB.
[detect] OOB listener up ... The target will open outbound connections.
[detect] sent 30 probes
```

The run contradicted itself in its own output, and the tier the operator selected did not mean what it said. This is the same class as the v2.21.1 fix that made chains carry the single-request safeguards.

It now requires `--verify-active-risk intrusive` — the tier that already holds back the corpus OOB payloads — and refuses with exit 1 **before** binding a listener port, so it never announces a listener it is about to abandon.

The blind-sink advice added in 2.23.0 had the mirror image of the same fault: it suggested an `oob` command without the risk flag, which the new gate would refuse. It now spells the flag out.

## 2. `--probe-depth quick` silently narrowed the timing separator screen

Reduced to `; ` only. That is the cheapest-looking saving available there and the most expensive: it puts back the exact `;`-only blind spot the screen was added in 2.22.0 to remove.

Demonstrated on a sink that filters `;` but is exploitable through a pipe:

| | before | after |
|---|---|---|
| `--probe-depth quick` | `negative` | `needs-review` |
| `--probe-depth full` | `needs-review` | `needs-review` |

The operator who picks `quick` is the one being careful with a rate-limited target, and they were the only one getting the silent miss. Both depths now screen every candidate separator. `--probe-depth` trades probe *shapes* for requests; `--separators` remains the way to narrow break-outs deliberately.

## 3. The DNS out-of-band probes could not call back, and nothing said so

A DNS callback travels the real resolver hierarchy: the target's resolver asks the authority for the OOB domain, which has to *be* this listener. That needs port 53 plus NS delegation. On the default `--listen-dns-port 5335` the DNS shapes were still built and sent, could never call back, and the startup line reported `DNS :5335` with no caveat.

Four of the six Unix shapes are DNS ones — deliberately, since a resolver is often the only egress a hardened target has — so this was most of the method going quietly nowhere:

```
[detect] OOB listener up on HTTP :8961, DNS :5335; probes call back to x.example. ...
[!] The DNS probes cannot call back on port 5335: a resolver reaches the authority for
    x.example on port 53 only. Run with --listen-dns-port 53 (needs root) and NS records
    delegating that domain here, or the DNS shapes are sent and silently never fire —
    only the HTTP ones are live.
```

Silent when the listener is on port 53, and silent for an address literal, which builds no DNS shapes at all.

## Verification

Same twenty-sink lab. Detection is unchanged where it should be:

- `;`-filtering sink: timing candidate at **both** probe depths.
- Safe tier + `oob`: exit 1, no listener bound, no probes sent.
- Intrusive tier + `oob`: runs, and the plan's "held back … OOB" line is not printed, so the two can no longer appear together.
- Full matrix: still **15/15** vulnerable sinks confirmed, **0/3** false positives on the clean ones.

## Notes

- Rebased onto `main` after #49 landed. That PR also claimed `2.23.1`, so this is now **`2.23.2`** — the collision was the real content of the `CHANGELOG.md` conflict, not the prose. #49's `2.23.1` section is preserved untouched.
- Version `2.23.1` to `2.23.2` (PATCH). Bug fixes, and the affected behaviour ships in 2.22.0/2.23.0, neither of which is tagged or released — so no published interface changes. Say the word if you would rather this were MINOR.
- Tests: **251 to 265, all green.** 14 new, covering the gate, the refusal ordering, the channel warning, the screen depth, and the advice line's own consistency.
- No new flags and no new capability. `--methods oob` gains one required flag; every other invocation is unchanged.
