### PR TITLE
feat(bench): check coverage claims against real targets instead of asserting them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,18 @@ from a given response; it cannot prove it confirms Webmin.
   images — so it runs by hand or in a dedicated job, and exits non-zero if any
   case fails. Two cases ship, transcribed from `docs/verify-it-yourself.md`:
   Webmin CVE-2019-15107 and Struts2 S2-001.
-- **A negative control is a required key.** The runner refuses to load a case
-  without one, refuses a control that expects `confirmed`, and refuses a control
-  that just repeats the vulnerable invocation. A benchmark without controls
-  measures nothing: a tool that shouted `confirmed` at every target would score
-  full marks on the vulnerable half. Three kinds are supported — a patched
-  build, the same target probed for the wrong class, and a weaker method that
-  must stay below `confirmed` on a target where it happens to be right.
+- **A negative control is a required key.** A benchmark without controls measures
+  nothing: a tool that shouted `confirmed` at every target would score full marks
+  on the vulnerable half. Three kinds are supported — a patched build, the same
+  target probed for the wrong class, and a weaker method that must stay below
+  `confirmed` on a target where it happens to be right. The runner refuses four
+  shapes of non-control: no control at all; one expecting `confirmed`; one that
+  runs the identical invocation against an identical target (judged on what it
+  would actually run, so an explicit copy of the vulnerable invocation is caught
+  as well as an omitted one); and one expecting `error` or `nothing-tested`,
+  since both mean the target was never exercised and such a control would stay
+  green with the detection engine entirely broken. Validation and execution
+  share one `control_plan` so they cannot drift.
 - **`overall_detection_verdict`** collapses a run to one verdict, ordered by what
   an operator must not miss rather than by frequency: one `confirmed` among a
   hundred negatives is the finding. `error` is reported only when *nothing*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,54 @@ formats, or the template schema.
 
 ## [Unreleased]
 
+## [2.25.0] — 2026-08-16
+
+A coverage benchmark, so a claim about what RCEKit confirms can be checked
+instead of asserted. The unit suite proves the tool reaches the right verdict
+from a given response; it cannot prove it confirms Webmin.
+
+### Added
+
+- **`--detect-json PATH`** writes a detection run as JSON: the run's overall
+  verdict, per-verdict counts, and every probe with its payload, method, context
+  and evidence. Text output is unchanged. This is the supported way to consume a
+  run programmatically — scraping stdout cannot be made reliable, because a
+  probe payload may contain a literal newline (the newline separator is a real
+  one, so line-oriented parsing splits a payload in half) and the detection path
+  exits 0 whether it confirmed or came back clean.
+- **`tests/bench/` — the coverage benchmark harness.** Each case brings a real
+  vulnerable build up, runs RCEKit as an operator would, checks the verdict, and
+  tears it down; `--markdown` emits the coverage table. Not part of
+  `python -m unittest discover -s tests` — cases need Docker and pull real
+  images — so it runs by hand or in a dedicated job, and exits non-zero if any
+  case fails. Two cases ship, transcribed from `docs/verify-it-yourself.md`:
+  Webmin CVE-2019-15107 and Struts2 S2-001.
+- **A negative control is a required key.** The runner refuses to load a case
+  without one, refuses a control that expects `confirmed`, and refuses a control
+  that just repeats the vulnerable invocation. A benchmark without controls
+  measures nothing: a tool that shouted `confirmed` at every target would score
+  full marks on the vulnerable half. Three kinds are supported — a patched
+  build, the same target probed for the wrong class, and a weaker method that
+  must stay below `confirmed` on a target where it happens to be right.
+- **`overall_detection_verdict`** collapses a run to one verdict, ordered by what
+  an operator must not miss rather than by frequency: one `confirmed` among a
+  hundred negatives is the finding. `error` is reported only when *nothing*
+  reached the target, and a run that built no probes is `nothing-tested` —
+  never `negative`, which would read as "not vulnerable".
+
+### Changed
+
+- `CONTRIBUTING.md` asks for a bench case alongside new detection coverage, and
+  for the README table to state the tier the case actually reached.
+
+### Notes
+
+- The two shipped cases have **not yet been executed through the harness** — it
+  was written where no Docker daemon was available. Their invocations come from
+  a documented, reproduced guide, but the case files themselves are unvalidated;
+  `tests/bench/README.md` says so and flags the one field that is a guess. No
+  README claim was changed to assert benchmark results.
+
 ## [2.24.0] — 2026-08-16
 
 The computed value is no longer looked for in the response body alone. A sink
@@ -341,7 +389,8 @@ this file and have not been restated here.
 - **[2.7.0]**
 - **[2.1.0]**
 
