### PR TITLE
perf(detection): stop paying for probes and waits that cannot produce a result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ formats, or the template schema.
 
 ## [Unreleased]
 
+## [2.23.3] — 2026-08-04
+
+Four items from the same review: requests and seconds spent on work that could
+not produce a result. No verdict changes — the lab still confirms 15 of 15
+vulnerable sinks with nothing on the clean five — the run just stops paying for
+probes that were structurally unable to confirm.
+
+### Changed
+
+- **The `awk` probe is no longer sent into a context that wraps the payload in
+  quotes.** It carries double quotes, so in `attribute` the quote closed early
+  and the rest was not a command: 5 requests per carrier that could only ever
+  come back negative. Measured on a verbose shell sink, that shape confirmed 8
+  times in `raw` and 0 times in `attribute`. Break-out contexts such as
+  `shell_double_quoted` *close* the sink's quote and comment its tail, so they
+  still get it. The same guard covers the PowerShell out-of-band shape.
+- **The timing screen runs in two waves.** Every delayed screen probe costs a
+  real sleep, so screening all five separators up front spent `5 × base` seconds
+  on every carrier, including the ones that cannot break out at all. `; ` and
+  `| ` are screened first and the rest only if neither delayed — a sink that
+  filters both is still swept, it is just no longer the price everyone pays.
+- **The out-of-band callback window is no longer paid per carrier.** Callbacks
+  land in a burst once the channel works, so a target that has not produced one
+  across every probe fired so far is not going to. The first carrier still gets
+  the full window, so a target that does call back is never cut short before its
+  first hit. On a clean target with the default carriers this was 30s of pure
+  waiting; it is now ~12s.
+- **`--probe-depth` documents what it does on Windows**, which is nothing:
+  `cmd.exe` has no `#` comment, no `${IFS}` and no `awk`, so both depths send
+  the single `set /a` probe. The docs promised three extra shapes per sink
+  without that caveat.
+
 ## [2.23.2] — 2026-08-04
 
 Three findings from a review of the detection work in 2.22.0 and 2.23.0. All
@@ -253,7 +285,8 @@ this file and have not been restated here.
 - **[2.7.0]**
 - **[2.1.0]**
 
