### PR TITLE
feat(detection): reach the two sink shapes no probe fitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,51 @@ formats, or the template schema.
 
 ## [Unreleased]
 
+## [2.26.0] — 2026-08-16
+
+The sink-shape ladder. An injected value lands in a *shape* — mid-command,
+inside quotes, as the whole command — and the shape decides what can reach it.
+Two shapes had no probe that fitted, so a genuinely exploitable target reported
+clean.
+
+### Added
+
+- **`--sink-shape auto|sep|raw|chain|newline|dq|sq|subshell`** (comma-separated)
+  names which shapes the shell probes try. `auto` is the whole ladder and the
+  default. Underneath it selects the existing separator sweep and break-out
+  contexts, so naming a rung narrows a supported run rather than switching on a
+  parallel path. The plan is printed before anything is sent, because the ladder
+  multiplies request count and an operator on a monitored engagement needs to
+  see the cost first.
+- **The `subshell` rung — `$(...)` and backticks.** Reaches a value sitting
+  inside double quotes *without closing the quote*, which is the one case a
+  quoted break-out loses to a filter on the quote character itself. Measured
+  against `system("echo PING \"$input\"")`: with `"` stripped, `dq` is inert and
+  both substitution forms execute; with `$` stripped, `dq` executes and the
+  backtick form still does. Both ship because they survive different filters.
+
+  **Which method it helps is the counter-intuitive part.** `reflected`'s core is
+  `$((a+b))`, which the shell expands inside double quotes anyway, so that
+  method already confirmed there. The methods whose core must actually *run* —
+  `time` (a sleep), `file` (a redirect), `oob` (a fetch) — are completely inert
+  inside those quotes. On a quote-filtering sink, `--methods file` went from **0
+  confirmations to 2**: it had been reporting an exploitable target as clean.
+- **The `raw` rung is now part of `auto`.** A `qx/$input/`-style sink, where the
+  input is the whole command, previously needed `--sink-raw` — so it reported
+  clean unless the operator already suspected the shape. One extra probe per
+  carrier buys it. `--sink-raw` keeps its meaning as the narrowing alias for
+  `--sink-shape raw`, and no existing command line changes behaviour.
+
+### Changed
+
+- **The backtick context drops probe shapes that carry their own backtick.**
+  Backticks do not nest, so such a probe closes the outer substitution early and
+  could only ever come back negative. `$( )` does nest and keeps every shape.
+- **Naming `--separators` now implies the sink is separator-led**, so the `raw`
+  rung is dropped unless `--sink-shape` names it explicitly. A profile with
+  `sink_needs_separator` drops it for the same reason. Both keep an explicitly
+  narrowed run from being widened behind the operator's back.
+
 ## [2.25.0] — 2026-08-16
 
 A coverage benchmark, so a claim about what RCEKit confirms can be checked
@@ -394,7 +439,8 @@ this file and have not been restated here.
 - **[2.7.0]**
 - **[2.1.0]**
 