-[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.24.0...HEAD
+[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.25.0...HEAD
+[2.25.0]: https://github.com/kabiri-labs/rcekit/compare/v2.24.0...v2.25.0
 [2.24.0]: https://github.com/kabiri-labs/rcekit/compare/v2.23.3...v2.24.0
 [2.23.3]: https://github.com/kabiri-labs/rcekit/compare/v2.23.2...v2.23.3
 [2.23.2]: https://github.com/kabiri-labs/rcekit/compare/v2.23.1...v2.23.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,3 +55,30 @@ To add one:
 4. Add a `/vuln` (executes) vs `/reflect` (echoes) test to
    `DetectionMethodTestCase`: the method must `confirm` on `/vuln` and stay
    unconfirmed on `/reflect`. No third-party deps; keep the suite green on 3.8+.
+5. Add a **bench case** (see below). A unit test proves the method reaches the
+   right verdict from a given response; only a bench case proves it reaches that
+   verdict against the real software.
+
+## Adding a bench case
+
+`tests/bench/` runs RCEKit against real vulnerable targets and checks the
+verdicts, so a coverage claim can be checked rather than asserted. It needs
+Docker and a [vulhub](https://github.com/vulhub/vulhub) checkout, so it is
+deliberately **not** part of `python -m unittest discover -s tests`:
+
+```bash
+python tests/bench/runner.py --list
+python tests/bench/runner.py --all --vulhub-root ~/vulhub --markdown coverage.md
+```
+
+New detection coverage should arrive with a case. Every case needs a **negative
+control** — the runner refuses to load one without it — because a benchmark with
+no controls rewards aggressive probing instead of measuring accuracy. The
+control may be a patched build, the same target probed for the wrong class, or a
+weaker method that must stay below `confirmed` on a target where it happens to
+be right.
+
+Run your case against the real target before submitting, and update the README
+table with the verdict tier it **actually** reached. A README claim the bench
+cannot reproduce is worse than a missing feature.
+[`tests/bench/README.md`](tests/bench/README.md) documents the case format.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.24.0** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.25.0** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -52,6 +52,7 @@ starting point — this page is for looking things up once you know what you wan
 | `--separators` | Break-out separators for shell probes; `\n` = newline | `; `, `\| `, `\|\| `, `&& `, newline |
 | `--evade` | WAF posture: `none`, or `low` for minimal `${IFS}`-for-spaces | `none` |
 | `--probe-depth` | `full` (also the substitution-free and comment-terminated shapes) or `quick` | `full` |
+| `--detect-json` | Also write the run to this path as JSON: overall verdict, counts, every probe | None |
 
 | `--methods` value | Confirms | Tier it can reach |
 |---|---|---|
@@ -100,6 +101,36 @@ depth and `--probe-depth` changes nothing for it.
 sweep, and it does not narrow the separator screen `--methods time` runs: both
 depths try every candidate break-out, because dropping one is not a saving in
 requests but a blind spot. Use `--separators` to narrow that deliberately.
+
+### Machine-readable results
+
+`--detect-json PATH` writes the run as JSON alongside the usual text report:
+
+```json
+{
+  "rcekit_version": "2.25.0",
+  "target": "https://target.example/lookup?host=FUZZ",
+  "methods": ["reflected"],
+  "verdict": "confirmed",
+  "counts": {"confirmed": 4, "negative": 9},
+  "probes": [{"verdict": "confirmed", "method": "reflected", "environment": "unix",
+              "context": "raw", "payload": "...", "detail": "target computed ..."}]
+}
+```
+
+Use it instead of parsing stdout. Two things make the text report unsafe to
+scrape: a probe payload may contain a literal newline — the newline separator is
+a real one — so line-oriented parsing splits a payload in half, and the
+detection path exits 0 whether it confirmed or came back clean.
+
+The top-level `verdict` collapses the run, ordered by what you must not miss
+rather than by what is most frequent: one `confirmed` among a hundred negatives
+is the finding. `error` appears only when *nothing* reached the target, and a run
+that built no probes is `nothing-tested` — never `negative`, which would read as
+"not vulnerable".
+
+This is the channel [`tests/bench/`](../tests/bench/README.md) reads to check
+verdicts against real vulnerable targets.
 
 ### Out-of-band detection
 

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.24.0"
+__version__ = "2.25.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -3352,6 +3352,57 @@ HIGH_RISK_CATEGORIES = {
 }
 
 
+def overall_detection_verdict(results: List[Dict[str, Any]]) -> str:
+    """The one verdict that describes a whole detection run.
+
+    Ordered by what the operator must not miss, and deliberately not by
+    frequency: one ``confirmed`` among a hundred negatives is the finding, so it
+    wins. ``needs-review`` outranks ``negative`` for the same reason.
+
+    ``error`` is reported only when *nothing* reached the target. A run that
+    reached the target and found nothing is a real negative even if some probes
+    errored on the way; a run where every probe failed to arrive tested nothing
+    at all, and calling that ``negative`` would read as "not vulnerable".
+    ``nothing-tested`` is its sibling: no probes were built, so there is not
+    even a delivery to speak of."""
+    if not results:
+        return "nothing-tested"
+    verdicts = {result["verdict"] for result in results}
+    for tier in ("confirmed", "needs-review"):
+        if tier in verdicts:
+            return tier
+    if verdicts == {"error"}:
+        return "error"
+    if "inconclusive" in verdicts:
+        return "inconclusive"
+    return "negative"
+
+
+def write_detection_json(path: str, results: List[Dict[str, Any]], target: str,
+                         methods: List[str]) -> None:
+    """Write a detection run to ``path`` as JSON.
+
+    The machine-readable sibling of the ``[detect]`` text report, for callers
+    that need the outcome rather than a human summary — the benchmark harness
+    is the first. Scraping stdout cannot work: a probe payload may contain a
+    literal newline (the newline separator is a real one, so line-oriented
+    parsing splits a payload in half), and the detection path exits 0 whether it
+    confirmed or came back clean."""
+    counts: Dict[str, int] = {}
+    for result in results:
+        counts[result["verdict"]] = counts.get(result["verdict"], 0) + 1
+    payload = {
+        "rcekit_version": __version__,
+        "target": target,
+        "methods": list(methods),
+        "verdict": overall_detection_verdict(results),
+        "counts": counts,
+        "probes": results,
+    }
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+
+
 def oob_channel_warnings(args: Any, dns_up: bool) -> List[str]:
     """Which of the OOB probe shapes can actually reach this listener.
 
@@ -3802,6 +3853,13 @@ def main():
                              "time (hardened blind-timing regression, needs-review only). "
                              "Opt-in and additive: when omitted, verification keeps its existing behaviour "
                              "unchanged.")
+    parser.add_argument("--detect-json", default=None, metavar="PATH",
+                        help="(--methods) Also write the detection results to PATH as JSON: the run's "
+                             "overall verdict, per-verdict counts, and every probe with its payload, "
+                             "method, context and evidence. Text output is unchanged. Use this instead "
+                             "of scraping stdout — a probe payload may contain a literal newline, and "
+                             "the process exit status does not distinguish a confirmation from a clean "
+                             "negative.")
     parser.add_argument("--verify-chain", default=None,
                         help="Path to a JSON chain profile: deliver each payload through a multi-step, "
                              "session-aware flow (login/CSRF -> prerequisites -> payload delivery -> trigger) "
@@ -4193,6 +4251,17 @@ def main():
                 url_location=args.verify_url_location, body_location=args.verify_body_location,
                 config=detection_config,
             )
+            if args.detect_json:
+                # Written before the text report and regardless of outcome, so a
+                # caller always gets a file to read -- including the
+                # nothing-tested case, which is exactly the one a benchmark must
+                # not mistake for a clean negative.
+                try:
+                    write_detection_json(args.detect_json, results, verify_url, method_names)
+                    print(f"[detect] results written to {args.detect_json}")
+                except OSError as exc:
+                    print(f"[!] could not write --detect-json {args.detect_json}: {exc}")
+                    return 1
             by_verdict = {}
             for result in results:
                 by_verdict[result["verdict"]] = by_verdict.get(result["verdict"], 0) + 1

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -37,8 +37,24 @@ Docker.
 A benchmark without negative controls measures nothing. A tool that shouted
 `confirmed` at every target would score full marks on the vulnerable half, and
 the harness would report that as progress. So a case passes only when **both**
-halves land, and `negative_control` is a required key — the runner refuses to
-load a case without one, and refuses a control that expects `confirmed`.
+halves land, and `negative_control` is a required key.
+
+The runner refuses to load a case whose control cannot measure anything:
+
+- **No control at all.**
+- **A control that expects `confirmed`** — a contradiction.
+- **A control that runs the identical invocation against an identical target.**
+  Judged on what it would actually run, not on which keys it declares: copying
+  the vulnerable `invocation` into the control is the same non-control as
+  omitting it. Vary the invocation (a different method or injection point) or
+  the target (a patched build). Reusing the *same* target with a *different*
+  invocation is the normal case and is fine.
+- **A control that expects `error` or `nothing-tested`.** Both mean the run never
+  exercised the target, so such a control would stay green with the detection
+  engine entirely broken — exactly what a control exists to catch. A control may
+  expect `negative`, `inconclusive`, or `needs-review`. (The vulnerable half may
+  still expect `error`: "an unreachable target reports `error`, not `negative`"
+  is a real property worth pinning.)
 
 Controls come in three kinds. All three share one invariant: the control must
 not reach `confirmed`.

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -1,0 +1,122 @@
+# Coverage benchmark
+
+The unit suite proves RCEKit builds the right payloads and reaches the right
+verdict from a given response. It cannot prove RCEKit confirms **Webmin**.
+
+This harness closes that gap. Each case points at a real vulnerable build, runs
+the tool the way an operator would, and checks the verdict against what the
+README claims. It is what makes a coverage claim checkable instead of asserted.
+
+## Running it
+
+Cases that declare a `vulhub_path` need Docker and a
+[vulhub](https://github.com/vulhub/vulhub) checkout:
+
+```bash
+git clone https://github.com/vulhub/vulhub.git ~/vulhub
+
+python tests/bench/runner.py --list
+python tests/bench/runner.py --case webmin-cve-2019-15107 --vulhub-root ~/vulhub
+python tests/bench/runner.py --all --vulhub-root ~/vulhub --markdown coverage.md
+```
+
+Exit status is 0 only when every case passed, so this drops into CI as-is.
+
+> These are deliberately vulnerable services. Run them on a machine you control
+> and tear them down afterwards. The runner passes `--acknowledge-consent` for
+> you, because a bench target is one you started yourself moments earlier — only
+> point cases at infrastructure you own.
+
+It is **not** part of `python -m unittest discover -s tests`. Cases pull real
+images and take minutes; the default suite must stay fast and dependency-free.
+The harness's own tests do run there (`tests/test_bench_runner.py`) and need no
+Docker.
+
+## Every case has a control
+
+A benchmark without negative controls measures nothing. A tool that shouted
+`confirmed` at every target would score full marks on the vulnerable half, and
+the harness would report that as progress. So a case passes only when **both**
+halves land, and `negative_control` is a required key — the runner refuses to
+load a case without one, and refuses a control that expects `confirmed`.
+
+Controls come in three kinds. All three share one invariant: the control must
+not reach `confirmed`.
+
+| Kind | What it proves | Example |
+|---|---|---|
+| `patched-build` | The tool does not confirm on a fixed version | same case against a patched image |
+| `class-attribution` | The tool names the class, rather than flagging the parameter | S2-001 probed with `reflected` → `negative` |
+| `tier-ceiling` | A weaker signal is not promoted on a target where it happens to be right | Webmin probed with `time` → `needs-review` |
+
+The third is the one people skip, and it is the one that protects the tool's
+central promise. Timing produces no computed value; if it were ever promoted to
+`confirmed` on a genuinely vulnerable sink, the erosion would look like a
+success.
+
+## Case format
+
+```json
+{
+  "name": "webmin-cve-2019-15107",
+  "rce_class": "OS command injection (results-based)",
+  "target": "Webmin 1.910 — CVE-2019-15107",
+  "vulhub_path": "webmin/CVE-2019-15107",
+  "wait_for": {"url": "https://127.0.0.1:10000/", "status": 200, "timeout": 180},
+  "invocation": ["-r", "{bench}/requests/webmin.txt", "-p", "old", "--methods", "reflected"],
+  "expect": "confirmed",
+  "expect_method": "reflected",
+  "negative_control": {"kind": "tier-ceiling", "invocation": ["..."], "expect": "needs-review"}
+}
+```
+
+| Key | Meaning |
+|---|---|
+| `vulhub_path` | Directory under `--vulhub-root`; the runner runs `docker compose up -d` there |
+| `compose` / `compose_down` | Explicit argv, when the standard compose commands are not enough |
+| `wait_for` | Poll until the target answers, so a slow boot is not read as a regression |
+| `invocation` | RCEKit arguments; `--acknowledge-consent` and `--detect-json` are added by the runner |
+| `expect` | `confirmed`, `needs-review`, `negative`, `inconclusive`, `error`, `nothing-tested` |
+| `expect_method` | Optional. `reflected`, or the full carrier `reflected/unix/raw` |
+| `negative_control` | Required. Its own `invocation` and/or `compose`, plus its `expect` |
+
+`{bench}` and `{repo}` in an `invocation` expand to this directory and the repo
+root, so a case can reference a captured request without a fragile relative path.
+
+Omit `vulhub_path` and `compose` to benchmark a target that is **already
+running** — useful for a target you brought up by hand, and how the harness's
+own tests run without Docker.
+
+## Why the runner reads JSON, not stdout
+
+The runner appends `--detect-json` and reads the result from there. Scraping the
+text report cannot be made reliable: a probe payload may contain a literal
+newline — the newline separator is a real one — so line-oriented parsing splits
+a payload in half, and the detection path exits 0 whether it confirmed or came
+back clean.
+
+The overall verdict follows what an operator must not miss, not what is most
+frequent: one `confirmed` among a hundred negatives is the finding. `error` is
+reported only when *nothing* reached the target, and a run that built no probes
+is `nothing-tested` — never `negative`, which would read as "not vulnerable".
+
+## Adding a case
+
+New detection coverage should arrive with a bench case. Write the case, run it
+against the real target, and paste the generated table row into the README next
+to the claim it supports. If a class only reaches `needs-review`, say so — the
+README table must not outrun the engine.
+
+## Status
+
+The two shipped cases are transcribed from
+[`docs/verify-it-yourself.md`](../../docs/verify-it-yourself.md), whose
+reproductions are documented as verified against vulhub. **They have not yet been
+executed through this harness** — it was written in an environment with no Docker
+daemon — so treat the first run as validation of the case files themselves. The
+`struts2-s2-001` case in particular guesses `/login.action` and `username` from
+vulhub's defaults, where that document deliberately tells the operator to read
+the form off the running app; its `notes` say so and how to check.
+
+Nothing in the repository's README has been changed to claim benchmark results.
+The coverage table becomes generated output once these cases have actually run.

--- a/tests/bench/cases/struts2-s2-001.json
+++ b/tests/bench/cases/struts2-s2-001.json
@@ -1,0 +1,46 @@
+{
+  "name": "struts2-s2-001",
+  "rce_class": "Expression injection (OGNL)",
+  "target": "Apache Struts2 — S2-001",
+  "vulhub_path": "struts2/s2-001",
+  "compose": ["docker", "compose", "up", "-d", "--build"],
+  "compose_down": ["docker", "compose", "down", "-v"],
+  "wait_for": {
+    "url": "http://127.0.0.1:8080/",
+    "status": 200,
+    "timeout": 240
+  },
+  "invocation": [
+    "--verify-url", "http://127.0.0.1:8080/login.action",
+    "--verify-method", "POST",
+    "--verify-data", "username=FUZZ",
+    "--methods", "eval"
+  ],
+  "expect": "confirmed",
+  "expect_method": "eval",
+  "negative_control": {
+    "kind": "class-attribution",
+    "invocation": [
+      "--verify-url", "http://127.0.0.1:8080/login.action",
+      "--verify-method", "POST",
+      "--verify-data", "username=FUZZ",
+      "--methods", "reflected"
+    ],
+    "expect": "negative"
+  },
+  "notes": [
+    "The control is class attribution: the same vulnerable target, probed for the",
+    "wrong class, must come back clean. S2-001 re-evaluates submitted values as",
+    "OGNL — there is no shell behind it — so the shell-syntax probes of `reflected`",
+    "have nothing to execute. A tool that confirmed here would be flagging the",
+    "parameter, not the class.",
+    "Both halves are stated as reproduced in docs/verify-it-yourself.md.",
+    "UNVERIFIED IN THIS FORM: that document deliberately tells the operator to read",
+    "the form's action and field name off the running app rather than trusting a",
+    "guess. /login.action + username are vulhub's documented defaults for s2-001,",
+    "but this case has not been executed. Confirm them on the first run:",
+    "  curl -s http://127.0.0.1:8080/ | grep -iE '<form|<input'",
+    "and correct this file if they differ.",
+    "--build is in the compose command because vulhub's s2-001 ships a Dockerfile."
+  ]
+}

--- a/tests/bench/cases/webmin-cve-2019-15107.json
+++ b/tests/bench/cases/webmin-cve-2019-15107.json
@@ -1,0 +1,43 @@
+{
+  "name": "webmin-cve-2019-15107",
+  "rce_class": "OS command injection (results-based)",
+  "target": "Webmin 1.910 — CVE-2019-15107",
+  "vulhub_path": "webmin/CVE-2019-15107",
+  "wait_for": {
+    "url": "https://127.0.0.1:10000/",
+    "status": 200,
+    "timeout": 180
+  },
+  "invocation": [
+    "-r", "{bench}/requests/webmin.txt",
+    "-p", "old",
+    "--request-scheme", "https",
+    "--insecure",
+    "--methods", "reflected"
+  ],
+  "expect": "confirmed",
+  "expect_method": "reflected",
+  "negative_control": {
+    "kind": "tier-ceiling",
+    "invocation": [
+      "-r", "{bench}/requests/webmin.txt",
+      "-p", "old",
+      "--request-scheme", "https",
+      "--insecure",
+      "--methods", "time",
+      "--time-base", "3"
+    ],
+    "expect": "needs-review"
+  },
+  "notes": [
+    "The control here is a tier ceiling, not a patched build: the same genuinely",
+    "vulnerable sink, measured by timing, must stay `needs-review`. Timing produces",
+    "no computed value, so promoting it would break the guarantee that `confirmed`",
+    "means executed — and it would break it on a target where the promotion happens",
+    "to be correct, which is exactly how that guarantee erodes.",
+    "Invocation and both expectations come from docs/verify-it-yourself.md, which",
+    "documents this reproduction against vulhub.",
+    "--insecure is required: the cert is self-signed, and without it every probe is",
+    "reported `error` rather than `negative`."
+  ]
+}

--- a/tests/bench/requests/webmin.txt
+++ b/tests/bench/requests/webmin.txt
@@ -1,0 +1,7 @@
+POST /password_change.cgi HTTP/1.1
+Host: 127.0.0.1:10000
+Cookie: redirect=1; testing=1; sid=x; sessiontest=1
+Referer: https://127.0.0.1:10000/session_login.cgi
+Content-Type: application/x-www-form-urlencoded
+
+user=rootxx&pam=&expired=2&old=test&new1=test2&new2=test2

--- a/tests/bench/runner.py
+++ b/tests/bench/runner.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""RCEKit coverage benchmark — run the tool against real vulnerable targets.
+
+The unit tests prove RCEKit builds the right payloads and reaches the right
+verdict from a given response. They cannot prove it confirms *Webmin*. This
+harness closes that gap: each case points at a real vulnerable build, runs the
+tool exactly as an operator would, and checks the verdict against what the
+README claims.
+
+Every case carries a **negative control** — a build or an endpoint that is not
+vulnerable and must come back clean. That is not paperwork. A benchmark without
+negative controls measures nothing: a tool that shouted `confirmed` at every
+target would score full marks on the vulnerable half and the harness would call
+it progress. A case passes only when both halves land.
+
+Not part of ``python -m unittest discover -s tests``: cases need Docker and pull
+real images, so they are opt-in and run by hand or in a dedicated job.
+
+    python tests/bench/runner.py --list
+    python tests/bench/runner.py --case webmin-cve-2019-15107
+    python tests/bench/runner.py --all --markdown coverage.md
+
+Cases whose target is already running (no ``compose`` key) need no Docker at
+all, which is also how the harness itself is tested.
+
+Only point cases at infrastructure you own or are authorised to test. The runner
+passes ``--acknowledge-consent`` on your behalf, because a bench case is a
+target you started yourself moments earlier.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+BENCH_ROOT = Path(__file__).resolve().parent
+CASES_DIR = BENCH_ROOT / "cases"
+REPO_ROOT = BENCH_ROOT.parent.parent
+RCEKIT = REPO_ROOT / "rcekit.py"
+
+# A case must say what it expects, where to point the tool, and how to prove the
+# result is not just an over-eager scanner. The negative control is required by
+# design -- see the module docstring.
+REQUIRED_KEYS = ("name", "rce_class", "target", "invocation", "expect", "negative_control")
+VALID_EXPECTATIONS = ("confirmed", "needs-review", "negative", "inconclusive",
+                      "error", "nothing-tested")
+
+
+class CaseError(Exception):
+    """A case file that cannot be trusted to measure anything."""
+
+
+def validate_case(case: Dict[str, Any], source: str = "<case>") -> Dict[str, Any]:
+    """Reject a case that cannot produce a meaningful result.
+
+    Loud and early: a benchmark that silently skips a malformed case reports a
+    smaller number of failures than reality, which is the one failure mode a
+    benchmark must not have."""
+    missing = [key for key in REQUIRED_KEYS if key not in case]
+    if missing:
+        raise CaseError(f"{source}: missing required key(s): {', '.join(missing)}")
+    if not isinstance(case["invocation"], list) or not case["invocation"]:
+        raise CaseError(f"{source}: 'invocation' must be a non-empty list of CLI arguments")
+    if case["expect"] not in VALID_EXPECTATIONS:
+        raise CaseError(f"{source}: 'expect' must be one of {', '.join(VALID_EXPECTATIONS)}, "
+                        f"got {case['expect']!r}")
+    control = case["negative_control"]
+    if not isinstance(control, dict):
+        raise CaseError(f"{source}: 'negative_control' must be an object")
+    if "invocation" not in control and "compose" not in control:
+        raise CaseError(f"{source}: 'negative_control' needs its own 'invocation' or 'compose' — "
+                        "a control that reuses the vulnerable target's is not a control")
+    control_expect = control.get("expect", "negative")
+    if control_expect == "confirmed":
+        raise CaseError(f"{source}: a negative control expecting 'confirmed' is a contradiction")
+    if control_expect not in VALID_EXPECTATIONS:
+        raise CaseError(f"{source}: negative_control 'expect' must be one of "
+                        f"{', '.join(VALID_EXPECTATIONS)}, got {control_expect!r}")
+    return case
+
+
+def load_case(path: Path) -> Dict[str, Any]:
+    """Read and validate one case file."""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            case = json.load(handle)
+    except ValueError as exc:
+        raise CaseError(f"{path}: not valid JSON ({exc})")
+    return validate_case(case, str(path))
+
+
+def discover_cases(cases_dir: Path = CASES_DIR) -> List[Path]:
+    return sorted(cases_dir.glob("*.json"))
+
+
+def wait_for_target(url: str, status: int = 200, timeout: float = 120.0,
+                    interval: float = 2.0, insecure: bool = True) -> bool:
+    """Poll ``url`` until it answers with ``status``, or ``timeout`` elapses.
+
+    A container that is up is not a container that is ready, and running the
+    tool against a half-started service produces an `error` verdict that looks
+    like a benchmark regression. Any HTTP answer counts as reachable — a 401 or
+    500 still means the server is listening — but the case's expected status is
+    what ends the wait."""
+    context = None
+    if insecure and url.lower().startswith("https"):
+        import ssl
+        context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=10, context=context) as response:
+                if response.status == status:
+                    return True
+        except urllib.error.HTTPError as exc:
+            if exc.code == status:
+                return True
+        except Exception:
+            pass
+        time.sleep(interval)
+    return False
+
+
+def expand_paths(invocation: List[str]) -> List[str]:
+    """Resolve ``{bench}`` / ``{repo}`` in a case's arguments.
+
+    A case that references a captured request file has to name it somehow, and
+    both a bare relative path (which breaks the moment the runner is invoked
+    from elsewhere) and an absolute one (which breaks on every other machine)
+    are wrong. The tokens make the anchor explicit."""
+    return [arg.replace("{bench}", str(BENCH_ROOT)).replace("{repo}", str(REPO_ROOT))
+            for arg in invocation]
+
+
+def run_rcekit(invocation: List[str], python: Optional[str] = None,
+               timeout: float = 900.0) -> Dict[str, Any]:
+    """Run RCEKit once with the case's arguments and return its JSON results.
+
+    ``--detect-json`` is appended by the harness rather than written into each
+    case: the outcome must come from the tool's own machine-readable channel,
+    not from scraping a report whose payload lines can contain literal
+    newlines."""
+    handle, results_path = tempfile.mkstemp(prefix="rcekit-bench-", suffix=".json")
+    os.close(handle)
+    command = [python or sys.executable, str(RCEKIT), "--acknowledge-consent",
+               *expand_paths(invocation), "--detect-json", results_path]
+    try:
+        completed = subprocess.run(command, capture_output=True, text=True, timeout=timeout,
+                                   cwd=str(REPO_ROOT))
+        try:
+            with open(results_path, encoding="utf-8") as results_file:
+                report = json.load(results_file)
+        except (OSError, ValueError):
+            # No JSON means the run never got as far as detecting anything --
+            # a bad invocation, a refused consent gate, a crash. Reporting that
+            # as `negative` would read as "target not vulnerable".
+            return {"verdict": "nothing-tested", "counts": {}, "probes": [],
+                    "stdout": completed.stdout, "stderr": completed.stderr,
+                    "exit_code": completed.returncode, "command": command}
+        report["stdout"] = completed.stdout
+        report["stderr"] = completed.stderr
+        report["exit_code"] = completed.returncode
+        report["command"] = command
+        return report
+    except subprocess.TimeoutExpired:
+        return {"verdict": "error", "counts": {}, "probes": [],
+                "stdout": "", "stderr": f"rcekit timed out after {timeout}s",
+                "exit_code": None, "command": command}
+    finally:
+        try:
+            os.unlink(results_path)
+        except OSError:
+            pass
+
+
+def method_signatures(report: Dict[str, Any], verdict: str) -> List[str]:
+    """The method identifiers behind every probe that reached ``verdict``.
+
+    Both the bare method (``reflected``) and the full carrier
+    (``reflected/unix/raw``) are returned, so a case can pin the exact break-out
+    that worked or stay at the method level."""
+    signatures: List[str] = []
+    for probe in report.get("probes", []):
+        if probe.get("verdict") != verdict:
+            continue
+        method = probe.get("method", "")
+        signatures.append(method)
+        signatures.append("{}/{}/{}".format(method, probe.get("environment", ""),
+                                            probe.get("context", "")))
+    return signatures
+
+
+def check_report(report: Dict[str, Any], expect: str,
+                 expect_method: Optional[str] = None) -> Tuple[bool, str]:
+    """Whether one run matched what the case expected, and why not if it did not."""
+    observed = report.get("verdict", "nothing-tested")
+    if observed != expect:
+        counts = report.get("counts") or {}
+        detail = ", ".join(f"{k}={v}" for k, v in sorted(counts.items())) or "no probes"
+        return False, f"expected {expect}, got {observed} ({detail})"
+    if expect_method:
+        signatures = method_signatures(report, expect)
+        if expect_method not in signatures:
+            return False, (f"verdict {observed} came from "
+                           f"{sorted(set(signatures)) or 'no method'}, not {expect_method!r}")
+    return True, f"{observed} as expected"
+
+
+def compose_command(case: Dict[str, Any], action: str) -> Optional[List[str]]:
+    """The compose command for a case, or ``None`` when it manages no containers.
+
+    A case may give ``compose`` as a ready-made argv list (full control) or rely
+    on ``vulhub_path``, in which case the standard compose invocation is run in
+    that directory under ``--vulhub-root``."""
+    if "compose" in case:
+        argv = list(case["compose"])
+        return argv if action == "up" else list(case.get("compose_down", []))
+    if "vulhub_path" not in case:
+        return None
+    if action == "up":
+        return ["docker", "compose", "up", "-d"]
+    return ["docker", "compose", "down", "-v"]
+
+
+def run_one(case: Dict[str, Any], invocation: List[str], expect: str,
+            expect_method: Optional[str], wait_for: Optional[Dict[str, Any]],
+            compose_case: Dict[str, Any], vulhub_root: Optional[Path],
+            keep_up: bool = False, verbose: bool = False) -> Tuple[bool, str, Dict[str, Any]]:
+    """Bring a target up, run RCEKit against it, tear it down, and judge."""
+    cwd = None
+    if "vulhub_path" in compose_case:
+        if not vulhub_root:
+            return False, "case needs --vulhub-root (it declares a vulhub_path)", {}
+        cwd = vulhub_root / compose_case["vulhub_path"]
+        if not cwd.is_dir():
+            return False, f"vulhub path not found: {cwd}", {}
+    up = compose_command(compose_case, "up")
+    started = False
+    try:
+        if up:
+            if verbose:
+                print(f"    $ {' '.join(up)}" + (f"  (in {cwd})" if cwd else ""))
+            started = subprocess.run(up, cwd=str(cwd) if cwd else None,
+                                     capture_output=True, text=True).returncode == 0
+            if not started:
+                return False, "compose up failed", {}
+        if wait_for:
+            ready = wait_for_target(wait_for["url"], wait_for.get("status", 200),
+                                    wait_for.get("timeout", 120))
+            if not ready:
+                return False, f"target never became ready at {wait_for['url']}", {}
+        report = run_rcekit(invocation)
+        ok, detail = check_report(report, expect, expect_method)
+        return ok, detail, report
+    finally:
+        down = compose_command(compose_case, "down")
+        if started and down and not keep_up:
+            if verbose:
+                print(f"    $ {' '.join(down)}")
+            subprocess.run(down, cwd=str(cwd) if cwd else None,
+                           capture_output=True, text=True)
+
+
+def run_case(case: Dict[str, Any], vulhub_root: Optional[Path] = None,
+             keep_up: bool = False, verbose: bool = False) -> Dict[str, Any]:
+    """Run a case's vulnerable half and its negative control.
+
+    The control runs even when the vulnerable half already failed. A case whose
+    vulnerable target stopped confirming *and* whose control started confirming
+    is a different problem from either alone, and only running both tells them
+    apart."""
+    outcome: Dict[str, Any] = {"name": case["name"], "rce_class": case["rce_class"],
+                               "target": case["target"]}
+    ok, detail, report = run_one(
+        case, case["invocation"], case["expect"], case.get("expect_method"),
+        case.get("wait_for"), case, vulhub_root, keep_up, verbose)
+    outcome["vulnerable_ok"] = ok
+    outcome["vulnerable_detail"] = detail
+    outcome["verdict"] = report.get("verdict", "nothing-tested")
+    outcome["methods"] = sorted(set(method_signatures(report, outcome["verdict"])))
+
+    control = case["negative_control"]
+    control_case = dict(case)
+    control_case.update({k: v for k, v in control.items() if k in ("vulhub_path", "compose",
+                                                                   "compose_down")})
+    if "vulhub_path" in control and "compose" not in control:
+        control_case.pop("compose", None)
+    control_ok, control_detail, control_report = run_one(
+        control_case, control.get("invocation", case["invocation"]),
+        control.get("expect", "negative"), control.get("expect_method"),
+        control.get("wait_for", case.get("wait_for")), control_case, vulhub_root,
+        keep_up, verbose)
+    outcome["control_ok"] = control_ok
+    outcome["control_detail"] = control_detail
+    outcome["control_verdict"] = control_report.get("verdict", "nothing-tested")
+    outcome["passed"] = bool(ok and control_ok)
+    return outcome
+
+
+def render_markdown(outcomes: List[Dict[str, Any]]) -> str:
+    """The coverage table, ready to paste into the README.
+
+    The control column is part of the table on purpose: a reader can see that
+    every confirmed row was checked against something that must stay clean,
+    rather than taking the claim on trust."""
+    lines = ["| RCE class | Target | Method | Verdict | Control | Result |",
+             "|---|---|---|---|---|---|"]
+    for outcome in outcomes:
+        methods = ", ".join(f"`{m}`" for m in outcome.get("methods", []) if "/" not in m) or "—"
+        verdict = outcome.get("verdict", "—")
+        cell = f"**`{verdict}`**" if verdict == "confirmed" else f"`{verdict}`"
+        control = f"`{outcome.get('control_verdict', '—')}`"
+        result = "pass" if outcome.get("passed") else "**FAIL**"
+        lines.append(f"| {outcome['rce_class']} | {outcome['target']} | {methods} | "
+                     f"{cell} | {control} | {result} |")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run RCEKit against real vulnerable targets and check the verdicts.")
+    parser.add_argument("--case", action="append", default=[],
+                        help="Case name (file stem) to run; repeatable.")
+    parser.add_argument("--all", action="store_true", help="Run every case.")
+    parser.add_argument("--list", action="store_true", help="List available cases and exit.")
+    parser.add_argument("--vulhub-root", default=os.environ.get("VULHUB_ROOT"),
+                        help="Path to a vulhub checkout; required by cases with a vulhub_path.")
+    parser.add_argument("--cases-dir", default=str(CASES_DIR))
+    parser.add_argument("--markdown", default=None,
+                        help="Write the coverage table to this file as well as stdout.")
+    parser.add_argument("--keep-up", action="store_true",
+                        help="Leave containers running after the case (for debugging).")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    cases_dir = Path(args.cases_dir)
+    paths = discover_cases(cases_dir)
+    if args.list:
+        for path in paths:
+            print(path.stem)
+        return 0
+    if args.case:
+        wanted = set(args.case)
+        paths = [p for p in paths if p.stem in wanted]
+        unknown = wanted - {p.stem for p in paths}
+        if unknown:
+            print(f"[!] unknown case(s): {', '.join(sorted(unknown))}", file=sys.stderr)
+            return 2
+    elif not args.all:
+        parser.error("choose --case NAME, --all, or --list")
+    if not paths:
+        print("[!] no cases to run", file=sys.stderr)
+        return 2
+
+    vulhub_root = Path(args.vulhub_root) if args.vulhub_root else None
+    outcomes: List[Dict[str, Any]] = []
+    for path in paths:
+        try:
+            case = load_case(path)
+        except CaseError as exc:
+            print(f"[!] {exc}", file=sys.stderr)
+            return 2
+        print(f"[bench] {case['name']}: {case['target']}")
+        outcome = run_case(case, vulhub_root, args.keep_up, args.verbose)
+        outcomes.append(outcome)
+        mark = "pass" if outcome["passed"] else "FAIL"
+        print(f"[bench]   vulnerable: {outcome['vulnerable_detail']}")
+        print(f"[bench]   control:    {outcome['control_detail']}")
+        print(f"[bench]   -> {mark}")
+
+    table = render_markdown(outcomes)
+    print("\n" + table)
+    if args.markdown:
+        with open(args.markdown, "w", encoding="utf-8") as handle:
+            handle.write(table + "\n")
+        print(f"\n[bench] table written to {args.markdown}")
+    failed = [o for o in outcomes if not o["passed"]]
+    print(f"\n[bench] {len(outcomes) - len(failed)}/{len(outcomes)} cases passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/bench/runner.py
+++ b/tests/bench/runner.py
@@ -51,10 +51,50 @@ RCEKIT = REPO_ROOT / "rcekit.py"
 REQUIRED_KEYS = ("name", "rce_class", "target", "invocation", "expect", "negative_control")
 VALID_EXPECTATIONS = ("confirmed", "needs-review", "negative", "inconclusive",
                       "error", "nothing-tested")
+# What a control may expect. Narrower than VALID_EXPECTATIONS on purpose:
+# `error` and `nothing-tested` both mean the run never exercised the target, so a
+# control expecting either proves nothing about false confirmation -- it would
+# stay green with the detection engine entirely broken, which is the one thing a
+# control exists to catch. `confirmed` is excluded as a contradiction.
+#
+# The vulnerable half may still expect them: "an unreachable target reports
+# `error`, not `negative`" is a real property worth pinning.
+CONTROL_EXPECTATIONS = ("negative", "inconclusive", "needs-review")
 
 
 class CaseError(Exception):
     """A case file that cannot be trusted to measure anything."""
+
+
+def target_setup(case: Dict[str, Any]) -> Tuple[Any, Tuple[str, ...], Tuple[str, ...]]:
+    """The part of a case that decides *which* target comes up."""
+    return (case.get("vulhub_path"), tuple(case.get("compose", ())),
+            tuple(case.get("compose_down", ())))
+
+
+def control_plan(case: Dict[str, Any]) -> Tuple[List[str], Dict[str, Any]]:
+    """The control's effective invocation and target setup.
+
+    A control inherits the case's target unless it overrides it — the common
+    controls (probe for the wrong class, probe with a weaker method) deliberately
+    run against the *same* container, and only a patched-build control brings up
+    a different one.
+
+    One function, used by both validation and execution, so the two cannot
+    drift: the duplication the validator rejects has to be the same duplication
+    the runner would otherwise have run."""
+    control = case["negative_control"]
+    invocation = list(control.get("invocation", case["invocation"]))
+    setup = dict(case)
+    for key in ("vulhub_path", "compose", "compose_down"):
+        if key in control:
+            setup[key] = control[key]
+    # A control naming its own vulhub_path without its own compose wants the
+    # standard compose commands in that directory, not the parent's explicit ones.
+    if "vulhub_path" in control and "compose" not in control:
+        setup.pop("compose", None)
+        setup.pop("compose_down", None)
+    return invocation, setup
 
 
 def validate_case(case: Dict[str, Any], source: str = "<case>") -> Dict[str, Any]:
@@ -74,15 +114,24 @@ def validate_case(case: Dict[str, Any], source: str = "<case>") -> Dict[str, Any
     control = case["negative_control"]
     if not isinstance(control, dict):
         raise CaseError(f"{source}: 'negative_control' must be an object")
-    if "invocation" not in control and "compose" not in control:
-        raise CaseError(f"{source}: 'negative_control' needs its own 'invocation' or 'compose' — "
-                        "a control that reuses the vulnerable target's is not a control")
+    # Compare what the control would *actually* run, not merely whether it
+    # declared a key. Copying the vulnerable invocation into the control passes a
+    # key-presence check while running the identical command against the
+    # identical target twice, which measures nothing.
+    control_invocation, control_setup = control_plan(case)
+    if (control_invocation == list(case["invocation"])
+            and target_setup(control_setup) == target_setup(case)):
+        raise CaseError(f"{source}: the negative control runs the identical invocation against "
+                        "an identical target, so it measures nothing — vary the invocation "
+                        "(a different method or injection point) or the target (a patched build)")
     control_expect = control.get("expect", "negative")
     if control_expect == "confirmed":
         raise CaseError(f"{source}: a negative control expecting 'confirmed' is a contradiction")
-    if control_expect not in VALID_EXPECTATIONS:
+    if control_expect not in CONTROL_EXPECTATIONS:
         raise CaseError(f"{source}: negative_control 'expect' must be one of "
-                        f"{', '.join(VALID_EXPECTATIONS)}, got {control_expect!r}")
+                        f"{', '.join(CONTROL_EXPECTATIONS)} — an outcome that means the target "
+                        f"was never exercised cannot show RCEKit avoids a false confirmation; "
+                        f"got {control_expect!r}")
     return case
 
 
@@ -289,13 +338,9 @@ def run_case(case: Dict[str, Any], vulhub_root: Optional[Path] = None,
     outcome["methods"] = sorted(set(method_signatures(report, outcome["verdict"])))
 
     control = case["negative_control"]
-    control_case = dict(case)
-    control_case.update({k: v for k, v in control.items() if k in ("vulhub_path", "compose",
-                                                                   "compose_down")})
-    if "vulhub_path" in control and "compose" not in control:
-        control_case.pop("compose", None)
+    control_invocation, control_case = control_plan(case)
     control_ok, control_detail, control_report = run_one(
-        control_case, control.get("invocation", case["invocation"]),
+        control_case, control_invocation,
         control.get("expect", "negative"), control.get("expect_method"),
         control.get("wait_for", case.get("wait_for")), control_case, vulhub_root,
         keep_up, verbose)

--- a/tests/test_bench_runner.py
+++ b/tests/test_bench_runner.py
@@ -1,0 +1,316 @@
+"""Unit tests for the coverage benchmark harness (tests/bench/runner.py).
+
+Run with the rest of the suite: python -m unittest discover -s tests
+
+The bench *cases* need Docker and are not run here. The harness itself does not:
+a case with no `compose` key points at a target that is already up, so the whole
+run-and-judge path is exercised end to end against a local socket. What Docker
+would add is `docker compose up` — the one step these tests skip.
+
+The properties locked in are the ones that decide whether the benchmark measures
+anything at all: a case without a negative control is rejected, a control that
+expects `confirmed` is rejected, and a run that never tested anything is never
+reported as a clean negative.
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+# Repo root for `rcekit`, this directory for `test_generator`'s local_target
+# helper, and bench/ for the harness itself. Spelled out so the module imports
+# the same way under `unittest discover -s tests` and `-m unittest tests....`.
+sys.path.insert(0, str(TESTS_DIR.parent))
+sys.path.insert(0, str(TESTS_DIR))
+sys.path.insert(0, str(TESTS_DIR / "bench"))
+
+import runner  # noqa: E402
+from test_generator import local_target  # noqa: E402
+
+BENCH_ROOT = Path(__file__).resolve().parent / "bench"
+
+
+def minimal_case(**overrides):
+    case = {
+        "name": "example",
+        "rce_class": "OS command injection",
+        "target": "Example 1.0",
+        "invocation": ["--verify-url", "http://127.0.0.1:1/?x=FUZZ", "--methods", "reflected"],
+        "expect": "confirmed",
+        "negative_control": {"invocation": ["--verify-url", "http://127.0.0.1:1/?y=FUZZ",
+                                            "--methods", "reflected"],
+                             "expect": "negative"},
+    }
+    case.update(overrides)
+    return case
+
+
+class CaseValidationTestCase(unittest.TestCase):
+    """A malformed case must fail loudly. A benchmark that quietly skips cases
+    reports fewer failures than reality — the one thing it must never do."""
+
+    def test_a_well_formed_case_validates(self):
+        self.assertEqual(runner.validate_case(minimal_case())["name"], "example")
+
+    def test_every_required_key_is_enforced(self):
+        for key in runner.REQUIRED_KEYS:
+            case = minimal_case()
+            del case[key]
+            with self.assertRaises(runner.CaseError, msg=f"missing {key} must be rejected") as ctx:
+                runner.validate_case(case)
+            self.assertIn(key, str(ctx.exception))
+
+    def test_a_case_without_a_negative_control_is_rejected(self):
+        case = minimal_case()
+        del case["negative_control"]
+        with self.assertRaises(runner.CaseError):
+            runner.validate_case(case)
+
+    def test_a_control_that_reuses_the_vulnerable_invocation_is_rejected(self):
+        # A "control" that runs the identical command against the identical
+        # target measures nothing; it just doubles the runtime.
+        case = minimal_case(negative_control={"expect": "negative"})
+        with self.assertRaises(runner.CaseError) as ctx:
+            runner.validate_case(case)
+        self.assertIn("not a control", str(ctx.exception))
+
+    def test_a_control_expecting_confirmed_is_rejected(self):
+        case = minimal_case(negative_control={"invocation": ["--x"], "expect": "confirmed"})
+        with self.assertRaises(runner.CaseError) as ctx:
+            runner.validate_case(case)
+        self.assertIn("contradiction", str(ctx.exception))
+
+    def test_an_unknown_expectation_is_rejected(self):
+        with self.assertRaises(runner.CaseError):
+            runner.validate_case(minimal_case(expect="vulnerable"))
+
+    def test_shipped_cases_all_validate(self):
+        paths = runner.discover_cases(BENCH_ROOT / "cases")
+        self.assertTrue(paths, "no bench cases found")
+        for path in paths:
+            runner.load_case(path)
+
+    def test_shipped_cases_reference_files_that_exist(self):
+        # A case pointing at a missing captured request fails only once someone
+        # has waited for a container to boot. Catch it here instead.
+        for path in runner.discover_cases(BENCH_ROOT / "cases"):
+            case = runner.load_case(path)
+            invocations = [case["invocation"], case["negative_control"].get("invocation", [])]
+            for invocation in invocations:
+                for arg in runner.expand_paths(invocation):
+                    if arg.startswith(str(BENCH_ROOT)):
+                        self.assertTrue(Path(arg).exists(), f"{path.name} references {arg}")
+
+
+class ReportCheckingTestCase(unittest.TestCase):
+    """Turning one RCEKit run into pass/fail."""
+
+    def test_matching_verdict_passes(self):
+        ok, detail = runner.check_report({"verdict": "confirmed", "counts": {"confirmed": 2}},
+                                         "confirmed")
+        self.assertTrue(ok)
+        self.assertIn("confirmed", detail)
+
+    def test_mismatched_verdict_fails_with_the_counts(self):
+        ok, detail = runner.check_report(
+            {"verdict": "negative", "counts": {"negative": 9}}, "confirmed")
+        self.assertFalse(ok)
+        self.assertIn("expected confirmed, got negative", detail)
+        self.assertIn("negative=9", detail)
+
+    def test_nothing_tested_is_not_a_negative(self):
+        # The distinction the whole harness rests on: a run that built no probes
+        # tested nothing, and must not satisfy a case expecting `negative`.
+        ok, _ = runner.check_report({"verdict": "nothing-tested", "counts": {}}, "negative")
+        self.assertFalse(ok)
+
+    def test_expect_method_pins_the_method_that_confirmed(self):
+        report = {"verdict": "confirmed", "counts": {"confirmed": 1},
+                  "probes": [{"verdict": "confirmed", "method": "eval",
+                              "environment": "unix", "context": "raw"}]}
+        self.assertTrue(runner.check_report(report, "confirmed", "eval")[0])
+        self.assertTrue(runner.check_report(report, "confirmed", "eval/unix/raw")[0])
+        ok, detail = runner.check_report(report, "confirmed", "reflected")
+        self.assertFalse(ok, "a confirmation from the wrong method must not satisfy the case")
+        self.assertIn("not 'reflected'", detail)
+
+
+class MarkdownTableTestCase(unittest.TestCase):
+    def test_table_shows_verdict_control_and_result(self):
+        table = runner.render_markdown([
+            {"name": "a", "rce_class": "OS command injection", "target": "Webmin 1.910",
+             "verdict": "confirmed", "control_verdict": "needs-review",
+             "methods": ["reflected", "reflected/unix/raw"], "passed": True},
+            {"name": "b", "rce_class": "Expression injection", "target": "Struts2",
+             "verdict": "negative", "control_verdict": "negative",
+             "methods": [], "passed": False},
+        ])
+        self.assertIn("| Webmin 1.910 | `reflected` | **`confirmed`** | `needs-review` | pass |",
+                      table)
+        self.assertIn("**FAIL**", table)
+        # The composite signature is detail for a failure message, not for the
+        # README table.
+        self.assertNotIn("reflected/unix/raw", table)
+
+
+class HarnessEndToEndTestCase(unittest.TestCase):
+    """The run-and-judge path against a real socket, with no Docker involved.
+
+    A case with no `compose` key targets something already running, which is
+    what makes this possible — and is also a real mode for anyone benchmarking
+    a target they started by hand."""
+
+    def _case(self, base, **overrides):
+        return minimal_case(
+            invocation=["--verify-url", f"{base}/?host=FUZZ", "--methods", "reflected"],
+            negative_control={"invocation": ["--verify-url", f"{base}/safe?host=FUZZ",
+                                             "--methods", "reflected"],
+                              "expect": "negative"},
+            **overrides)
+
+    def test_a_vulnerable_target_with_a_clean_control_passes(self):
+        import os
+
+        def route(method, path, params, headers, body):
+            if path.startswith("/safe"):
+                return 200, "<html>nothing executes here</html>"
+            pipe = os.popen("echo " + params.get("host", "") + " 2>&1")
+            out = pipe.read()
+            pipe.close()
+            return 200, out
+
+        with local_target(route) as base:
+            outcome = runner.run_case(self._case(base))
+        self.assertTrue(outcome["vulnerable_ok"], outcome["vulnerable_detail"])
+        self.assertTrue(outcome["control_ok"], outcome["control_detail"])
+        self.assertTrue(outcome["passed"])
+        self.assertEqual(outcome["verdict"], "confirmed")
+        self.assertIn("reflected", outcome["methods"])
+
+    def test_a_control_that_starts_confirming_fails_the_case(self):
+        # The failure mode negative controls exist to catch: if the "clean"
+        # endpoint also confirms, the case must fail even though the vulnerable
+        # half is perfect.
+        import os
+
+        def route(method, path, params, headers, body):
+            pipe = os.popen("echo " + params.get("host", "") + " 2>&1")
+            out = pipe.read()
+            pipe.close()
+            return 200, out
+
+        with local_target(route) as base:
+            outcome = runner.run_case(self._case(base))
+        self.assertTrue(outcome["vulnerable_ok"], outcome["vulnerable_detail"])
+        self.assertFalse(outcome["control_ok"])
+        self.assertFalse(outcome["passed"], "a confirming control must fail the case")
+
+    def test_a_patched_target_fails_the_vulnerable_half(self):
+        with local_target(lambda *a: (200, "<html>patched</html>")) as base:
+            outcome = runner.run_case(self._case(base))
+        self.assertFalse(outcome["vulnerable_ok"])
+        self.assertTrue(outcome["control_ok"])
+        self.assertFalse(outcome["passed"])
+
+    def test_an_unreachable_target_is_an_error_not_a_negative(self):
+        # Reporting a dead target as `negative` would read as "not vulnerable",
+        # which is the misreport this whole project exists to avoid.
+        case = minimal_case(
+            invocation=["--verify-url", "http://127.0.0.1:9/?x=FUZZ", "--methods", "reflected"],
+            expect="error")
+        outcome = runner.run_case(case)
+        self.assertEqual(outcome["verdict"], "error")
+        self.assertTrue(outcome["vulnerable_ok"], outcome["vulnerable_detail"])
+
+
+class RunnerCLITestCase(unittest.TestCase):
+    def test_list_prints_the_shipped_cases(self):
+        import contextlib
+        import io
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            code = runner.main(["--list", "--cases-dir", str(BENCH_ROOT / "cases")])
+        self.assertEqual(code, 0)
+        self.assertIn("webmin-cve-2019-15107", buffer.getvalue())
+
+    def test_an_unknown_case_name_is_an_error(self):
+        import contextlib
+        import io
+        with contextlib.redirect_stderr(io.StringIO()):
+            code = runner.main(["--case", "no-such-case", "--cases-dir",
+                                str(BENCH_ROOT / "cases")])
+        self.assertEqual(code, 2)
+
+    def test_no_selection_is_refused(self):
+        import contextlib
+        import io
+        with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            runner.main(["--cases-dir", str(BENCH_ROOT / "cases")])
+
+
+class DetectJsonTestCase(unittest.TestCase):
+    """--detect-json is the channel the harness reads. Its contract is tested
+    here rather than in the harness, because the harness only trusts it."""
+
+    def test_overall_verdict_prefers_the_finding_over_the_majority(self):
+        import rcekit
+        many_negatives = [{"verdict": "negative"}] * 99
+        self.assertEqual(
+            rcekit.overall_detection_verdict(many_negatives + [{"verdict": "confirmed"}]),
+            "confirmed")
+        self.assertEqual(
+            rcekit.overall_detection_verdict(many_negatives + [{"verdict": "needs-review"}]),
+            "needs-review")
+
+    def test_no_probes_is_nothing_tested_not_negative(self):
+        import rcekit
+        self.assertEqual(rcekit.overall_detection_verdict([]), "nothing-tested")
+
+    def test_error_only_when_nothing_reached_the_target(self):
+        import rcekit
+        self.assertEqual(rcekit.overall_detection_verdict([{"verdict": "error"}] * 3), "error")
+        # Some probes errored but others landed and came back clean: that is a
+        # real negative, not an untested run.
+        self.assertEqual(
+            rcekit.overall_detection_verdict([{"verdict": "error"}, {"verdict": "negative"}]),
+            "negative")
+
+    def test_written_file_carries_the_verdict_counts_and_probes(self):
+        import rcekit
+        probes = [{"verdict": "confirmed", "method": "reflected", "environment": "unix",
+                   "context": "raw", "payload": "; id", "detail": "computed"},
+                  {"verdict": "negative", "method": "reflected", "environment": "unix",
+                   "context": "raw", "payload": "| id", "detail": ""}]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = str(Path(tmp) / "out.json")
+            rcekit.write_detection_json(path, probes, "http://t/FUZZ", ["reflected"])
+            with open(path, encoding="utf-8") as handle:
+                written = json.load(handle)
+        self.assertEqual(written["verdict"], "confirmed")
+        self.assertEqual(written["counts"], {"confirmed": 1, "negative": 1})
+        self.assertEqual(written["target"], "http://t/FUZZ")
+        self.assertEqual(written["methods"], ["reflected"])
+        self.assertEqual(len(written["probes"]), 2)
+        self.assertEqual(written["rcekit_version"], rcekit.__version__)
+
+    def test_a_payload_containing_a_newline_survives_the_round_trip(self):
+        # The reason this channel exists: line-oriented parsing of the text
+        # report splits such a payload in half.
+        import rcekit
+        payload = "\necho RKABCDE$((1+2))RKFGHIJ"
+        with tempfile.TemporaryDirectory() as tmp:
+            path = str(Path(tmp) / "out.json")
+            rcekit.write_detection_json(
+                path, [{"verdict": "confirmed", "method": "reflected", "environment": "unix",
+                        "context": "raw", "payload": payload, "detail": ""}],
+                "http://t", ["reflected"])
+            with open(path, encoding="utf-8") as handle:
+                written = json.load(handle)
+        self.assertEqual(written["probes"][0]["payload"], payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bench_runner.py
+++ b/tests/test_bench_runner.py
@@ -75,7 +75,59 @@ class CaseValidationTestCase(unittest.TestCase):
         case = minimal_case(negative_control={"expect": "negative"})
         with self.assertRaises(runner.CaseError) as ctx:
             runner.validate_case(case)
-        self.assertIn("not a control", str(ctx.exception))
+        self.assertIn("measures nothing", str(ctx.exception))
+
+    def test_an_explicitly_copied_control_invocation_is_rejected_too(self):
+        # Key presence is not the test — what the control would actually run is.
+        # Spelling the vulnerable invocation out again is the same non-control as
+        # omitting it, and this case expects `needs-review`, where a duplicated
+        # control would otherwise pass and prove nothing.
+        case = minimal_case(
+            expect="needs-review",
+            negative_control={"invocation": list(minimal_case()["invocation"]),
+                              "expect": "needs-review"})
+        with self.assertRaises(runner.CaseError) as ctx:
+            runner.validate_case(case)
+        self.assertIn("measures nothing", str(ctx.exception))
+
+    def test_the_same_invocation_against_a_different_build_is_a_valid_control(self):
+        # The patched-build control: identical command, different target. That is
+        # the strongest control there is, so the duplication check must not
+        # mistake it for a duplicate.
+        case = minimal_case(vulhub_path="webmin/CVE-2019-15107",
+                            negative_control={"vulhub_path": "webmin/patched",
+                                              "expect": "negative"})
+        self.assertEqual(runner.validate_case(case)["name"], "example")
+
+    def test_a_control_may_not_expect_an_outcome_that_never_reached_the_target(self):
+        # `error` and `nothing-tested` mean nothing was exercised, so such a
+        # control would stay green with the detection engine entirely broken.
+        for expectation in ("error", "nothing-tested"):
+            case = minimal_case(negative_control={"invocation": ["--bogus"],
+                                                  "expect": expectation})
+            with self.assertRaises(runner.CaseError, msg=expectation) as ctx:
+                runner.validate_case(case)
+            self.assertIn("never exercised", str(ctx.exception))
+
+    def test_a_control_may_expect_any_exercised_outcome(self):
+        for expectation in runner.CONTROL_EXPECTATIONS:
+            case = minimal_case(negative_control={"invocation": ["--other"],
+                                                  "expect": expectation})
+            self.assertEqual(runner.validate_case(case)["name"], "example", expectation)
+
+    def test_the_vulnerable_half_may_still_expect_error(self):
+        # Narrowing control expectations must not narrow the case's own: "an
+        # unreachable target reports error, not negative" is worth pinning.
+        self.assertEqual(runner.validate_case(minimal_case(expect="error"))["name"], "example")
+
+    def test_validation_and_execution_read_the_same_control_plan(self):
+        # The duplication the validator rejects must be the duplication the
+        # runner would have run, so both go through control_plan.
+        case = minimal_case(compose=["docker", "compose", "up", "-d"],
+                            negative_control={"invocation": ["--other"], "expect": "negative"})
+        invocation, setup = runner.control_plan(case)
+        self.assertEqual(invocation, ["--other"])
+        self.assertEqual(runner.target_setup(setup), runner.target_setup(case))
 
     def test_a_control_expecting_confirmed_is_rejected(self):
         case = minimal_case(negative_control={"invocation": ["--x"], "expect": "confirmed"})


### PR DESCRIPTION
Phase 9 of the detection coverage plan. Rebased onto `main` after #52 merged, so this branch now carries only the two bench commits.

## Why

The unit suite proves RCEKit builds the right payloads and reaches the right verdict from a given response. It cannot prove it confirms *Webmin*. Every coverage claim in the README currently rests on a run someone did by hand once, and nothing re-checks it.

`tests/bench/` makes those claims checkable. A case brings a real vulnerable build up, runs the tool the way an operator would, checks the verdict, tears it down, and `--markdown` emits the coverage table.

```bash
python tests/bench/runner.py --list
python tests/bench/runner.py --all --vulhub-root ~/vulhub --markdown coverage.md
```

Exit status is 0 only when every case passes, so it drops into a dedicated job as-is. It stays out of `python -m unittest discover -s tests` because cases pull real images.

## Every case needs a control, and the runner enforces it

A benchmark without negative controls measures nothing — a tool that shouted `confirmed` at every target would score full marks on the vulnerable half and the harness would report it as progress. So `negative_control` is a required key.

Three kinds, all sharing the invariant that the control must not reach `confirmed`:

| Kind | What it proves |
|---|---|
| `patched-build` | the tool does not confirm on a fixed version |
| `class-attribution` | the tool names the class rather than flagging the parameter — S2-001 probed with `reflected` must be `negative` |
| `tier-ceiling` | a weaker signal is not promoted on a target where it happens to be right — Webmin probed with `time` must stay `needs-review` |

The third is the one that usually gets skipped, and it is the one guarding the tool's central promise.

The runner refuses four shapes of non-control: no control at all; one expecting `confirmed`; one that runs the identical invocation against an identical target; and one expecting `error` or `nothing-tested`, since both mean the target was never exercised and such a control would stay green with the detection engine entirely broken. The duplication check judges what the control would *actually run*, not which keys it declares, so an explicit copy of the vulnerable invocation is caught as well as an omitted one — while a patched-build control (identical command, different build) stays valid. Validation and execution share one `control_plan`, because a validator that reimplements the runner is a validator that will eventually disagree with it.

## `--detect-json`

Reading the verdict needed a machine-readable channel. Scraping stdout cannot be made reliable, and this is measurable rather than theoretical: **7 of the 35 probes** in a default `reflected` run carry a literal newline (the newline separator is a real one), so line-oriented parsing splits a payload in half — and the detection path exits 0 whether it confirmed or came back clean.

`--detect-json PATH` writes the overall verdict, per-verdict counts, and every probe. Text output is unchanged.

`overall_detection_verdict` collapses a run by what an operator must not miss rather than by frequency — one `confirmed` among a hundred negatives is the finding. `error` is reported only when *nothing* reached the target, and a run that built no probes is `nothing-tested`; collapsing either into `negative` would read as "not vulnerable".

## Tests

31 new tests in the default suite, no Docker: case validation (every required key, the four refused control shapes, and that a patched-build control is not mistaken for a duplicate), report checking, table rendering, the `--detect-json` contract including a newline round-trip, and **four end-to-end harness runs against a local socket** — a vulnerable target with a clean control passes, a control that starts confirming fails the case, a patched target fails the vulnerable half, and an unreachable target is `error` rather than `negative`.

```
python -m unittest discover -s tests
Ran 331 tests in 127.053s

OK
```

## What is not verified

The two shipped cases are transcribed from `docs/verify-it-yourself.md`, whose reproductions are documented as verified against vulhub. **They have not been executed through this harness** — the environment this was written in has no Docker daemon. `tests/bench/README.md` states that plainly, and the `struts2-s2-001` case flags in its own `notes` that `/login.action` and `username` are vulhub defaults taken on faith, where that document deliberately tells the operator to read the form off the running app.

Treat the first real run as validation of the case files themselves. **No README claim was changed to assert benchmark results** — the coverage table becomes generated output once these cases have actually run.

## Compatibility

Additive. `--detect-json` is opt-in and changes no existing output. Version 2.24.0 → 2.25.0 (MINOR), README badge, CHANGELOG, `docs/reference.md` and `CONTRIBUTING.md` updated.