-[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.23.2...HEAD
+[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.23.3...HEAD
+[2.23.3]: https://github.com/kabiri-labs/rcekit/compare/v2.23.2...v2.23.3
 [2.23.2]: https://github.com/kabiri-labs/rcekit/compare/v2.23.1...v2.23.2
 [2.23.1]: https://github.com/kabiri-labs/rcekit/compare/v2.23.0...v2.23.1
 [2.23.0]: https://github.com/kabiri-labs/rcekit/compare/v2.22.0...v2.23.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.23.2** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.23.3** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -183,6 +183,10 @@ sweep every separator, and both screen every separator in `--methods time`,
 because dropping one is not a saving in requests but a blind spot. Narrow that
 deliberately with `--separators`.
 
+The extra shapes are all Unix ones — `cmd.exe` has no `#` comment, no `${IFS}`
+and no `awk` — so `--environments windows` sends the same single probe at either
+depth.
+
 **Scope the environments to cut noise.** The shell methods (`reflected`, `file`,
 `time`) apply to any environment whose runtime reaches a shell — the shell
 environments themselves *plus* the language runtimes, because PHP's `system()`,

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -77,7 +77,11 @@ the canonical probes:
 
 - **substitution-free** (`awk`, bare `expr`) — both canonical probes route the
   arithmetic through `$((…))` or a backtick, so a sink that strips `$(` blocks
-  them while remaining exploitable through a plain `;`.
+  them while remaining exploitable through a plain `;`. The `awk` shape carries
+  double quotes, so it is not sent into a context that *wraps* the payload in
+  them (`attribute`): the quote would close early and the probe could only ever
+  come back negative. Break-out contexts such as `shell_double_quoted` close the
+  sink's quote and comment its tail, so they still get it.
 - **keyword-diverse** (`awk` again) — a filter on `echo`/`expr` blocks both
   canonical probes; `awk` is not on those blocklists.
 - **comment-terminated** (`… #`) — comments out whatever the application appends
@@ -87,6 +91,10 @@ the canonical probes:
 
 `quick` sends only the canonical probes — roughly half the requests, for
 rate-limited targets or when the sink's shape is already known.
+
+**All of these shapes are Unix.** `cmd.exe` has no `#` comment, no `${IFS}`, and
+no `awk`, so `--environments windows` gets the one `set /a` probe at either
+depth and `--probe-depth` changes nothing for it.
 
 `--probe-depth` governs probe *shapes* only. It does not narrow the separator
 sweep, and it does not narrow the separator screen `--methods time` runs: both

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.23.2"
+__version__ = "2.23.3"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -1682,9 +1682,11 @@ class RCEKit:
         return results
 
     # How many times an aggregate method may answer with a further probe batch.
-    # Two is what a screen-then-measure method needs; the bound exists so a
-    # buggy method cannot drive the engine forever against a live target.
-    MAX_PROBE_ROUNDS = 3
+    # The timing method needs three (two screening waves, then the regression);
+    # the fourth is slack, so a method that grows a phase is not silently
+    # truncated. The bound exists so a buggy method cannot drive the engine
+    # forever against a live target.
+    MAX_PROBE_ROUNDS = 4
 
     @staticmethod
     def _quoted_shell_carriers(carriers: List[PayloadRecord],
@@ -2457,6 +2459,8 @@ class DetectionMethod:
         for body in bodies:
             if evade and not windows and self.config.get("evade") == "low":
                 body = body.replace(" ", "${IFS}")
+            if self._context_swallows(record, body):
+                continue
             payloads.append(self._wrap_context(record, body))
         return payloads
 
@@ -2487,6 +2491,32 @@ class DetectionMethod:
                 continue
             pairs.append((separator, f"{trimmed}{core}"))
         return pairs
+
+    def _context_swallows(self, record: "PayloadRecord", body: str) -> bool:
+        """Whether this context would break ``body`` rather than carry it.
+
+        A context that opens *and* closes with the same quote puts the payload
+        **inside** that quote — ``attribute`` wraps it in ``"``. A probe whose
+        body also contains that quote closes it early and the rest is no longer
+        a command, so the probe is structurally unable to execute: it costs a
+        request and can only ever come back negative. Measured on a verbose
+        shell sink, the ``awk`` shape confirmed 8 times in ``raw`` and 0 times
+        in ``attribute``, while the quote-free shapes confirmed in both.
+
+        A break-out context is the opposite case and must not be caught here:
+        ``shell_double_quoted`` (``"; `` … `` #``) *closes* the sink's quote and
+        comments out its tail, so quotes in the body are fine — verified.
+
+        Only for contexts that pass the body through verbatim. Where an escape
+        rule applies, the quote is the serialization layer's, and what the sink
+        finally sees depends on the parser in between."""
+        ctx = self.gen.contexts.get(record.context, {})
+        prefix, suffix = ctx.get("prefix", ""), ctx.get("suffix", "")
+        if ctx.get("escape", "none") != "none":
+            return False
+        if prefix and prefix == suffix and prefix in ('"', "'"):
+            return prefix in body
+        return False
 
     def _wrap_context(self, record: "PayloadRecord", body: str) -> str:
         """Escape ``body`` for the record's serialization context and apply the
@@ -2706,6 +2736,10 @@ class ParametricTime(DetectionMethod):
     _record: Optional["PayloadRecord"] = None
     _rng: Optional["random.Random"] = None
     _separator: Optional[str] = None
+    _pending_separators: Tuple[Optional[str], ...] = ()
+    # Separators screened before the rest: ';' and '|' break out of the large
+    # majority of sinks, so most carriers never pay for the other three.
+    SCREEN_FIRST_WAVE = 2
 
     def applicable(self, record: "PayloadRecord") -> bool:
         return record.environment in SHELL_CAPABLE_ENVIRONMENTS
@@ -2732,6 +2766,18 @@ class ParametricTime(DetectionMethod):
         # rate-limited target. --probe-depth trades probe *shapes* for requests;
         # it does not trade away a break-out this method cannot detect without.
         separators = (self._separators(windows) if self._needs_separator(record) else (None,))
+        # Screen in two waves. Each delayed screen probe costs a real sleep, so
+        # screening all five separators up front spent `5 x base` seconds on
+        # every carrier -- including the carriers that can never break out at
+        # all. The first wave is the two separators that work on the large
+        # majority of sinks; the rest are only screened if neither delayed.
+        self._pending_separators = tuple(separators[self.SCREEN_FIRST_WAVE:])
+        return self._screen_probes(record, separators[:self.SCREEN_FIRST_WAVE], base, windows, rng)
+
+    def _screen_probes(self, record: "PayloadRecord", separators, base: float,
+                       windows: bool, rng: "random.Random") -> List[Probe]:
+        """A paired 0s/base probe per separator. The pair is what keeps a
+        uniformly slow endpoint from reading as a break-out."""
         probes = [Probe(payload=self._payload(record, 0.0, sep, windows), expected="",
                         delay_s=0.0, separator=sep, phase="screen")
                   for sep in separators]
@@ -2774,6 +2820,12 @@ class ParametricTime(DetectionMethod):
         gains = {sep: slow[sep] - quick.get(sep, 0.0) for sep in slow if sep in quick}
         candidates = [sep for sep, gain in gains.items() if gain >= 0.6 * base]
         if not candidates:
+            # Nothing in the first wave broke out. Screen the separators held
+            # back rather than concluding anything from a partial sweep -- a
+            # sink that filters ';' and '|' is exactly the case the sweep is for.
+            pending, self._pending_separators = self._pending_separators, ()
+            if pending:
+                return self._screen_probes(self._record, pending, base, windows, self._rng)
             return []
         best = max(candidates, key=lambda sep: gains[sep])
         self._separator = best
@@ -2936,6 +2988,8 @@ class OobCallback(DetectionMethod):
     # probe asked the target to evaluate. Reporting detail only.
     _shape: Dict[str, str] = {}
     _computed: Optional[int] = None
+    # Whether any carrier has already been given the full callback window.
+    _waited_once: bool = False
 
     def applicable(self, record: "PayloadRecord") -> bool:
         if not self.config.get("oob_host"):
@@ -2977,6 +3031,10 @@ class OobCallback(DetectionMethod):
                 token = self._token(rng)
                 core = core_for_token(token)
                 body = core if separator is None else f"{separator}{core}"
+                # The PowerShell shape carries double quotes, so a context that
+                # wraps the payload in them cannot execute it.
+                if self._context_swallows(record, body):
+                    continue
                 payload = self._wrap_context(record, body)
                 probes.append(Probe(payload=payload, expected=token, separator=separator))
                 self._shape[token] = label
@@ -3039,6 +3097,17 @@ class OobCallback(DetectionMethod):
         if listener is None:
             return [(probe, Verdict("error", "no OOB listener was started"))
                     for probe, _ in series]
+        # The full window is only worth paying while a callback is still
+        # plausible. Callbacks land in a burst once the channel works, so if not
+        # one has arrived across every probe fired so far, this target is not
+        # calling back and the remaining carriers need a grace period, not the
+        # whole window. Without this the run slept `wait` seconds per carrier --
+        # 30s of pure waiting on a clean target with the default carriers -- for
+        # nothing. The first carrier always gets the full window, so a target
+        # that does call back is never cut short before its first hit.
+        if self._waited_once and not listener.hits:
+            wait = min(wait, 1.5)
+        self._waited_once = True
         deadline = time.time() + wait
         wanted = {probe.expected for probe, _ in series}
         while time.time() < deadline:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2117,14 +2117,37 @@ class ParametricTimeTestCase(unittest.TestCase):
         self.assertEqual(len({p.separator for p in regression}), 1)
 
     def test_no_separator_delays_means_no_regression_is_run(self):
+        # The screen runs in waves, so "nothing broke out" is only a conclusion
+        # once every separator has been tried -- a sink that filters ';' and '|'
+        # is exactly the case the sweep exists for.
+        import random as _random
+        record = make_record(environment="unix", context="raw")
+        series, batch = [], self.method.build_probes(record, _random.Random(1))
+        waves = 0
+        while batch:
+            waves += 1
+            series += [(p, Observation(status=200, body="", elapsed=0.1)) for p in batch]
+            batch = self.method.next_probes(series)
+        self.assertGreater(waves, 1, "the held-back separators must still be screened")
+        self.assertEqual({p.separator for p, _ in series},
+                         {"; ", "| ", "|| ", "&& ", "\n"})
+        self.assertFalse([p for p, _ in series if p.phase == "regress"])
+        verdict = self.method.confirm_series(series)
+        self.assertEqual(verdict.status, "negative")
+        self.assertIn("no command separator produced a delay", verdict.evidence)
+
+    def test_a_first_wave_hit_skips_the_rest_of_the_screen(self):
+        # Each delayed screen probe costs a real sleep, so the separators held
+        # back are never sent once one has already broken out.
         import random as _random
         record = make_record(environment="unix", context="raw")
         screen = self.method.build_probes(record, _random.Random(1))
-        flat = [(p, Observation(status=200, body="", elapsed=0.1)) for p in screen]
-        self.assertEqual(self.method.next_probes(flat), [])
-        verdict = self.method.confirm_series(flat)
-        self.assertEqual(verdict.status, "negative")
-        self.assertIn("no command separator produced a delay", verdict.evidence)
+        series = [(p, Observation(status=200, body="",
+                                  elapsed=(p.delay_s or 0.0) + 0.05)) for p in screen]
+        nxt = self.method.next_probes(series)
+        self.assertTrue(nxt)
+        self.assertTrue(all(p.phase == "regress" for p in nxt),
+                        "a working separator must go straight to the regression")
 
     def test_confirm_series_linear_response_is_needs_review(self):
         verdict = self.method.confirm_series(
@@ -2781,16 +2804,22 @@ class SeparatorSweepTestCase(unittest.TestCase):
         # merely filters ';' as negative, while '| sleep 3' delayed on it.
         import random as _random
         method = ParametricTime(self.gen, {"time_base": 1.0})
-        screen = method.build_probes(self.rec, _random.Random(1))
-        for separator in ("; ", "| ", "|| ", "&& ", "\n"):
+        # Only the pipe breaks out on this imaginary sink. Drive the screen to
+        # exhaustion: it runs in waves, so a separator missing from the first
+        # batch is held back, not dropped.
+        series, batch, regression = [], method.build_probes(self.rec, _random.Random(1)), []
+        while batch:
+            if all(p.phase == "regress" for p in batch):
+                regression = batch
+                break
+            series += [(p, Observation(status=200, body="",
+                                       elapsed=(p.delay_s or 0.0) + 0.05 if p.separator == "| "
+                                       else 0.05)) for p in batch]
+            batch = method.next_probes(series)
+        screened = {p.payload[:2] for p, _ in series}
+        for separator in ("; ", "| "):
             with self.subTest(separator=separator):
-                self.assertTrue(any(p.payload.startswith(separator) for p in screen))
-        # Only the pipe breaks out on this imaginary sink.
-        series = [(p, Observation(status=200, body="",
-                                  elapsed=(p.delay_s or 0.0) + 0.05 if p.separator == "| "
-                                  else 0.05))
-                  for p in screen]
-        regression = method.next_probes(series)
+                self.assertIn(separator, screened)
         self.assertTrue(regression)
         self.assertEqual({p.separator for p in regression}, {"| "})
 
@@ -3490,6 +3519,130 @@ class BlindSinkAdviceCLITestCase(unittest.TestCase):
         self.assertNotIn("NO OUTPUT", result.stdout)
 
 
+class QuoteWrappingContextTestCase(unittest.TestCase):
+    """A context that opens *and* closes with the same quote puts the payload
+    inside it, so a probe body carrying that quote closes it early and the rest
+    is no longer a command. Those probes cost a request and can only ever come
+    back negative."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+
+    def _payloads(self, context):
+        import random as _random
+        return [p.payload for p in ReflectedMath(self.gen, {}).build_probes(
+            make_record(environment="unix", context=context), _random.Random(1))]
+
+    def test_the_quote_carrying_shape_is_not_sent_into_a_wrapping_context(self):
+        self.assertFalse([p for p in self._payloads("attribute") if "awk" in p])
+
+    def test_the_quote_free_shapes_still_are(self):
+        payloads = self._payloads("attribute")
+        self.assertTrue(payloads)
+        self.assertTrue([p for p in payloads if "$((" in p])
+        self.assertTrue([p for p in payloads if "${IFS}" in p])
+
+    def test_a_break_out_context_still_gets_it(self):
+        # shell_double_quoted CLOSES the sink's quote and comments its tail, so
+        # quotes in the body are fine there — the opposite case, and it must not
+        # be caught by the same guard.
+        self.assertTrue([p for p in self._payloads("shell_double_quoted") if "awk" in p])
+
+    def test_raw_is_untouched(self):
+        self.assertTrue([p for p in self._payloads("raw") if "awk" in p])
+
+    def test_the_guard_only_applies_to_verbatim_contexts(self):
+        # Where an escape rule applies, the quote belongs to the serialization
+        # layer and what the sink sees depends on the parser in between.
+        method = ReflectedMath(self.gen, {})
+        yaml_record = make_record(environment="unix", context="yaml")
+        self.assertFalse(method._context_swallows(yaml_record, 'awk "x"'))
+        attr_record = make_record(environment="unix", context="attribute")
+        self.assertTrue(method._context_swallows(attr_record, 'awk "x"'))
+        self.assertFalse(method._context_swallows(attr_record, "echo x"))
+
+    def test_detection_is_unchanged_by_the_guard(self):
+        # The removed probes were the ones that could never confirm, so a real
+        # sink must still be confirmed in exactly the contexts it was before.
+        import os
+
+        def route(method, path, params, headers, body):
+            pipe = os.popen("echo probing " + params.get("q", "") + " 2>/dev/null")
+            out = pipe.read()
+            pipe.close()
+            return 200, out
+
+        with local_target(route) as base:
+            results = self.gen.run_detection(
+                [make_record(environment="unix", context="attribute")],
+                url=f"{base}/x?q=FUZZ", methods=["reflected"])
+        self.assertTrue([r for r in results if r["verdict"] == "confirmed"])
+
+
+class OobWaitTestCase(unittest.TestCase):
+    """The callback window is only worth paying while a callback is plausible.
+    Callbacks land in a burst once the channel works, so a target that has not
+    produced a single one across every probe fired so far is not going to."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.rec = make_record(environment="unix", context="raw")
+
+    def _method(self, listener, wait=3.0):
+        return rcekit.OobCallback(self.gen, {"oob_host": "x.example",
+                                             "oob_listener": listener, "oob_wait": wait})
+
+    def test_the_first_carrier_gets_the_full_window(self):
+        import time as _time
+        listener = OOBListener()
+        method = self._method(listener, wait=1.0)
+        import random as _random
+        probes = method.build_probes(self.rec, _random.Random(1))[:1]
+        series = [(probes[0], Observation(status=200, body="ok"))]
+        started = _time.time()
+        method.confirm_each(series)
+        self.assertGreaterEqual(_time.time() - started, 0.9)
+
+    def test_later_carriers_are_cut_short_when_nothing_ever_called_back(self):
+        import time as _time
+        listener = OOBListener()
+        method = self._method(listener, wait=30.0)
+        method._waited_once = True
+        import random as _random
+        probes = method.build_probes(self.rec, _random.Random(1))[:1]
+        series = [(probes[0], Observation(status=200, body="ok"))]
+        started = _time.time()
+        method.confirm_each(series)
+        self.assertLess(_time.time() - started, 5.0)
+
+    def test_a_live_channel_still_gets_the_full_window(self):
+        # One hit anywhere means callbacks are flowing, so later carriers must
+        # not be cut short.
+        import time as _time
+        listener = OOBListener()
+        listener.record("http", "10.0.0.9", "somewhere", "/earlier-token")
+        method = self._method(listener, wait=1.0)
+        method._waited_once = True
+        import random as _random
+        probes = method.build_probes(self.rec, _random.Random(1))[:1]
+        series = [(probes[0], Observation(status=200, body="ok"))]
+        started = _time.time()
+        method.confirm_each(series)
+        self.assertGreaterEqual(_time.time() - started, 0.9)
+
+    def test_cutting_the_wait_short_never_changes_a_verdict_that_had_arrived(self):
+        listener = OOBListener()
+        method = self._method(listener, wait=30.0)
+        method._waited_once = True
+        import random as _random
+        probes = method.build_probes(self.rec, _random.Random(1))[:2]
+        listener.record("dns", "10.0.0.9", f"{probes[0].expected}.x.example")
+        series = [(p, Observation(status=200, body="ok")) for p in probes]
+        verdicts = {p.payload: v.status for p, v in method.confirm_each(series)}
+        self.assertEqual(verdicts[probes[0].payload], "confirmed")
+        self.assertEqual(verdicts[probes[1].payload], "negative")
+
+
 class OobSafetyGateTestCase(unittest.TestCase):
     """Detection methods build their own probes and so bypass every corpus-level
     safety filter. That was harmless while every method was inert, but `oob`
@@ -3595,10 +3748,16 @@ class TimingScreenDepthTestCase(unittest.TestCase):
         self.rec = make_record(environment="unix", context="raw")
 
     def _separators(self, depth):
+        """Every separator the screen tries, across all of its waves."""
         import random as _random
-        probes = ParametricTime(self.gen, {"time_base": 1.0, "probe_depth": depth}).build_probes(
-            self.rec, _random.Random(1))
-        return {p.separator for p in probes}
+        method = ParametricTime(self.gen, {"time_base": 1.0, "probe_depth": depth})
+        series, batch, seen = [], method.build_probes(self.rec, _random.Random(1)), set()
+        while batch and not any(p.phase == "regress" for p in batch):
+            seen |= {p.separator for p in batch}
+            # Nothing breaks out, so the screen keeps widening until exhausted.
+            series += [(p, Observation(status=200, body="", elapsed=0.1)) for p in batch]
+            batch = method.next_probes(series)
+        return seen
 
     def test_both_depths_screen_every_separator(self):
         expected = {"; ", "| ", "|| ", "&& ", "\n"}


### PR DESCRIPTION
The four efficiency items from the same review. **None of them changes a verdict** — the lab still confirms 15 of 15 vulnerable sinks with nothing on the clean five. They are requests and seconds spent on work that was structurally unable to confirm.

## The `awk` probe was sent where it could never run

It carries double quotes. The `attribute` context wraps the payload in double quotes, so the quote closed early and what followed was no longer a command.

Measured on a verbose shell sink, grouped by context and shape:

| context | shape | confirmed |
|---|---|---|
| `attribute` | arithmetic / backtick / space-free | 5 each |
| `attribute` | **awk** | **0** |
| `raw` | awk | 8 |

Five requests per carrier that could only ever come back negative.

A break-out context is the opposite case and must not be caught by the same guard: `shell_double_quoted` *closes* the sink's quote and comments its tail, so quotes in the body are fine there. Verified directly against a shell — the break-out form prints the computed value, the wrapping form prints nothing at all.

The guard applies only where the context passes the body through verbatim; where an escape rule applies the quote belongs to the serialization layer and what the sink sees depends on the parser in between. It also covers the PowerShell out-of-band shape, which has the same problem.

## The timing screen paid for every separator on every carrier

Each delayed screen probe costs a real sleep, so screening all five separators up front spent `5 × base` seconds per carrier — including the carriers that cannot break out at all, which is most of them.

It now screens `; ` and `| ` first and widens to the rest **only if neither delayed**. A sink that filters both is still swept; it is just no longer the price everyone pays. The engine's round budget goes from 3 to 4 so the extra wave is not silently truncated.

## The out-of-band callback window was paid per carrier

Callbacks land in a burst once the channel works, so a target that has not produced a single one across every probe fired so far is not going to. The first carrier always gets the full window, so a target that *does* call back is never cut short before its first hit; later carriers get a grace period instead of the whole thing.

## `--probe-depth` on Windows

It does nothing there — `cmd.exe` has no `#` comment, no `${IFS}` and no `awk`, so both depths send the single `set /a` probe. There was no waste to remove; the docs simply promised three extra shapes per sink without that caveat, so they now say it.

## Measured

| | before | after |
|---|---|---|
| `reflected` on a verbose sink | 95 probes, 43 confirmed | **90 probes, 43 confirmed** |
| `time` on a blind sink | 44 req, 26.4s | **38 req, 22.4s** |
| `oob` on a clean target, default carriers | 30.4s | **12.4s** |
| Full lab matrix | 15/15, 0/3 | **15/15, 0/3** |

## Notes

- Version `2.23.2` to `2.23.3` (PATCH).
- Tests: **265 to 276, all green.** 11 new. Four existing timing tests encoded the single-wave screen and were rewritten to assert the property that matters — every separator is *eventually* screened — rather than the shape of one batch.
- No flag changes, no behaviour changes an operator would notice beyond the run being shorter.