-[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.25.0...HEAD
+[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.26.0...HEAD
+[2.26.0]: https://github.com/kabiri-labs/rcekit/compare/v2.25.0...v2.26.0
 [2.25.0]: https://github.com/kabiri-labs/rcekit/compare/v2.24.0...v2.25.0
 [2.24.0]: https://github.com/kabiri-labs/rcekit/compare/v2.23.3...v2.24.0
 [2.23.3]: https://github.com/kabiri-labs/rcekit/compare/v2.23.2...v2.23.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,14 +37,33 @@ clean.
   `time` (a sleep), `file` (a redirect), `oob` (a fetch) — are completely inert
   inside those quotes. On a quote-filtering sink, `--methods file` went from **0
   confirmations to 2**: it had been reporting an exploitable target as clean.
-- **The `raw` rung is now part of `auto`.** A `qx/$input/`-style sink, where the
-  input is the whole command, previously needed `--sink-raw` — so it reported
-  clean unless the operator already suspected the shape. One extra probe per
-  carrier buys it. `--sink-raw` keeps its meaning as the narrowing alias for
-  `--sink-shape raw`, and no existing command line changes behaviour.
+- **The `raw` rung is now part of `auto`, for every shell method.** A
+  `qx/$input/`-style sink, where the input is the whole command, previously
+  needed `--sink-raw` — so it reported clean unless the operator already
+  suspected the shape. One extra probe per carrier buys it. `--sink-raw` keeps
+  its meaning as the narrowing alias for `--sink-shape raw`, and no existing
+  command line changes behaviour. `reflected`, `file`, `time` and `oob` all
+  build their candidates through one `_separator_candidates` helper, so a rung
+  cannot reach some methods and not others; `time` screens it in its second
+  wave, alongside the separators it holds back.
+
+### Fixed
+
+- **A method that builds no probes no longer reports `negative`.** An aggregate
+  method asked to judge zero samples answers honestly — "no delay was observed",
+  "no callback arrived" — and that reads as "not vulnerable" from a run that
+  tested nothing. The engine now emits no row for a carrier that produced no
+  probes, which lets its own loud nothing-tested path fire instead. Reachable
+  through any narrowing that leaves a carrier with nothing to send.
 
 ### Changed
 
+- **The pre-flight sink-shape plan is computed from the effective run**, not
+  from the `--sink-shape` value. `--separators`, `--contexts` and `--sink-raw`
+  each narrow the ladder, so printing the flag described a run that would not
+  happen — and this output is presented as an audit of the traffic about to be
+  sent. `effective_sink_shapes` is the single source of truth the engine and the
+  plan both read.
 - **The backtick context drops probe shapes that carry their own backtick.**
   Backticks do not nest, so such a probe closes the outer substitution early and
   could only ever come back negative. `$( )` does nest and keeps every shape.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.25.0** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.26.0** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -53,6 +53,7 @@ starting point — this page is for looking things up once you know what you wan
 | `--evade` | WAF posture: `none`, or `low` for minimal `${IFS}`-for-spaces | `none` |
 | `--probe-depth` | `full` (also the substitution-free and comment-terminated shapes) or `quick` | `full` |
 | `--detect-json` | Also write the run to this path as JSON: overall verdict, counts, every probe | None |
+| `--sink-shape` | Sink shapes the shell probes try: `auto`, or any of `sep`, `raw`, `chain`, `newline`, `dq`, `sq`, `subshell` | `auto` |
 
 | `--methods` value | Confirms | Tier it can reach |
 |---|---|---|
@@ -101,6 +102,61 @@ depth and `--probe-depth` changes nothing for it.
 sweep, and it does not narrow the separator screen `--methods time` runs: both
 depths try every candidate break-out, because dropping one is not a saving in
 requests but a blind spot. Use `--separators` to narrow that deliberately.
+
+### The sink-shape ladder
+
+An injected value lands in a *shape*, and the shape decides what can reach it.
+`--sink-shape` names which ones to try; `auto` tries the whole ladder.
+
+| Rung | Probe looks like | Sink shape |
+|---|---|---|
+| `sep` | `; cmd` | mid-command concatenation |
+| `raw` | `cmd` | the input **is** the whole command (`qx/$input/`) |
+| `chain` | `\| cmd`, `\|\| cmd`, `&& cmd` | pipes and conditional chains |
+| `newline` | newline + `cmd` | line-oriented sinks (CGI, config writers) |
+| `dq` | `"; cmd #` | value inside double quotes |
+| `sq` | `'; cmd #` | value inside single quotes |
+| `subshell` | `$(cmd)`, `` `cmd` `` | value inside quotes, reached **without closing them** |
+
+`subshell` is the rung that is easy to mis-explain, so here is what it is
+actually for. Against `system("echo PING \"$input\"")`, with the app filtering
+one metacharacter:
+
+| app strips | `dq` | `subshell` |
+|---|---|---|
+| `"` | inert | **executes** |
+| `$` | executes | inert (backtick form still executes) |
+
+Both substitution forms ship because they survive different filters.
+
+And the rung matters **per method**, which is the counter-intuitive part.
+`reflected`'s core is `$((a+b))`, which the shell expands inside double quotes
+anyway — so that method already confirmed on a quoted sink without this rung.
+The methods whose core has to actually *run* something are the ones that were
+blind there:
+
+| Core | Inside `"…"` | Inside `$( )` |
+|---|---|---|
+| `$((a+b))` — `reflected` | expands | expands |
+| `sleep 5` — `time` | inert | sleeps |
+| `echo TOKEN > file` — `file` | no write | writes |
+| `curl …` — `oob` | no request | fetches |
+
+Narrow the ladder once the sink's shape is known — it is the request-count
+control. `--sink-raw` is the narrowing alias for `--sink-shape raw`, and naming
+`--separators` implies the sink is separator-led, so the `raw` rung is dropped
+unless you name it explicitly. A profile with `sink_needs_separator` drops it
+too. The plan is printed before anything is sent:
+
+```
+[detect] sink shapes: auto (full ladder)
+[detect]   sep       '; ' -- mid-command concatenation
+[detect]   raw       input is the whole command (no separator)
+...
+```
+
+`eval` does not ride the ladder: its probes are template/expression syntax, not
+shell, so no separator or quote break-out applies to them.
 
 ### Machine-readable results
 

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.25.0"
+__version__ = "2.26.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -36,6 +36,88 @@ SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 # engine: keeping it in one place is what stops the two from drifting apart,
 # as they did when only the generator carried the guard.
 SELF_SEPARATING_CONTEXTS = {"shell_single_quoted", "shell_double_quoted"}
+
+# Contexts that reach the shell through *command substitution* rather than by
+# breaking out of the running command. They need no separator either, but for
+# the opposite reason: there is nothing to break out of. The payload is a
+# substitution the shell evaluates where it sits.
+#
+# This is the sink shape no other context reaches. Measured against `sh -c 'echo
+# PING "<input>"'`, with the app filtering one metacharacter:
+#
+#   filter        shell_double_quoted   shell_subshell   shell_backtick
+#   strips "      inert                 EXECUTED         EXECUTED
+#   strips $      EXECUTED              inert            EXECUTED
+#
+# So the quoted break-out and the substitution cover different filters, and the
+# backtick form survives both -- which is why both substitution shapes ship
+# rather than the `$( )` one alone.
+SUBSTITUTION_CONTEXTS = {"shell_subshell", "shell_backtick"}
+
+# Contexts that supply their own way into the shell, so a probe must not prepend
+# a command separator to them.
+NO_SEPARATOR_CONTEXTS = SELF_SEPARATING_CONTEXTS | SUBSTITUTION_CONTEXTS
+
+# The sink-shape ladder: one name per shape the injected value can land in, in
+# escalation order (cheapest and most common first). `--sink-shape` selects
+# rungs; the machinery underneath is the existing separator sweep and break-out
+# contexts, so naming a rung narrows an already-supported run rather than
+# switching on a parallel code path.
+SINK_SHAPE_RUNGS = ("sep", "raw", "chain", "newline", "dq", "sq", "subshell")
+# Rungs that vary the command *separator* the probe breaks out with.
+SINK_SHAPE_SEPARATORS = {
+    "sep": ("; ",),
+    "chain": ("| ", "|| ", "&& "),
+    "newline": ("\n",),
+}
+# Rungs that vary the *context* the probe is wrapped in.
+SINK_SHAPE_CONTEXTS = {
+    "sq": ("shell_single_quoted",),
+    "dq": ("shell_double_quoted",),
+    "subshell": ("shell_subshell", "shell_backtick"),
+}
+
+
+# Methods whose probes are shell commands, and so ride the sink-shape ladder.
+# `eval` is deliberately absent: its probes are template/expression syntax, not
+# shell, so no separator or quote break-out applies to them.
+SHELL_PROBE_METHODS = {"reflected", "file", "time", "oob"}
+
+
+def sink_shape_plan(shapes: Optional[Tuple[str, ...]]) -> List[str]:
+    """One line per rung the run will try, for the pre-flight execution plan.
+
+    The ladder multiplies request count, so what it is about to send is stated
+    before it is sent rather than inferred from the traffic afterwards."""
+    selected = shapes or SINK_SHAPE_RUNGS
+    described = {
+        "raw": "input is the whole command (no separator)",
+        "sep": "'; ' -- mid-command concatenation",
+        "chain": "'| ', '|| ', '&& ' -- pipes and conditional chains",
+        "newline": "newline -- line-oriented sinks (CGI, config writers)",
+        "sq": "\"'; ... #\" -- value inside single quotes",
+        "dq": "'\"; ... #' -- value inside double quotes",
+        "subshell": "'$(...)' and backticks -- substitution inside a quoted string",
+    }
+    return [f"[detect]   {rung:<9} {described[rung]}"
+            for rung in SINK_SHAPE_RUNGS if rung in selected]
+
+
+def parse_sink_shapes(value: Optional[str]) -> Optional[Tuple[str, ...]]:
+    """``--sink-shape`` -> the rungs to try, or ``None`` for the whole ladder.
+
+    Raises ``ValueError`` naming the offending rung, so a typo is refused rather
+    than silently narrowing the run to nothing."""
+    if not value or value == "auto":
+        return None
+    rungs = tuple(part.strip() for part in value.split(",") if part.strip())
+    unknown = [rung for rung in rungs if rung not in SINK_SHAPE_RUNGS]
+    if unknown:
+        raise ValueError(f"unknown sink shape(s): {', '.join(unknown)}; "
+                         f"choose from auto, {', '.join(SINK_SHAPE_RUNGS)}")
+    if not rungs:
+        return None
+    return rungs
 
 
 @dataclass(frozen=True)
@@ -101,6 +183,12 @@ class RCEKit:
             "powershell": {"prefix": "", "suffix": "", "escape": "none"},
             "shell_single_quoted": {"prefix": "'; ", "suffix": " #", "escape": "none"},
             "shell_double_quoted": {"prefix": "\"; ", "suffix": " #", "escape": "none"},
+            # Command substitution: runs where it sits, so it reaches a
+            # double-quoted sink without closing the quote (see
+            # SUBSTITUTION_CONTEXTS). Both forms ship because they survive
+            # different filters.
+            "shell_subshell": {"prefix": "$(", "suffix": ")", "escape": "none"},
+            "shell_backtick": {"prefix": "`", "suffix": "`", "escape": "none"},
             "graphql_string": {"prefix": "", "suffix": "", "escape": "graphql"},
             # Transport / serialization contexts (carry any environment's payload)
             "json": {"prefix": "", "suffix": "", "escape": "json"},
@@ -1827,16 +1915,29 @@ class RCEKit:
         one sink shape they exist for was the one shape that could not be
         detected at all. They are cheap (self-separating, so one body each).
 
+        The substitution contexts ride here too, for the same reason and with
+        the same shape of argument: ``$(...)`` and backticks reach a sink whose
+        value sits inside double quotes *without closing the quote*, which is
+        the one case a quoted break-out loses to a filter on the quote itself.
+
+        Which contexts are added follows ``--sink-shape``, so naming a rung
+        narrows this rather than bypassing it.
+
         Skipped when the operator named ``--contexts`` explicitly -- a narrowed
         run is a deliberate choice about what to send, and widening it behind
         the operator's back is not this function's call."""
         if config.get("contexts_explicit"):
             return []
+        shapes = config.get("sink_shapes")
+        wanted: List[str] = []
+        for rung in SINK_SHAPE_RUNGS:
+            if rung in SINK_SHAPE_CONTEXTS and (not shapes or rung in shapes):
+                wanted.extend(SINK_SHAPE_CONTEXTS[rung])
         extra: List[PayloadRecord] = []
         for record in list(carriers):
             if record.environment not in SHELL_CAPABLE_ENVIRONMENTS:
                 continue
-            for context in sorted(SELF_SEPARATING_CONTEXTS):
+            for context in wanted:
                 key = (record.environment, context)
                 if key in carrier_seen:
                     continue
@@ -2585,25 +2686,79 @@ class DetectionMethod:
     }
 
     def _separators(self, windows: bool) -> Tuple[str, ...]:
-        """The separators to sweep, from ``--separators`` when given."""
+        """The separators to sweep.
+
+        ``--separators`` is the explicit, lowest-level control and still wins
+        outright. Otherwise ``--sink-shape`` narrows the sweep to the separators
+        of the rungs it named — and if it named none of them (say
+        ``--sink-shape sq``), the sweep is empty on purpose: the only shapes
+        left are ones that supply their own way into the shell, so a
+        separator-led probe would be a request that cannot confirm.
+
+        Windows keeps its own table. Its separators are genuinely different
+        (``&`` and ``&&`` work, ``;`` does not), so a rung name maps to the
+        environment's own vocabulary rather than to a global one."""
         configured = self.config.get("separators")
         if configured:
             return tuple(configured)
-        return self.DEFAULT_SEPARATORS["windows" if windows else "unix"]
+        table = self.DEFAULT_SEPARATORS["windows" if windows else "unix"]
+        shapes = self.config.get("sink_shapes")
+        if not shapes:
+            return table
+        if windows:
+            # Map the rungs onto cmd.exe's vocabulary by position of meaning:
+            # 'sep' is its plain chainer, 'chain' its pipes/conditionals. cmd
+            # has no line-oriented separator, so 'newline' contributes nothing.
+            windows_rungs = {"sep": (" & ",), "chain": (" | ", " || ", " && "), "newline": ()}
+            selected: List[str] = []
+            for rung in SINK_SHAPE_RUNGS:
+                if rung in shapes:
+                    selected.extend(windows_rungs.get(rung, ()))
+            return tuple(dict.fromkeys(selected))
+        selected = []
+        for rung in SINK_SHAPE_RUNGS:
+            if rung in shapes:
+                selected.extend(SINK_SHAPE_SEPARATORS.get(rung, ()))
+        return tuple(dict.fromkeys(selected))
 
     def _needs_separator(self, record: "PayloadRecord") -> bool:
         """Whether a probe for this record must supply its own separator.
 
-        Two cases must not get one. With ``--sink-raw`` the injected input is
+        Three cases must not get one. With ``--sink-raw`` the injected input is
         executed as the *whole* command (a ``qx/$input/``-style sink with no
         surrounding command to break out of), so a leading ``;`` is a syntax
-        error. And a shell-quoted context's prefix already ends in one, so
+        error. A shell-quoted context's prefix already ends in one, so
         adding another produced ``'; ; cmd`` -- the generator has guarded that
         since it was found there; the detection engine had not, which made the
         one context genuinely fitting a quoted sink the one that could not
-        confirm on it."""
+        confirm on it.
+
+        A substitution context is the third, and it is not the second in
+        disguise: ``$(cmd)`` and ``` `cmd` ``` never break out of the running
+        command, they *are* an expression the shell evaluates where it sits. A
+        leading ``;`` would put a syntax error inside the substitution."""
         return not (self.config.get("sink_raw")
-                    or record.context in SELF_SEPARATING_CONTEXTS)
+                    or record.context in NO_SEPARATOR_CONTEXTS)
+
+    def _raw_rung_selected(self) -> bool:
+        """Whether the bare, separator-free body should also be sent.
+
+        Part of the ladder rather than a mode: ``--sink-raw`` makes the raw
+        shape the *only* one tried (a deliberate narrowing, unchanged), while
+        the ladder sends it *alongside* the separator sweep so a whole-command
+        sink is found without the operator having guessed its shape first."""
+        if self.config.get("sink_raw"):
+            return False  # already the only body; see _needs_separator
+        shapes = self.config.get("sink_shapes")
+        if shapes is not None:
+            return "raw" in shapes
+        if self.config.get("separators"):
+            # Naming the separators is a statement that the sink is
+            # separator-led: the operator has said which break-outs it accepts,
+            # so a bare command is not one of the shapes they asked for.
+            # --sink-shape raw,... overrides this, being the more specific say.
+            return False
+        return True
 
     def _wrap_variants(self, record: "PayloadRecord", core: str, windows: bool = False,
                        evade: bool = True, terminate: bool = False) -> List[str]:
@@ -2635,6 +2790,14 @@ class DetectionMethod:
             core = f"{core} #"
         if self._needs_separator(record):
             bodies = [f"{separator}{core}" for separator in self._separators(windows)]
+            if self._raw_rung_selected():
+                # The `raw` rung: the sink runs the injected value as the whole
+                # command, so the bare core is the probe. It used to need
+                # --sink-raw, which meant a qx/$input/-style sink reported clean
+                # unless the operator already suspected its shape -- a false
+                # negative that took prior knowledge to avoid. One extra probe
+                # per carrier buys it.
+                bodies.append(core)
         else:
             bodies = [core]
         payloads: List[str] = []
@@ -2672,6 +2835,10 @@ class DetectionMethod:
             if " " in trimmed:
                 continue
             pairs.append((separator, f"{trimmed}{core}"))
+        if self._raw_rung_selected():
+            # A space-filtering sink can also be a whole-command sink; the two
+            # filters are unrelated, so the raw rung applies here as well.
+            pairs.append((None, core))
         return pairs
 
     def _context_swallows(self, record: "PayloadRecord", body: str) -> bool:
@@ -2689,6 +2856,13 @@ class DetectionMethod:
         ``shell_double_quoted`` (``"; `` … `` #``) *closes* the sink's quote and
         comments out its tail, so quotes in the body are fine — verified.
 
+        The backtick substitution context is the same failure through a
+        different character: ``` `...` ``` does not nest, so a probe whose body
+        carries its own backtick (the ``expr`` shape does) closes the outer
+        substitution early and the remainder is no longer a command. ``$( )``
+        *does* nest, so the subshell context carries every shape and is
+        deliberately not caught here.
+
         Only for contexts that pass the body through verbatim. Where an escape
         rule applies, the quote is the serialization layer's, and what the sink
         finally sees depends on the parser in between."""
@@ -2696,7 +2870,7 @@ class DetectionMethod:
         prefix, suffix = ctx.get("prefix", ""), ctx.get("suffix", "")
         if ctx.get("escape", "none") != "none":
             return False
-        if prefix and prefix == suffix and prefix in ('"', "'"):
+        if prefix and prefix == suffix and prefix in ('"', "'", "`"):
             return prefix in body
         return False
 
@@ -3900,7 +4074,16 @@ def main():
     parser.add_argument("--sink-raw", action="store_true", default=None,
                         help="(--methods) Sink runs the injected input as the whole command "
                              "(no surrounding command to break out of, e.g. a qx/$input/ sink): "
-                             "send shell probes as bare commands without a leading separator")
+                             "send shell probes as bare commands ONLY. Narrowing alias for "
+                             "--sink-shape raw; the ladder already tries the raw shape alongside "
+                             "the others, so this is for cutting requests once you know the sink.")
+    parser.add_argument("--sink-shape", default=None, metavar="SHAPES",
+                        help="(--methods) Which sink shapes the shell probes try, comma-separated: "
+                             f"auto (default, the whole ladder) or any of {', '.join(SINK_SHAPE_RUNGS)}. "
+                             "sep/chain/newline vary the command separator; raw sends the bare "
+                             "command; sq/dq break out of a surrounding quote; subshell reaches a "
+                             "quoted value through $(...) and backticks without closing the quote. "
+                             "Narrow it to cut request count once the sink's shape is known.")
     parser.add_argument("--sink-blind", action="store_true", default=None,
                         help="Sink returns no output: keep only out-of-band confirmable payloads (timing/OOB)")
     parser.add_argument("--sink-decodes", nargs="+", default=None,
@@ -3963,6 +4146,16 @@ def main():
     # Sink-shape awareness: narrow generation to what this sink could execute.
     needs_separator = bool(from_profile(args.sink_needs_separator, "sink_needs_separator"))
     sink_raw = bool(from_profile(args.sink_raw, "sink_raw"))
+    try:
+        sink_shapes = parse_sink_shapes(from_profile(args.sink_shape, "sink_shape"))
+    except ValueError as exc:
+        print(f"[!] {exc}")
+        return 1
+    if needs_separator and sink_shapes is None:
+        # A profile that states the sink concatenates input mid-command has
+        # already ruled the raw shape out: the value is never the whole command
+        # there, so those probes are requests that cannot confirm.
+        sink_shapes = tuple(rung for rung in SINK_SHAPE_RUNGS if rung != "raw")
     blind = bool(from_profile(args.sink_blind, "sink_blind"))
     sink_decodes = from_profile(args.sink_decodes, "sink_decodes") or []
     # Separators the shell probes break out with. A profile may carry them as a
@@ -4199,6 +4392,7 @@ def main():
             detection_config = {"webroot": args.webroot, "web_base_url": args.web_base_url,
                                 "time_base": args.time_base, "evade": args.evade,
                                 "sink_raw": sink_raw, "separators": separators,
+                                "sink_shapes": sink_shapes,
                                 "probe_depth": args.probe_depth,
                                 "contexts_explicit": bool(selected_contexts),
                                 "oob_host": args.oob_host,
@@ -4244,6 +4438,15 @@ def main():
                     return 1
                 print(f"[detect] file-based method WRITES to {args.webroot} on the target and fetches via "
                       f"{args.web_base_url}; each confirmed finding lists a cleanup command.")
+            if not sink_raw and set(method_names) & SHELL_PROBE_METHODS:
+                # The ladder multiplies request count, so say which shapes are
+                # about to be tried before trying them. An operator on a
+                # monitored engagement needs to see the cost first, not infer it
+                # from the traffic afterwards.
+                label = "auto (full ladder)" if sink_shapes is None else ", ".join(sink_shapes)
+                print(f"[detect] sink shapes: {label}")
+                for line in sink_shape_plan(sink_shapes):
+                    print(line)
             results = generator.run_detection(
                 to_send, url=verify_url, methods=method_names, method=method,
                 data=verify_data, headers=verify_headers, delay=args.verify_delay,

--- a/rcekit.py
+++ b/rcekit.py
@@ -84,6 +84,31 @@ SINK_SHAPE_CONTEXTS = {
 SHELL_PROBE_METHODS = {"reflected", "file", "time", "oob"}
 
 
+def effective_sink_shapes(config: Dict[str, Any]) -> Tuple[str, ...]:
+    """The rungs a run will *actually* try, after every narrowing in play.
+
+    ``--sink-shape`` is the operator's stated choice, but three other flags
+    narrow it, and the pre-flight plan is presented as an audit of the traffic
+    about to be sent -- so it has to be computed from the effective state rather
+    than from the raw flag, or it describes a run that will not happen.
+
+    Single source of truth: the engine asks this too (see
+    ``DetectionMethod._raw_rung_selected``), so what is printed and what is sent
+    cannot drift."""
+    if config.get("sink_raw"):
+        return ("raw",)
+    shapes = config.get("sink_shapes")
+    selected = set(shapes if shapes is not None else SINK_SHAPE_RUNGS)
+    if shapes is None and config.get("separators"):
+        # Naming the separators is a statement that the sink is separator-led.
+        selected.discard("raw")
+    if config.get("contexts_explicit"):
+        # An explicit --contexts suppresses the added quote/substitution
+        # carriers, so those rungs never get a carrier to ride on.
+        selected -= set(SINK_SHAPE_CONTEXTS)
+    return tuple(rung for rung in SINK_SHAPE_RUNGS if rung in selected)
+
+
 def sink_shape_plan(shapes: Optional[Tuple[str, ...]]) -> List[str]:
     """One line per rung the run will try, for the pre-flight execution plan.
 
@@ -2024,6 +2049,16 @@ class RCEKit:
                             if delay:
                                 time.sleep(delay)
                         batch = meth.next_probes(series)
+                    if not series:
+                        # The method built no probes for this carrier, so there
+                        # is nothing to judge. Falling through would ask an
+                        # aggregate method to decide from zero samples, and its
+                        # honest answer to that ("no delay was observed", "no
+                        # callback arrived") reads as `negative` -- a run that
+                        # tested nothing reported as "not vulnerable". Emitting
+                        # no row is what makes the engine's own nothing-tested
+                        # path fire instead.
+                        continue
                     per_probe = meth.confirm_each(series)
                     if per_probe is not None:
                         for probe, verdict in per_probe:
@@ -2749,16 +2784,26 @@ class DetectionMethod:
         sink is found without the operator having guessed its shape first."""
         if self.config.get("sink_raw"):
             return False  # already the only body; see _needs_separator
-        shapes = self.config.get("sink_shapes")
-        if shapes is not None:
-            return "raw" in shapes
-        if self.config.get("separators"):
-            # Naming the separators is a statement that the sink is
-            # separator-led: the operator has said which break-outs it accepts,
-            # so a bare command is not one of the shapes they asked for.
-            # --sink-shape raw,... overrides this, being the more specific say.
-            return False
-        return True
+        return "raw" in effective_sink_shapes(self.config)
+
+    def _separator_candidates(self, record: "PayloadRecord",
+                              windows: bool) -> Tuple[Optional[str], ...]:
+        """The separators to build one probe each for; ``None`` means "none".
+
+        Every method that builds a probe per separator goes through here, which
+        is the point. The raw rung used to live only in ``_wrap_variants``, so
+        it reached ``reflected`` and nothing else: ``file``, ``time`` and ``oob``
+        read the separator list directly and so never sent a bare command to a
+        whole-command sink. Worse, narrowing those methods to ``--sink-shape
+        raw`` left them with an empty separator list and *zero probes*, and an
+        aggregate method with no samples reported ``negative`` -- a run that
+        tested nothing reading as "not vulnerable"."""
+        if not self._needs_separator(record):
+            return (None,)
+        candidates: List[Optional[str]] = list(self._separators(windows))
+        if self._raw_rung_selected():
+            candidates.append(None)
+        return tuple(candidates)
 
     def _wrap_variants(self, record: "PayloadRecord", core: str, windows: bool = False,
                        evade: bool = True, terminate: bool = False) -> List[str]:
@@ -2788,18 +2833,14 @@ class DetectionMethod:
             if windows or ctx.get("suffix"):
                 return []
             core = f"{core} #"
-        if self._needs_separator(record):
-            bodies = [f"{separator}{core}" for separator in self._separators(windows)]
-            if self._raw_rung_selected():
-                # The `raw` rung: the sink runs the injected value as the whole
-                # command, so the bare core is the probe. It used to need
-                # --sink-raw, which meant a qx/$input/-style sink reported clean
-                # unless the operator already suspected its shape -- a false
-                # negative that took prior knowledge to avoid. One extra probe
-                # per carrier buys it.
-                bodies.append(core)
-        else:
-            bodies = [core]
+        # One body per candidate, where a `None` candidate is the `raw` rung:
+        # the sink runs the injected value as the whole command, so the bare
+        # core is the probe. It used to need --sink-raw, which meant a
+        # qx/$input/-style sink reported clean unless the operator already
+        # suspected its shape -- a false negative that took prior knowledge to
+        # avoid.
+        bodies = [core if separator is None else f"{separator}{core}"
+                  for separator in self._separator_candidates(record, windows)]
         payloads: List[str] = []
         for body in bodies:
             if evade and not windows and self.config.get("evade") == "low":
@@ -2827,18 +2868,17 @@ class DetectionMethod:
         are trimmed here — no shell needs the space after ``;`` or ``&&``. The
         newline separator is kept as-is: it is not a space, and a sink that
         strips spaces still passes it through."""
-        if not self._needs_separator(record):
-            return [(None, core)]
         pairs: List[Tuple[Optional[str], str]] = []
-        for separator in self._separators(windows=False):
+        for separator in self._separator_candidates(record, windows=False):
+            if separator is None:
+                # The raw rung. A space-filtering sink can also be a
+                # whole-command sink; the two filters are unrelated.
+                pairs.append((None, core))
+                continue
             trimmed = separator if separator == "\n" else separator.strip()
             if " " in trimmed:
                 continue
             pairs.append((separator, f"{trimmed}{core}"))
-        if self._raw_rung_selected():
-            # A space-filtering sink can also be a whole-command sink; the two
-            # filters are unrelated, so the raw rung applies here as well.
-            pairs.append((None, core))
         return pairs
 
     def _context_swallows(self, record: "PayloadRecord", body: str) -> bool:
@@ -3022,7 +3062,7 @@ class FileBased(DetectionMethod):
         # probe's followup succeed as soon as any one separator wrote the file,
         # so a confirmation could not say which break-out actually worked -- and
         # its cleanup command would name a file another probe wrote.
-        for separator in (self._separators(windows) if self._needs_separator(record) else (None,)):
+        for separator in self._separator_candidates(record, windows):
             name = "rcekit-" + "".join(rng.choice(string.ascii_lowercase + string.digits)
                                        for _ in range(12)) + ".txt"
             token = self._tag(rng) + "".join(rng.choice(string.ascii_uppercase + string.digits)
@@ -3125,7 +3165,7 @@ class ParametricTime(DetectionMethod):
         # and only for the operator who chose 'quick' to be gentle on a
         # rate-limited target. --probe-depth trades probe *shapes* for requests;
         # it does not trade away a break-out this method cannot detect without.
-        separators = (self._separators(windows) if self._needs_separator(record) else (None,))
+        separators = self._separator_candidates(record, windows)
         # Screen in two waves. Each delayed screen probe costs a real sleep, so
         # screening all five separators up front spent `5 x base` seconds on
         # every carrier -- including the carriers that can never break out at
@@ -3380,7 +3420,7 @@ class OobCallback(DetectionMethod):
 
         listener = self.config.get("oob_listener")
 
-        separators = (self._separators(windows) if self._needs_separator(record) else (None,))
+        separators = self._separator_candidates(record, windows)
 
         def add(core_for_token, label: str):
             # A token per *separator*, not per shape. Sharing one token across
@@ -4438,15 +4478,26 @@ def main():
                     return 1
                 print(f"[detect] file-based method WRITES to {args.webroot} on the target and fetches via "
                       f"{args.web_base_url}; each confirmed finding lists a cleanup command.")
-            if not sink_raw and set(method_names) & SHELL_PROBE_METHODS:
+            if set(method_names) & SHELL_PROBE_METHODS:
                 # The ladder multiplies request count, so say which shapes are
                 # about to be tried before trying them. An operator on a
                 # monitored engagement needs to see the cost first, not infer it
                 # from the traffic afterwards.
-                label = "auto (full ladder)" if sink_shapes is None else ", ".join(sink_shapes)
+                #
+                # Computed from the effective state, not from --sink-shape:
+                # --separators, --contexts and --sink-raw each narrow the ladder,
+                # so printing the raw flag would describe a run that is not the
+                # one about to happen. This output is an audit or it is noise.
+                effective = effective_sink_shapes(detection_config)
+                narrowed = (sink_shapes is not None or sink_raw or separators
+                            or bool(selected_contexts))
+                label = ", ".join(effective) if narrowed else "auto (full ladder)"
                 print(f"[detect] sink shapes: {label}")
-                for line in sink_shape_plan(sink_shapes):
+                for line in sink_shape_plan(effective):
                     print(line)
+                if separators:
+                    print("[detect]   (separators pinned by --separators: "
+                          f"{', '.join(repr(s) for s in separators)})")
             results = generator.run_detection(
                 to_send, url=verify_url, methods=method_names, method=method,
                 data=verify_data, headers=verify_headers, delay=args.verify_delay,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -3160,9 +3160,17 @@ class QuotedShellCarrierTestCase(unittest.TestCase):
         seen = {("unix", "raw")}
         return [r.context for r in RCEKit._quoted_shell_carriers(base, seen, config)]
 
-    def test_quoted_contexts_are_added_by_default(self):
+    def test_quoted_and_substitution_contexts_are_added_by_default(self):
+        # The substitution contexts joined the quoted ones here: they are the
+        # shapes that reach a value sitting inside double quotes *without*
+        # closing the quote, which is what a filter on the quote defeats.
         self.assertEqual(sorted(self._carriers({})),
-                         ["shell_double_quoted", "shell_single_quoted"])
+                         ["shell_backtick", "shell_double_quoted", "shell_single_quoted",
+                          "shell_subshell"])
+
+    def test_naming_rungs_narrows_which_contexts_are_added(self):
+        self.assertEqual(sorted(self._carriers({"sink_shapes": ("dq", "subshell")})),
+                         ["shell_backtick", "shell_double_quoted", "shell_subshell"])
 
     def test_an_explicit_contexts_selection_is_respected(self):
         # Narrowing the run is a deliberate choice about what to send; widening
@@ -3177,7 +3185,7 @@ class QuotedShellCarrierTestCase(unittest.TestCase):
         base = [make_record(environment="unix", context="shell_single_quoted")]
         seen = {("unix", "shell_single_quoted")}
         self.assertEqual([r.context for r in RCEKit._quoted_shell_carriers(base, seen, {})],
-                         ["shell_double_quoted"])
+                         ["shell_double_quoted", "shell_subshell", "shell_backtick"])
 
     def test_a_single_quoted_sink_is_confirmed_without_naming_the_context(self):
         import os
@@ -3800,6 +3808,220 @@ class TimingScreenDepthTestCase(unittest.TestCase):
             self.gen, {"time_base": 1.0, "separators": ["| "]}).build_probes(
             self.rec, _random.Random(1))
         self.assertEqual({p.separator for p in probes}, {"| "})
+
+
+class SinkShapeLadderTestCase(unittest.TestCase):
+    """The sink-shape ladder: the shapes an injected value can land in.
+
+    The rung that carries the weight is `subshell`. Its value is *not* where it
+    first looks: `reflected`'s arithmetic core `$((a+b))` is expanded by the
+    shell inside double quotes anyway, so that method already confirmed on a
+    quoted sink without any new rung. The methods whose core has to actually
+    *run* something — file (a redirect), time (a sleep), oob (a fetch) — are
+    completely inert inside those quotes, and a command substitution is the only
+    shape that reaches them there. These lock that distinction in, because it is
+    the reason the rung exists."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.rec = make_record(environment="unix", context="raw")
+
+    def _payloads(self, context, config=None, method=ReflectedMath):
+        import random as _random
+        rec = make_record(environment="unix", context=context)
+        return [p.payload for p in method(self.gen, config or {}).build_probes(
+            rec, _random.Random(5))]
+
+    # -- shape parsing -------------------------------------------------------
+
+    def test_auto_and_empty_mean_the_whole_ladder(self):
+        for value in (None, "", "auto"):
+            self.assertIsNone(rcekit.parse_sink_shapes(value), value)
+
+    def test_named_rungs_are_parsed_in_order(self):
+        self.assertEqual(rcekit.parse_sink_shapes("sq,subshell"), ("sq", "subshell"))
+        self.assertEqual(rcekit.parse_sink_shapes(" raw , sep "), ("raw", "sep"))
+
+    def test_an_unknown_rung_is_refused_by_name(self):
+        # Silently narrowing a run to nothing because of a typo would report a
+        # clean negative from a run that tested almost nothing.
+        with self.assertRaises(ValueError) as ctx:
+            rcekit.parse_sink_shapes("sq,bogus")
+        self.assertIn("bogus", str(ctx.exception))
+
+    def test_every_rung_has_a_plan_line(self):
+        lines = rcekit.sink_shape_plan(None)
+        self.assertEqual(len(lines), len(rcekit.SINK_SHAPE_RUNGS))
+        for rung in rcekit.SINK_SHAPE_RUNGS:
+            self.assertTrue(any(f" {rung} " in line for line in lines), rung)
+
+    def test_the_plan_lists_only_the_selected_rungs(self):
+        lines = rcekit.sink_shape_plan(("sq", "subshell"))
+        self.assertEqual(len(lines), 2)
+        self.assertTrue(any(" sq " in line for line in lines))
+        self.assertFalse(any(" chain " in line for line in lines))
+
+    # -- substitution contexts ----------------------------------------------
+
+    def test_substitution_contexts_get_no_separator(self):
+        # $(...) does not break out of a running command, it is an expression
+        # evaluated where it sits. A leading ';' would be a syntax error inside
+        # the substitution.
+        for context, opener in (("shell_subshell", "$("), ("shell_backtick", "`")):
+            for payload in self._payloads(context):
+                self.assertTrue(payload.startswith(opener), payload)
+                self.assertFalse(payload.startswith(("; ", "| ", "&& ")), payload)
+
+    def test_substitution_probes_still_carry_an_unforgeable_expected_value(self):
+        import random as _random
+        rec = make_record(environment="unix", context="shell_subshell")
+        for probe in ReflectedMath(self.gen).build_probes(rec, _random.Random(5)):
+            self.assertNotIn(probe.expected, probe.payload)
+
+    def test_the_backtick_context_drops_shapes_that_carry_a_backtick(self):
+        # Backticks do not nest: a body carrying its own would close the outer
+        # substitution early, so the probe could only ever come back negative.
+        for payload in self._payloads("shell_backtick"):
+            self.assertEqual(payload.count("`"), 2, payload)
+
+    def test_the_subshell_context_keeps_them_because_it_nests(self):
+        # $( ) does nest, so it carries every shape including the backtick one —
+        # dropping it there would be a lost probe for no reason.
+        self.assertTrue(any("`expr " in p for p in self._payloads("shell_subshell")))
+
+    def test_substitution_carriers_are_added_under_auto(self):
+        carriers = self.gen._quoted_shell_carriers([self.rec], {("unix", "raw")}, {})
+        contexts = {c.context for c in carriers}
+        self.assertIn("shell_subshell", contexts)
+        self.assertIn("shell_backtick", contexts)
+        self.assertIn("shell_single_quoted", contexts)
+
+    def test_naming_rungs_narrows_which_carriers_are_added(self):
+        carriers = self.gen._quoted_shell_carriers(
+            [self.rec], {("unix", "raw")}, {"sink_shapes": ("sq",)})
+        self.assertEqual({c.context for c in carriers}, {"shell_single_quoted"})
+
+    def test_explicit_contexts_still_suppress_the_extra_carriers(self):
+        self.assertEqual(
+            self.gen._quoted_shell_carriers([self.rec], {("unix", "raw")},
+                                            {"contexts_explicit": True}), [])
+
+    # -- the raw rung --------------------------------------------------------
+
+    def test_the_ladder_sends_the_bare_command_alongside_the_separators(self):
+        # A qx/$input/ sink used to need --sink-raw, so it reported clean unless
+        # the operator already suspected its shape. The ladder tries it.
+        payloads = self._payloads("raw")
+        self.assertTrue(any(p.startswith("; ") for p in payloads))
+        self.assertTrue(any(p.startswith("echo ") for p in payloads),
+                        "the raw rung must send a bare command too")
+
+    def test_sink_raw_still_narrows_to_the_bare_command_only(self):
+        payloads = self._payloads("raw", {"sink_raw": True})
+        self.assertTrue(payloads)
+        for payload in payloads:
+            self.assertFalse(payload.lstrip().startswith((";", "|", "&")), payload)
+
+    def test_dropping_the_raw_rung_drops_the_bare_command(self):
+        # Every payload stays separator-led. The space-free shape trims the
+        # separator's trailing space (a space-stripping sink would remove it
+        # anyway), so the check is on the separator character, not the spelling.
+        payloads = self._payloads("raw", {"sink_shapes": ("sep", "chain")})
+        self.assertTrue(payloads)
+        for payload in payloads:
+            self.assertTrue(payload.startswith((";", "|", "&")), payload)
+
+    # -- separator rungs -----------------------------------------------------
+
+    def test_naming_separators_suppresses_the_raw_rung(self):
+        # Naming the separators is a statement that the sink is separator-led,
+        # so a bare command is not one of the shapes the operator asked for.
+        payloads = self._payloads("raw", {"separators": ["| "]})
+        self.assertTrue(payloads)
+        for payload in payloads:
+            self.assertTrue(payload.startswith("|"), payload)
+
+    def test_naming_the_raw_rung_overrides_that(self):
+        # --sink-shape is the more specific say, so it wins over the inference.
+        payloads = self._payloads("raw", {"separators": ["| "],
+                                          "sink_shapes": ("sep", "raw")})
+        self.assertTrue(any(p.startswith("echo ") for p in payloads), payloads)
+
+    def test_separator_rungs_select_their_own_separators(self):
+        method = ReflectedMath(self.gen, {"sink_shapes": ("chain",)})
+        self.assertEqual(method._separators(windows=False), ("| ", "|| ", "&& "))
+        method = ReflectedMath(self.gen, {"sink_shapes": ("sep", "newline")})
+        self.assertEqual(method._separators(windows=False), ("; ", "\n"))
+
+    def test_selecting_no_separator_rung_empties_the_sweep(self):
+        # With only sq/subshell selected, a separator-led probe is a request
+        # that cannot confirm.
+        method = ReflectedMath(self.gen, {"sink_shapes": ("sq", "subshell")})
+        self.assertEqual(method._separators(windows=False), ())
+
+    def test_explicit_separators_still_win_outright(self):
+        method = ReflectedMath(self.gen, {"sink_shapes": ("chain",), "separators": ["; "]})
+        self.assertEqual(method._separators(windows=False), ("; ",))
+
+    def test_windows_rungs_map_to_cmd_vocabulary(self):
+        # ';' is not a cmd.exe separator, so a rung name must resolve against
+        # the environment's own table rather than a global one.
+        method = ReflectedMath(self.gen, {"sink_shapes": ("sep",)})
+        self.assertEqual(method._separators(windows=True), (" & ",))
+        method = ReflectedMath(self.gen, {"sink_shapes": ("newline",)})
+        self.assertEqual(method._separators(windows=True), ())
+
+    def test_auto_is_unchanged_for_the_separator_sweep(self):
+        self.assertEqual(ReflectedMath(self.gen)._separators(windows=False),
+                         ReflectedMath.DEFAULT_SEPARATORS["unix"])
+
+    # -- end to end ----------------------------------------------------------
+
+    def test_a_quote_filtered_double_quoted_sink_needs_the_substitution_rung(self):
+        # The acceptance case. The sink puts the value inside double quotes and
+        # strips the quote character, so the dq break-out cannot close it. The
+        # file method's core is a redirect, which is inert inside those quotes —
+        # a command substitution is the only shape that reaches it.
+        import os
+        import tempfile
+
+        webroot = tempfile.mkdtemp()
+
+        def route(method, path, params, headers, body):
+            if path.startswith("/files/"):
+                served = os.path.join(webroot, os.path.basename(path))
+                if os.path.exists(served):
+                    with open(served) as handle:
+                        return 200, handle.read()
+                return 404, "not found"
+            raw = params.get("host", "").replace('"', "")
+            pipe = os.popen('echo PING "%s" 2>&1' % raw)
+            out = pipe.read()
+            pipe.close()
+            return 200, out
+
+        with local_target(route) as base:
+            config = {"webroot": webroot, "web_base_url": f"{base}/files"}
+            without = self.gen.run_detection(
+                [self.rec], url=f"{base}/?host=FUZZ", methods=["file"],
+                config=dict(config, sink_shapes=("sep", "chain", "newline", "sq", "dq", "raw")),
+                timeout=15)
+            with_ladder = self.gen.run_detection(
+                [self.rec], url=f"{base}/?host=FUZZ", methods=["file"],
+                config=config, timeout=15)
+
+        self.assertFalse([r for r in without if r["verdict"] == "confirmed"],
+                         "precondition: without the substitution rung this sink reads clean")
+        confirmed = [r for r in with_ladder if r["verdict"] == "confirmed"]
+        self.assertTrue(confirmed, "the substitution rung must reach a quote-filtered sink")
+        self.assertTrue({r["context"] for r in confirmed} <= rcekit.SUBSTITUTION_CONTEXTS)
+
+    def test_a_clean_target_stays_negative_through_every_rung(self):
+        # Widening the ladder must not widen what gets confirmed.
+        with local_target(lambda *a: (200, "<html>static 12345678</html>")) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/?host=FUZZ", methods=["reflected"])
+        self.assertFalse([r for r in results if r["verdict"] == "confirmed"])
 
 
 class ResponseChannelTestCase(unittest.TestCase):

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2154,8 +2154,10 @@ class ParametricTimeTestCase(unittest.TestCase):
             series += [(p, Observation(status=200, body="", elapsed=0.1)) for p in batch]
             batch = self.method.next_probes(series)
         self.assertGreater(waves, 1, "the held-back separators must still be screened")
+        # None is the `raw` rung — a whole-command sink is screened alongside
+        # the break-outs, so the timing method finds one without being told.
         self.assertEqual({p.separator for p, _ in series},
-                         {"; ", "| ", "|| ", "&& ", "\n"})
+                         {"; ", "| ", "|| ", "&& ", "\n", None})
         self.assertFalse([p for p, _ in series if p.phase == "regress"])
         verdict = self.method.confirm_series(series)
         self.assertEqual(verdict.status, "negative")
@@ -2813,7 +2815,8 @@ class SeparatorSweepTestCase(unittest.TestCase):
         probes = FileBased(self.gen, {"webroot": "/var/www/html",
                                       "web_base_url": "http://t"}).build_probes(
             self.rec, _random.Random(1))
-        self.assertEqual(len(probes), 5)
+        # Five separators plus the `raw` rung's separator-free probe.
+        self.assertEqual(len(probes), 6)
         urls = {p.followup["url"] for p in probes}
         tokens = {p.expected for p in probes}
         self.assertEqual(len(urls), len(probes))
@@ -3793,7 +3796,10 @@ class TimingScreenDepthTestCase(unittest.TestCase):
         return seen
 
     def test_both_depths_screen_every_separator(self):
-        expected = {"; ", "| ", "|| ", "&& ", "\n"}
+        # None is the `raw` rung, screened at both depths for the same reason
+        # every separator is: leaving a whole sink shape undetectable is not the
+        # kind of saving --probe-depth is for.
+        expected = {"; ", "| ", "|| ", "&& ", "\n", None}
         self.assertEqual(self._separators("quick"), expected)
         self.assertEqual(self._separators("full"), expected)
 
@@ -3930,6 +3936,95 @@ class SinkShapeLadderTestCase(unittest.TestCase):
         self.assertTrue(payloads)
         for payload in payloads:
             self.assertTrue(payload.startswith((";", "|", "&")), payload)
+
+    def test_every_shell_method_gets_the_raw_rung(self):
+        # The rung used to live only in _wrap_variants, so it reached
+        # `reflected` and nothing else: file/time/oob read the separator list
+        # directly and never sent a bare command to a whole-command sink.
+        import random as _random
+        config = {"webroot": "/var/www", "web_base_url": "http://t",
+                  "time_base": 2, "oob_host": "x.example"}
+        for name, cls in (("reflected", ReflectedMath), ("file", FileBased),
+                          ("oob", rcekit.OobCallback)):
+            probes = cls(self.gen, config).build_probes(self.rec, _random.Random(1))
+            self.assertTrue(any(p.payload.startswith(("echo ", "sleep ", "curl ", "awk ",
+                                                      "expr ", "wget ", "nslookup ", "host "))
+                                for p in probes),
+                            f"{name} sends no bare command under the full ladder")
+
+    def test_the_timing_method_reaches_the_raw_rung_in_its_second_wave(self):
+        # time screens in two waves to avoid paying a sleep per separator up
+        # front, so the raw candidate lands in the second wave rather than the
+        # first. It must still be reached.
+        import random as _random
+        method = ParametricTime(self.gen, {"time_base": 2})
+        first = method.build_probes(self.rec, _random.Random(1))
+        series = [(p, Observation(status=200, body="", elapsed=0.1)) for p in first]
+        second = method.next_probes(series)
+        self.assertIn(None, {p.separator for p in second})
+        self.assertTrue(any(p.payload.startswith("sleep ") for p in second))
+
+    def test_narrowing_to_raw_leaves_every_method_with_probes(self):
+        # Narrowing to `raw` used to empty the separator list, so file/time/oob
+        # built ZERO probes -- and an aggregate method judging zero samples
+        # answered `negative`. A run that tested nothing must never read as
+        # "not vulnerable".
+        import random as _random
+        config = {"webroot": "/var/www", "web_base_url": "http://t", "time_base": 2,
+                  "oob_host": "x.example", "sink_shapes": ("raw",)}
+        for name, cls in (("reflected", ReflectedMath), ("file", FileBased),
+                          ("time", ParametricTime), ("oob", rcekit.OobCallback)):
+            probes = cls(self.gen, config).build_probes(self.rec, _random.Random(1))
+            self.assertTrue(probes, f"{name} built no probes for --sink-shape raw")
+
+    def test_a_method_that_built_no_probes_reports_nothing_rather_than_negative(self):
+        # The engine-level guard behind that. An aggregate method's honest
+        # answer to an empty series ("no delay was observed") is `negative`, so
+        # the row must not be emitted at all -- which is what lets the engine's
+        # own nothing-tested path fire instead.
+        # An explicit --contexts suppresses the sq carrier, and naming only the
+        # sq rung leaves the raw carrier with no separators and no raw rung —
+        # so nothing anywhere builds a probe.
+        with local_target(lambda *a: (200, "ok")) as base:
+            results = self.gen.run_detection(
+                [make_record(environment="unix", context="raw")],
+                url=f"{base}/?host=FUZZ", methods=["time"],
+                config={"time_base": 1, "sink_shapes": ("sq",), "contexts_explicit": True})
+        self.assertEqual(results, [],
+                         "a carrier with no probes must not produce a verdict")
+        self.assertEqual(rcekit.overall_detection_verdict(results), "nothing-tested")
+
+    # -- the effective ladder ------------------------------------------------
+
+    def test_effective_shapes_drop_raw_when_separators_are_pinned(self):
+        self.assertNotIn("raw", rcekit.effective_sink_shapes({"separators": ["| "]}))
+        self.assertIn("raw", rcekit.effective_sink_shapes({}))
+
+    def test_effective_shapes_drop_context_rungs_when_contexts_are_explicit(self):
+        # An explicit --contexts suppresses the added carriers, so those rungs
+        # never get anything to ride on.
+        effective = rcekit.effective_sink_shapes({"contexts_explicit": True})
+        for rung in ("sq", "dq", "subshell"):
+            self.assertNotIn(rung, effective)
+        self.assertIn("sep", effective)
+
+    def test_sink_raw_reduces_the_effective_ladder_to_raw(self):
+        self.assertEqual(rcekit.effective_sink_shapes({"sink_raw": True}), ("raw",))
+
+    def test_an_explicit_shape_choice_survives_the_other_narrowings(self):
+        self.assertEqual(
+            rcekit.effective_sink_shapes({"separators": ["| "], "sink_shapes": ("sep", "raw")}),
+            ("sep", "raw"))
+
+    def test_the_printed_plan_matches_what_the_engine_will_do(self):
+        # The plan is presented as an audit of the traffic about to be sent, so
+        # printing the raw flag would describe a run that is not the one about
+        # to happen.
+        config = {"separators": ["| "]}
+        self.assertEqual(ReflectedMath(self.gen, config)._raw_rung_selected(),
+                         "raw" in rcekit.effective_sink_shapes(config))
+        lines = rcekit.sink_shape_plan(rcekit.effective_sink_shapes(config))
+        self.assertFalse(any(" raw " in line for line in lines), lines)
 
     # -- separator rungs -----------------------------------------------------
 


### PR DESCRIPTION
Phase 10 of the detection coverage plan, and the last item in M1.

## Why

An injected value lands in a *shape* — mid-command, inside quotes, as the whole command — and the shape decides what can reach it. Two shapes had no probe that fitted, so a genuinely exploitable target reported `negative`.

`--sink-shape auto|sep|raw|chain|newline|dq|sq|subshell` names which rungs to try. `auto` is the whole ladder and the default. Underneath it selects the existing separator sweep and break-out contexts, so naming a rung narrows a supported run rather than switching on a parallel code path.

## The `subshell` rung

`$(...)` and backticks reach a value sitting inside double quotes **without closing the quote** — the one case a quoted break-out loses to a filter on the quote character itself. Measured against `system("echo PING \"$input\"")`:

| app strips | `dq` | `$( )` | `` ` ` `` |
|---|---|---|---|
| `"` | inert | **executes** | **executes** |
| `$` | executes | inert | **executes** |

Both substitution forms ship because they survive different filters — the plan only called for `$( )`.

## Which method it helps is not what it looks like

This is the part I got wrong before testing it, so it is worth stating plainly. `reflected`'s core is `$((a+b))`, and the shell expands that inside double quotes anyway — so `reflected` **already confirmed** on a quoted sink and this rung changes nothing for it. The methods whose core has to actually *run* something are the ones that were blind there:

| Core | Inside `"…"` | Inside `$( )` |
|---|---|---|
| `$((a+b))` — `reflected` | expands | expands |
| `sleep 3` — `time` | 0s | 3s |
| `echo TOK > file` — `file` | no write | writes |
| `curl …` — `oob` | no request | fetches |

Measured through RCEKit on a quote-filtering sink, `--methods file` went from **0 confirmations to 2**. It had been reporting an exploitable target as clean.

## The `raw` rung joins `auto`

A `qx/$input/`-style sink, where the input is the whole command, previously required `--sink-raw` — so finding it required already suspecting it. One extra probe per carrier buys it. `--sink-raw` keeps its meaning as the narrowing alias for `--sink-shape raw`; **no existing command line changes behaviour.**

## Two guards the shapes need

- **Backticks do not nest.** The backtick context drops probe shapes carrying their own backtick — they would close the outer substitution early and could only ever come back negative. `$( )` does nest and keeps every shape.
- **Naming `--separators` now implies a separator-led sink**, so the `raw` rung is dropped unless `--sink-shape` names it explicitly. An explicitly narrowed run must not be widened behind the operator's back. A profile with `sink_needs_separator` drops it for the same reason. This one was surfaced by an existing test rather than foreseen — the suite caught my first implementation quietly widening a run the operator had pinned.

## Cost

The ladder multiplies request count (35 → 61 probes per carrier set under `auto`, ~1.7×, not the 7× the plan feared). The plan is printed before anything is sent:

```
[detect] sink shapes: auto (full ladder)
[detect]   sep       '; ' -- mid-command concatenation
[detect]   raw       input is the whole command (no separator)
[detect]   chain     '| ', '|| ', '&& ' -- pipes and conditional chains
...
```

`eval` does not ride the ladder — its probes are template/expression syntax, not shell.

## Tests

25 new tests: rung parsing (including that a typo is refused by name rather than silently narrowing a run to nothing), the plan lines, both guards, per-environment separator mapping (`;` is not a `cmd.exe` separator, so a rung maps to the environment's own vocabulary), and an end-to-end quote-filtered sink that reads clean without the rung and confirms with it.

Three existing tests changed expectations, all intentional behaviour changes, none loosened.

```
python -m unittest discover -s tests
Ran 356 tests in 142.508s

OK
```

## Not implemented, deliberately

The plan asks `auto` to **short-circuit on the first `confirmed`**. I did not do that, and I would want your call before adding it: the engine currently reports *every* probe that worked, and short-circuiting would trade that away for requests. Knowing that three break-outs work — not just the first — is what tells you whether a filter is partial. At 1.7× the cost rather than 7×, the trade looks worse than the plan assumed.

## Compatibility

Additive. Version 2.25.0 → 2.26.0 (MINOR), README badge, CHANGELOG and `docs/reference.md` updated.