### PR TITLE
feat(detection): enumerate a capture's injection points instead of naming one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,53 @@ formats, or the template schema.
 
 ## [Unreleased]
 
+## [2.28.0] — 2026-08-17
+
+Injection-point enumeration. `-p NAME` needed the tester to already know which
+parameter was the sink, so a capture's other candidates — including the headers
+and nested JSON leaves that carry some of the highest-value classes — were never
+tried.
+
+### Added
+
+- **`-p all` / `--auto-params KINDS`** expands one captured request into every
+  candidate injection point and runs the selected `--methods` against each.
+  Query values, JSON leaves addressed by path (`user.profile.name`, `tags[1]`),
+  form fields, cookie crumbs and headers, each rewritten in **its own**
+  serialization rather than blanket-encoded. Verified end to end: a sink
+  reachable only through `User-Agent` is confirmed from `-r request.txt -p all`
+  with no manual header selection.
+- **`--point-order fast|thorough`** — `fast` tries a curated high-yield header
+  list (the headers real published RCEs inject through); `thorough` adds every
+  remaining non-hop-by-hop header. **`--max-points N`** bounds the run and
+  reports what it dropped. **`--include-path-segments`** is opt-in, because
+  rewriting a path segment usually just produces a 404.
+- **The run states its cost before sending it** —
+  `6 points x ~61 probes = at least 372 requests` — via a new
+  `estimate_detection_probes`, which builds the probes and counts them without
+  firing any. Enumeration multiplies an already-laddered probe count by the
+  candidate count, and an operator on a monitored engagement has to see that
+  before it happens rather than infer it from the traffic.
+- **Findings name the point they came from**: `[reflected/unix/raw] at header
+  'User-Agent' ...`.
+
+### Changed
+
+- **Each candidate carries its own payload-free control.** Differencing a header
+  probe against a query probe's control would compare two different responses
+  and prove nothing.
+- **Cheap methods run first per candidate, and a candidate stops at its first
+  confirmation.** `reflected` and `eval` cost one response each; `time` sleeps
+  and `oob` waits for a callback, and on a candidate that has already proven
+  execution those buy a second name for the same finding. Candidates that stay
+  clean still get every method, and single-point runs are unchanged.
+- A JSON leaf is **replaced, never created**. Assigning to a missing key would
+  have injected into a field the application never sends — a probe that cannot
+  say anything about the parameter that does exist. Caught by its own test.
+- `Host`, `Content-Length`, `Cookie` and the hop-by-hop headers are never
+  candidates: injecting into those changes the request's plumbing rather than
+  testing the application, and two of them are rebuilt by the delivery layer.
+
 ## [2.27.0] — 2026-08-17
 
 Engine carriers for the `eval` probe. Three template engines evaluate the
@@ -500,7 +547,8 @@ this file and have not been restated here.
 - **[2.7.0]**
 - **[2.1.0]**
 
-[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.27.0...HEAD
+[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.28.0...HEAD
+[2.28.0]: https://github.com/kabiri-labs/rcekit/compare/v2.27.0...v2.28.0
 [2.27.0]: https://github.com/kabiri-labs/rcekit/compare/v2.26.0...v2.27.0
 [2.26.0]: https://github.com/kabiri-labs/rcekit/compare/v2.25.0...v2.26.0
 [2.25.0]: https://github.com/kabiri-labs/rcekit/compare/v2.24.0...v2.25.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,20 @@ tried.
 - A JSON leaf is **replaced, never created**. Assigning to a missing key would
   have injected into a field the application never sends — a probe that cannot
   say anything about the parameter that does exist. Caught by its own test.
+- **JSON points are addressed by tokens, not by a joined path string.** A key may
+  itself contain the separator: `{"user.name": ..., "user": {"name": ...}}`
+  rendered *both* leaves as `user.name`, so the literal key was never probed and
+  both candidates mutated the nested field — a false negative and a misattributed
+  finding at once. Tokens remove the ambiguity, and the display form
+  bracket-quotes such a key (`["user.name"]`) so the two stay distinguishable on
+  screen.
+- **A deeply nested captured body no longer ends `-p all` with a traceback.**
+  `json.loads` recurses in C, so `RecursionError` joins the caught exceptions in
+  both the enumerator and the placer, as it already had in the response-channel
+  parser. The body yields no candidates; the rest of the request still enumerates.
+- **The cost estimate honours `--max-payloads`.** It counted every probe the
+  carriers could produce while the run stops at the cap, so the figure was wrong
+  exactly when the operator had reached for the budget guard.
 - `Host`, `Content-Length`, `Cookie` and the hop-by-hop headers are never
   candidates: injecting into those changes the request's plumbing rather than
   testing the application, and two of them are rebuilt by the delivery layer.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.27.0** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.28.0** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -55,6 +55,10 @@ starting point — this page is for looking things up once you know what you wan
 | `--detect-json` | Also write the run to this path as JSON: overall verdict, counts, every probe | None |
 | `--sink-shape` | Sink shapes the shell probes try: `auto`, or any of `sep`, `raw`, `chain`, `newline`, `dq`, `sq`, `subshell` | `auto` |
 | `--eval-engines` | (`eval`) Engine carriers to add to the bare expression probes: `auto`, or names from `eval_carriers` | `auto` |
+| `--auto-params` | (`-r` with `--methods`) Enumerate injection points: kinds from `query`, `json`, `form`, `cookie`, `header`, `path`, or `all`. Implied by `-p all` | off |
+| `--point-order` | (enumeration) `fast` (curated high-yield headers) or `thorough` (every non-hop-by-hop header) | `fast` |
+| `--max-points` | (enumeration) Stop after N candidates; the run reports how many it dropped | `40` |
+| `--include-path-segments` | (enumeration) Also inject into URL path segments | off |
 
 | `--methods` value | Confirms | Tier it can reach |
 |---|---|---|
@@ -103,6 +107,62 @@ depth and `--probe-depth` changes nothing for it.
 sweep, and it does not narrow the separator screen `--methods time` runs: both
 depths try every candidate break-out, because dropping one is not a saving in
 requests but a blind spot. Use `--separators` to narrow that deliberately.
+
+### Enumerating injection points
+
+`-p NAME` needs you to already know which parameter is the sink. A real capture
+carries ten to forty candidates, and some of the highest-value classes inject
+through a **header** — Shellshock through `User-Agent`, Struts2 S2-045 through
+`Content-Type` — or through a JSON leaf several levels down that no top-level
+parameter name addresses.
+
+```bash
+python rcekit.py --acknowledge-consent -r request.txt -p all --methods reflected
+```
+
+Candidates are tried in expected-yield order, each rewritten in **its own**
+serialization rather than blanket-encoded:
+
+| Kind | Addressed as | Rewritten by |
+|---|---|---|
+| `query` | parameter name | the `a=1&b=2` encoder |
+| `json` | path — `user.profile.name`, `tags[1]` | the JSON encoder, re-serialised |
+| `form` | field name | the `a=1&b=2` encoder |
+| `cookie` | crumb name | the `Cookie` header, other crumbs untouched |
+| `header` | header name | single-line header escaping |
+| `path` | segment index | the URL path (opt-in, see below) |
+
+A JSON leaf is only *replaced*, never created: assigning to a missing key would
+test a field the application never sends.
+
+`Host`, `Content-Length`, `Cookie` and the hop-by-hop headers are never
+candidates — injecting into those changes the request's plumbing rather than
+testing the app, and two of them are rebuilt by the delivery layer.
+
+Path segments are off by default (`--include-path-segments`): rewriting one
+usually just produces a 404, which costs a request and proves nothing.
+
+**The cost is printed before the traffic**, because enumeration multiplies an
+already-laddered probe count by the number of candidates:
+
+```
+[detect] enumerating 6 injection point(s) x 1 method(s)
+[detect] cost: 6 points x ~61 probes = at least 372 requests (each point carries its own payload-free control)
+[detect]   query param 'view': negative (61 probes)
+[detect]   header 'User-Agent': confirmed (61 probes)  <-- CONFIRMED
+```
+
+Each candidate gets **its own** payload-free control: differencing a header
+probe against a query probe's control would compare two different responses and
+prove nothing. Use `--max-points` and `--max-payloads` to bound a run, and
+`--verify-delay` to pace it — the delay applies across the whole enumeration.
+
+Cheap methods run first per candidate. `reflected` and `eval` cost one response
+each; `time` sleeps and `oob` waits for a callback. Once a candidate has proven
+execution, the slow methods on *that* candidate are skipped — they would buy a
+second name for a finding already made. Candidates that stay clean still get
+every method. Single-point runs (`-p NAME`, or a `FUZZ` marker) are unchanged
+and still run every method.
 
 ### Expression-engine carriers
 

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.27.0"
+__version__ = "2.28.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -77,6 +77,11 @@ SINK_SHAPE_CONTEXTS = {
     "subshell": ("shell_subshell", "shell_backtick"),
 }
 
+
+# Methods that cost one response per probe. The rest sleep (time) or wait for a
+# callback (oob) or need a second fetch (file), which is what makes them worth
+# skipping on a candidate that has already proven execution.
+CHEAP_DETECTION_METHODS = {"reflected", "eval"}
 
 # Methods whose probes are shell commands, and so ride the sink-shape ladder.
 # `eval` is deliberately absent: its probes are template/expression syntax, not
@@ -1975,6 +1980,62 @@ class RCEKit:
                 extra.append(dataclass_replace(record, context=context))
         return extra
 
+    def _detection_carriers(self, records: Iterator[PayloadRecord],
+                            config: Dict[str, Any]) -> List[PayloadRecord]:
+        """Reduce the selected records to distinct ``(environment, context)``
+        carriers, plus the extra quoted/substitution carriers.
+
+        Shared by the run and by the cost estimate, so the number printed before
+        firing is derived from the same reduction that decides what is fired."""
+        carriers: List[PayloadRecord] = []
+        carrier_seen: Set[Tuple[str, str]] = set()
+        for record in records:
+            key = (record.environment, record.context)
+            if key in carrier_seen:
+                continue
+            carrier_seen.add(key)
+            carriers.append(record)
+        carriers.extend(self._quoted_shell_carriers(carriers, carrier_seen, config))
+        return carriers
+
+    def estimate_detection_probes(self, records: List[PayloadRecord], methods: List[str],
+                                  config: Optional[Dict[str, Any]] = None) -> int:
+        """How many requests a detection run would send, without sending any.
+
+        The ladder and the carrier list both multiply probe count, and
+        enumeration multiplies it again by the number of candidate points. An
+        operator on a monitored engagement has to be able to see that number
+        *before* it happens rather than infer it from the traffic, so this
+        builds the probes and counts them.
+
+        A floor, not an exact figure: an aggregate method may answer with
+        further screening waves once it has seen the first batch, and each
+        payload-free control adds one request per run."""
+        rng = random.Random(0)
+        carriers = self._detection_carriers(records, config or {})
+        total = 0
+        seen: Set[str] = set()
+        for name in methods:
+            if name not in DETECTION_METHODS:
+                continue
+            meth = DETECTION_METHODS[name](self, config)
+            for record in carriers:
+                if not meth.applicable(record):
+                    continue
+                try:
+                    probes = meth.build_probes(record, rng)
+                except Exception:  # a cost estimate must never break the run
+                    continue
+                if getattr(meth, "aggregate", False):
+                    total += len(probes)
+                    continue
+                for probe in probes:
+                    if probe.payload in seen:
+                        continue
+                    seen.add(probe.payload)
+                    total += 1
+        return total
+
     def run_detection(self, records: Iterator[PayloadRecord], url: str,
                       methods: List[str], method: str = "GET",
                       data: Optional[str] = None, headers: Optional[List[str]] = None,
@@ -2011,15 +2072,7 @@ class RCEKit:
 
         # Reduce records to distinct (environment, context) carriers so the same
         # probe shape is not refired for every payload sharing that carrier.
-        carriers: List[PayloadRecord] = []
-        carrier_seen: Set[Tuple[str, str]] = set()
-        for record in records:
-            key = (record.environment, record.context)
-            if key in carrier_seen:
-                continue
-            carrier_seen.add(key)
-            carriers.append(record)
-        carriers.extend(self._quoted_shell_carriers(carriers, carrier_seen, config or {}))
+        carriers = self._detection_carriers(records, config or {})
 
         results: List[Dict[str, Any]] = []
         seen: Set[str] = set()
@@ -3839,6 +3892,247 @@ def parse_raw_request(text: str) -> Dict[str, Any]:
             "headers": headers, "body": body, "host": host}
 
 
+@dataclass(frozen=True)
+class InjectionPoint:
+    """One place in a captured request where a payload could be injected.
+
+    ``kind`` picks the placement rule (and therefore the encoding), ``name`` is
+    the addressable identifier within that kind — a parameter name, a JSON path
+    like ``user.profile.name``, a header name, a path-segment index — and
+    ``label`` is what a finding calls it."""
+    kind: str
+    name: str
+    label: str
+
+
+# Headers worth trying before the rest. Not a guess: each is a header that
+# real, published RCEs inject through -- Shellshock rides User-Agent and
+# Referer, Struts2 S2-045 rides Content-Type, Spring Cloud Function rides a
+# routing-expression header, and X-Forwarded-For lands in log pipelines and
+# admin views that later render it.
+HIGH_YIELD_HEADERS = ("User-Agent", "Referer", "X-Forwarded-For", "Content-Type",
+                      "Accept-Language", "X-Api-Version", "X-Forwarded-Host",
+                      "spring.cloud.function.routing-expression")
+
+# Headers a probe must not touch. Hop-by-hop headers belong to the connection
+# rather than the application, and Host/Content-Length are rebuilt by the
+# delivery layer -- injecting into them changes the request's plumbing instead
+# of testing the app. Cookie is excluded because its crumbs are enumerated
+# individually, which is the addressable unit an application actually reads.
+NON_INJECTABLE_HEADERS = {
+    "host", "content-length", "connection", "keep-alive", "proxy-authenticate",
+    "proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade", "cookie",
+}
+
+# The candidate kinds, in the order they are tried.
+INJECTION_POINT_KINDS = ("query", "json", "form", "cookie", "header", "path")
+
+
+def _json_path_tokens(path: str) -> List[Any]:
+    """``user.profile.name`` / ``items[0].v`` -> ``['user','profile','name']`` /
+    ``['items',0,'v']``."""
+    tokens: List[Any] = []
+    for chunk in path.split("."):
+        name, _, rest = chunk.partition("[")
+        if name:
+            tokens.append(name)
+        while rest:
+            index, _, rest = rest.partition("]")
+            if index:
+                tokens.append(int(index))
+            _, _, rest = rest.partition("[")
+    return tokens
+
+
+def _json_leaf_paths(obj: Any, limit: int = 256, max_depth: int = 64) -> List[str]:
+    """Paths to every scalar leaf of a parsed JSON body, in document order.
+
+    Iterative and bounded for the same reason the response-channel walk is: a
+    pathological body must cost a bounded amount of work, not a RecursionError
+    that the caller reports as a delivery failure."""
+    leaves: List[str] = []
+    stack: List[Tuple[Any, str, int]] = [(obj, "", 0)]
+    while stack and len(leaves) < limit:
+        node, path, depth = stack.pop()
+        if depth > max_depth:
+            continue
+        if isinstance(node, dict):
+            for key in reversed(list(node.keys())):
+                stack.append((node[key], f"{path}.{key}" if path else str(key), depth + 1))
+        elif isinstance(node, list):
+            for index in range(len(node) - 1, -1, -1):
+                stack.append((node[index], f"{path}[{index}]", depth + 1))
+        elif isinstance(node, str) or isinstance(node, (int, float)) and not isinstance(node, bool):
+            if path:
+                leaves.append(path)
+    return leaves
+
+
+def _set_json_path(obj: Any, path: str, value: str) -> bool:
+    """Set the leaf at ``path`` to ``value`` in place. False if it is not there.
+
+    Replaces an existing leaf only — assigning to a dict would otherwise *create*
+    a key the application never sends, which tests a field that does not exist
+    and cannot say anything about the one that does."""
+    tokens = _json_path_tokens(path)
+    if not tokens:
+        return False
+    node = obj
+    for token in tokens[:-1]:
+        try:
+            node = node[token]
+        except (KeyError, IndexError, TypeError):
+            return False
+    leaf = tokens[-1]
+    if isinstance(node, dict):
+        if leaf not in node:
+            return False
+    elif isinstance(node, list):
+        if not isinstance(leaf, int) or not 0 <= leaf < len(node):
+            return False
+    else:
+        return False
+    node[leaf] = value
+    return True
+
+
+def enumerate_injection_points(req: Dict[str, Any], kinds: Optional[Tuple[str, ...]] = None,
+                               include_path_segments: bool = False,
+                               thorough: bool = False) -> List[InjectionPoint]:
+    """Every candidate injection point in a captured request, cheapest first.
+
+    ``-p NAME`` requires the tester to already know which parameter is the sink.
+    Real captures carry ten to forty candidates, and some of the highest-value
+    classes inject through a *header* -- Shellshock through ``User-Agent``,
+    Struts2 S2-045 through ``Content-Type`` -- or through a JSON leaf several
+    levels down, which no top-level parameter name addresses.
+
+    Order is by expected yield per request: query, then body (JSON leaves by
+    path, or form fields), then cookies, then headers. Path segments are last
+    and opt-in: rewriting a path segment often just produces a 404, which costs
+    a request and tells you nothing.
+
+    ``thorough`` adds the remaining non-hop-by-hop headers after the curated
+    ones; without it only the high-yield list is tried."""
+    selected = set(kinds or INJECTION_POINT_KINDS)
+    points: List[InjectionPoint] = []
+    target, headers, body = req["target"], req["headers"], req.get("body", "")
+
+    if "query" in selected:
+        _, _, query = target.partition("?")
+        for pair in query.split("&") if query else []:
+            key, sep, _ = pair.partition("=")
+            if sep and key:
+                points.append(InjectionPoint("query", key, f"query param '{key}'"))
+
+    stripped = (body or "").strip()
+    if stripped[:1] in "{[" and "json" in selected:
+        try:
+            parsed = json.loads(body)
+        except (ValueError, TypeError):
+            parsed = None
+        if parsed is not None:
+            for path in _json_leaf_paths(parsed):
+                points.append(InjectionPoint("json", path, f"JSON field '{path}'"))
+    elif "=" in (body or "") and "form" in selected:
+        for pair in body.split("&"):
+            key, sep, _ = pair.partition("=")
+            if sep and key:
+                points.append(InjectionPoint("form", key, f"body param '{key}'"))
+
+    if "cookie" in selected:
+        for name, value in headers:
+            if name.lower() != "cookie":
+                continue
+            for crumb in value.split(";"):
+                key, sep, _ = crumb.strip().partition("=")
+                if sep and key.strip():
+                    points.append(InjectionPoint("cookie", key.strip(),
+                                                 f"cookie '{key.strip()}'"))
+
+    if "header" in selected:
+        present = [name for name, _ in headers if name.lower() not in NON_INJECTABLE_HEADERS]
+        high_yield = [n for n in HIGH_YIELD_HEADERS
+                      if any(n.lower() == p.lower() for p in present)]
+        ordered = list(high_yield)
+        if thorough:
+            ordered += [p for p in present
+                        if not any(p.lower() == h.lower() for h in high_yield)]
+        seen_headers: Set[str] = set()
+        for name in ordered:
+            actual = next((p for p in present if p.lower() == name.lower()), name)
+            if actual.lower() in seen_headers:
+                continue
+            seen_headers.add(actual.lower())
+            points.append(InjectionPoint("header", actual, f"header '{actual}'"))
+
+    if include_path_segments and "path" in selected:
+        path_part, _, _ = target.partition("?")
+        for index, segment in enumerate(path_part.split("/")):
+            if segment:
+                points.append(InjectionPoint("path", str(index),
+                                             f"path segment {index} ('{segment}')"))
+    return points
+
+
+def place_injection_point(target: str, headers: List[List[str]], body: str,
+                          point: InjectionPoint, mark: str
+                          ) -> Optional[Tuple[str, List[List[str]], str]]:
+    """Put ``mark`` at ``point``. ``None`` when the point is no longer there.
+
+    Each kind is rewritten in its own serialization -- a JSON leaf through the
+    JSON encoder, a form field in the ``a=1&b=2`` blob, a header as a single
+    line -- so the value is escaped by the layer that owns it rather than
+    blanket-encoded for all of them."""
+    if point.kind == "query":
+        path, sep, query = target.partition("?")
+        if not sep:
+            return None
+        marked = _mark_urlencoded_param(query, point.name, mark)
+        return (f"{path}?{marked}", headers, body) if marked is not None else None
+    if point.kind == "json":
+        try:
+            parsed = json.loads(body)
+        except (ValueError, TypeError):
+            return None
+        if not _set_json_path(parsed, point.name, mark):
+            return None
+        return target, headers, json.dumps(parsed)
+    if point.kind == "form":
+        marked = _mark_urlencoded_param(body, point.name, mark)
+        return (target, headers, marked) if marked is not None else None
+    if point.kind == "cookie":
+        for index, (name, value) in enumerate(headers):
+            if name.lower() != "cookie":
+                continue
+            marked = _mark_cookie(value, point.name, mark)
+            if marked is not None:
+                new_headers = [list(h) for h in headers]
+                new_headers[index][1] = marked
+                return target, new_headers, body
+        return None
+    if point.kind == "header":
+        for index, (name, _value) in enumerate(headers):
+            if name.lower() == point.name.lower():
+                new_headers = [list(h) for h in headers]
+                new_headers[index][1] = mark
+                return target, new_headers, body
+        return None
+    if point.kind == "path":
+        path, sep, query = target.partition("?")
+        segments = path.split("/")
+        try:
+            index = int(point.name)
+        except ValueError:
+            return None
+        if not 0 <= index < len(segments):
+            return None
+        segments[index] = mark
+        rebuilt = "/".join(segments)
+        return (f"{rebuilt}?{query}" if sep else rebuilt), headers, body
+    return None
+
+
 def _mark_urlencoded_param(blob: str, param: str, mark: str) -> Optional[str]:
     """Replace ``param``'s value with ``mark`` in a ``a=1&b=2`` blob (query or
     form body). Returns the rewritten blob, or None if ``param`` is absent."""
@@ -3938,11 +4232,33 @@ def _infer_request_scheme(host: str) -> str:
 
 
 def build_request_inputs(text: str, param: Optional[str] = None,
-                         scheme: Optional[str] = None, mark: str = "FUZZ"
+                         scheme: Optional[str] = None, mark: str = "FUZZ",
+                         point: Optional[InjectionPoint] = None
                          ) -> Tuple[str, str, Optional[str], List[str], str]:
     """Build ``(url, method, data, headers, injection)`` from a raw HTTP request,
-    with ``mark`` placed at the injection point. Precedence: an inline ``FUZZ``
-    already in the request, then an inline ``*`` marker, then ``-p NAME``."""
+    with ``mark`` placed at the injection point. Precedence: an explicit
+    ``point`` (enumeration), then an inline ``FUZZ`` already in the request, then
+    an inline ``*`` marker, then ``-p NAME``.
+
+    ``point`` wins over an inline marker because enumeration is asking about a
+    specific candidate; honouring a leftover marker instead would silently test
+    the same place for every candidate."""
+    if point is not None:
+        req = parse_raw_request(text)
+        placed = place_injection_point(req["target"], req["headers"], req.get("body", ""),
+                                       point, mark)
+        if placed is None:
+            raise ValueError(f"injection point not found: {point.label}")
+        target, headers, body = placed
+        host = req["host"]
+        if not host:
+            raise ValueError("raw request has no Host header; cannot build an absolute URL")
+        if scheme is None:
+            scheme = _infer_request_scheme(host)
+        out_headers = [f"{name}: {value}" for name, value in headers
+                       if name.lower() not in {"host", "content-length"}]
+        return (f"{scheme}://{host}{target}", req["method"], body or None,
+                out_headers, point.label)
     inline = False
     if mark in text:
         inline = True
@@ -4064,8 +4380,24 @@ def main():
                              "cookies are reused, each encoded for the context it lands in.")
     parser.add_argument("-p", "--param", action="append", default=None,
                         help="Parameter/field/header/cookie to inject into for -r (precedence: query > body "
-                             "> header > cookie). One injection point per run in this release; --all-params "
-                             "enumeration is planned.")
+                             "> header > cookie). Pass 'all' to enumerate every candidate in the capture "
+                             "instead of naming one.")
+    parser.add_argument("--auto-params", default=None, metavar="KINDS",
+                        help="(-r with --methods) Enumerate injection points instead of naming one. "
+                             f"Comma-separated kinds from {', '.join(INJECTION_POINT_KINDS)}, or 'all'. "
+                             "Query values, JSON leaves addressed by path, form fields, cookie values and "
+                             "headers each get their own encoding. Implied by '-p all'.")
+    parser.add_argument("--point-order", choices=["fast", "thorough"], default="fast",
+                        help="(enumeration) 'fast' (default) tries query, body, cookies and a curated "
+                             "high-yield header list; 'thorough' also tries every remaining "
+                             "non-hop-by-hop header.")
+    parser.add_argument("--max-points", type=int, default=40, metavar="N",
+                        help="(enumeration) Stop after N candidates. A budget guard, not a filter: the "
+                             "run says how many it dropped.")
+    parser.add_argument("--include-path-segments", action="store_true", default=False,
+                        help="(enumeration) Also inject into URL path segments. Off by default: rewriting "
+                             "a path segment usually just produces a 404, which costs a request and "
+                             "proves nothing.")
     parser.add_argument("--request-scheme", choices=["http", "https"], default=None,
                         help="Scheme for the URL built from -r (default: https when the Host is on :443, "
                              "otherwise http — a portless capture cannot record which, and http keeps "
@@ -4397,6 +4729,9 @@ def main():
                   "--acknowledge-consent to confirm you are authorised to test it.")
             return 1
         # Source the request from a raw capture (-r) or the --verify-* flags.
+        # `injection_runs` is non-empty only when enumerating: one entry per
+        # candidate point, each a fully built request in its own encoding.
+        injection_runs: List[Tuple[Any, str, str, Optional[str], List[str], str]] = []
         if args.request_file:
             try:
                 with open(args.request_file, "r", encoding="utf-8") as request_fh:
@@ -4405,19 +4740,71 @@ def main():
                 print(f"[!] Unable to read --request-file {args.request_file}: {exc}")
                 return 1
             params = args.param or []
-            if len(params) > 1:
-                print("[!] -r supports a single injection point in this release; pass one -p "
-                      "(or a FUZZ/* marker). --all-params enumeration is not yet available.")
+            auto_kinds = args.auto_params
+            if not auto_kinds and any(p.lower() == "all" for p in params):
+                auto_kinds = "all"
+                params = [p for p in params if p.lower() != "all"]
+            if auto_kinds and not args.methods:
+                print("[!] Enumerating injection points needs --methods: the classic per-payload "
+                      "oracle fires a whole corpus per point, which is not a budget anyone wants "
+                      "multiplied by every candidate in the capture.")
                 return 1
-            try:
-                verify_url, method, verify_data, verify_headers, injection = build_request_inputs(
-                    raw_request, param=(params[0] if params else None), scheme=args.request_scheme)
-            except ValueError as exc:
-                print(f"[!] Could not build a request from {args.request_file}: {exc}")
+            if not auto_kinds and len(params) > 1:
+                print("[!] -r takes a single -p, or '-p all' / --auto-params to enumerate.")
                 return 1
+            if auto_kinds:
+                kinds = (None if auto_kinds.strip() == "all"
+                         else tuple(k.strip() for k in auto_kinds.split(",") if k.strip()))
+                unknown = [k for k in (kinds or ()) if k not in INJECTION_POINT_KINDS]
+                if unknown:
+                    print(f"[!] Unknown --auto-params kind(s): {', '.join(unknown)}. "
+                          f"Choose from {', '.join(INJECTION_POINT_KINDS)}, or 'all'.")
+                    return 1
+                try:
+                    parsed_request = parse_raw_request(raw_request)
+                except ValueError as exc:
+                    print(f"[!] Could not parse {args.request_file}: {exc}")
+                    return 1
+                points = enumerate_injection_points(
+                    parsed_request, kinds=kinds,
+                    include_path_segments=args.include_path_segments,
+                    thorough=args.point_order == "thorough")
+                if not points:
+                    print("[!] No injection points found in the capture — nothing was tested. "
+                          "Widen --auto-params, or add --include-path-segments.")
+                    return 1
+                dropped = max(0, len(points) - args.max_points)
+                points = points[:args.max_points]
+                for point in points:
+                    try:
+                        built = build_request_inputs(raw_request, scheme=args.request_scheme,
+                                                     point=point)
+                    except ValueError:
+                        continue
+                    injection_runs.append((point, ) + built)
+                if not injection_runs:
+                    print("[!] Every enumerated point failed to build a request — nothing was tested.")
+                    return 1
+                verify_url, method, verify_data, verify_headers, injection = injection_runs[0][1:]
+                print(f"[verify] loaded request from {args.request_file}: enumerating "
+                      f"{len(injection_runs)} injection point(s)"
+                      + (f", {dropped} dropped by --max-points {args.max_points}"
+                         if dropped else ""))
+            else:
+                try:
+                    verify_url, method, verify_data, verify_headers, injection = build_request_inputs(
+                        raw_request, param=(params[0] if params else None),
+                        scheme=args.request_scheme)
+                except ValueError as exc:
+                    print(f"[!] Could not build a request from {args.request_file}: {exc}")
+                    return 1
             method = args.verify_method or method
-            print(f"[verify] loaded request from {args.request_file}: {method} {verify_url} "
-                  f"(injecting at {injection})")
+            if injection_runs:
+                for point, url, _m, _d, _h, label in injection_runs:
+                    print(f"[verify]   {label}")
+            else:
+                print(f"[verify] loaded request from {args.request_file}: {method} {verify_url} "
+                      f"(injecting at {injection})")
             if args.request_scheme is None:
                 resolved_scheme = verify_url.split("://", 1)[0]
                 print(f"[verify] the capture records no scheme; inferred {resolved_scheme} "
@@ -4560,13 +4947,61 @@ def main():
                 if separators:
                     print("[detect]   (separators pinned by --separators: "
                           f"{', '.join(repr(s) for s in separators)})")
-            results = generator.run_detection(
-                to_send, url=verify_url, methods=method_names, method=method,
-                data=verify_data, headers=verify_headers, delay=args.verify_delay,
-                timeout=args.verify_timeout, max_payloads=args.max_payloads,
-                url_location=args.verify_url_location, body_location=args.verify_body_location,
-                config=detection_config,
-            )
+            if injection_runs:
+                # Enumeration. Each candidate is its own request shape, so each
+                # gets its own payload-free control -- differencing a header
+                # probe against a query probe's control would compare two
+                # different responses and prove nothing.
+                #
+                # Cheap methods first, per candidate. reflected and eval cost one
+                # response each; time sleeps and oob waits for a callback. Once a
+                # candidate has proven execution, paying for the slow methods on
+                # it buys a second name for a finding already made, so that
+                # candidate stops there. Candidates that stay clean still get
+                # every method.
+                cheap = [m for m in method_names if m in CHEAP_DETECTION_METHODS]
+                costly = [m for m in method_names if m not in CHEAP_DETECTION_METHODS]
+                waves = [w for w in (cheap, costly) if w]
+                per_point = generator.estimate_detection_probes(
+                    to_send, method_names, detection_config)
+                print(f"[detect] enumerating {len(injection_runs)} injection point(s) "
+                      f"x {len(method_names)} method(s)")
+                print(f"[detect] cost: {len(injection_runs)} points x ~{per_point} probes "
+                      f"= at least {len(injection_runs) * (per_point + len(waves))} requests "
+                      f"(each point carries its own payload-free control)")
+                if args.max_payloads:
+                    print(f"[detect] --max-payloads {args.max_payloads} caps each point.")
+                results = []
+                for point, point_url, point_method, point_data, point_headers, label in injection_runs:
+                    point_results: List[Dict[str, Any]] = []
+                    for wave in waves:
+                        wave_results = generator.run_detection(
+                            to_send, url=point_url, methods=wave,
+                            method=args.verify_method or point_method,
+                            data=point_data, headers=point_headers, delay=args.verify_delay,
+                            timeout=args.verify_timeout, max_payloads=args.max_payloads,
+                            url_location=args.verify_url_location,
+                            body_location=args.verify_body_location,
+                            config=detection_config,
+                        )
+                        point_results.extend(wave_results)
+                        if any(r["verdict"] == "confirmed" for r in wave_results):
+                            break
+                    for result in point_results:
+                        result["point"] = label
+                    verdict = overall_detection_verdict(point_results)
+                    marker = "  <-- CONFIRMED" if verdict == "confirmed" else ""
+                    print(f"[detect]   {label}: {verdict} "
+                          f"({len(point_results)} probes){marker}")
+                    results.extend(point_results)
+            else:
+                results = generator.run_detection(
+                    to_send, url=verify_url, methods=method_names, method=method,
+                    data=verify_data, headers=verify_headers, delay=args.verify_delay,
+                    timeout=args.verify_timeout, max_payloads=args.max_payloads,
+                    url_location=args.verify_url_location, body_location=args.verify_body_location,
+                    config=detection_config,
+                )
             if args.detect_json:
                 # Written before the text report and regardless of outcome, so a
                 # caller always gets a file to read -- including the
@@ -4611,7 +5046,8 @@ def main():
             if confirmed:
                 print(f"\n[detect] CONFIRMED execution ({len(confirmed)}):")
                 for result in confirmed:
-                    print(f"  [{result['method']}/{result['environment']}/{result['context']}] "
+                    at = f" at {result['point']}" if result.get("point") else ""
+                    print(f"  [{result['method']}/{result['environment']}/{result['context']}]{at} "
                           f"{result['payload']}   ({result['detail']})")
                     if result.get("cleanup"):
                         print(f"      cleanup: {result['cleanup']}")
@@ -4620,7 +5056,8 @@ def main():
                 print(f"\n[detect] {len(needs_review)} NEEDS-REVIEW candidates "
                       "(not proof of execution — review manually):")
                 for result in needs_review:
-                    print(f"  [{result['method']}/{result['environment']}/{result['context']}] "
+                    at = f" at {result['point']}" if result.get("point") else ""
+                    print(f"  [{result['method']}/{result['environment']}/{result['context']}]{at} "
                           f"{result['payload']}   ({result['detail']})")
             if not confirmed:
                 errored = [r for r in results if r["verdict"] == "error"]

--- a/rcekit.py
+++ b/rcekit.py
@@ -1999,7 +1999,8 @@ class RCEKit:
         return carriers
 
     def estimate_detection_probes(self, records: List[PayloadRecord], methods: List[str],
-                                  config: Optional[Dict[str, Any]] = None) -> int:
+                                  config: Optional[Dict[str, Any]] = None,
+                                  max_payloads: Optional[int] = None) -> int:
         """How many requests a detection run would send, without sending any.
 
         The ladder and the carrier list both multiply probe count, and
@@ -2007,6 +2008,11 @@ class RCEKit:
         operator on a monitored engagement has to be able to see that number
         *before* it happens rather than infer it from the traffic, so this
         builds the probes and counts them.
+
+        ``max_payloads`` mirrors the run's own stopping point, so the figure
+        stays true exactly when the budget guard the operator reached for is in
+        play — an estimate that ignores ``--max-payloads`` is wrong precisely
+        when someone is trying to bound the run.
 
         A floor, not an exact figure: an aggregate method may answer with
         further screening waves once it has seen the first batch, and each
@@ -2028,12 +2034,16 @@ class RCEKit:
                     continue
                 if getattr(meth, "aggregate", False):
                     total += len(probes)
+                    if max_payloads and total >= max_payloads:
+                        return max_payloads
                     continue
                 for probe in probes:
                     if probe.payload in seen:
                         continue
                     seen.add(probe.payload)
                     total += 1
+                    if max_payloads and total >= max_payloads:
+                        return max_payloads
         return total
 
     def run_detection(self, records: Iterator[PayloadRecord], url: str,
@@ -3899,10 +3909,19 @@ class InjectionPoint:
     ``kind`` picks the placement rule (and therefore the encoding), ``name`` is
     the addressable identifier within that kind — a parameter name, a JSON path
     like ``user.profile.name``, a header name, a path-segment index — and
-    ``label`` is what a finding calls it."""
+    ``label`` is what a finding calls it.
+
+    For a JSON point, ``tokens`` is the authority and ``name`` is only for
+    reading. A dotted string cannot round-trip a key that itself contains a dot:
+    ``{"user.name": ..., "user": {"name": ...}}`` renders both leaves as
+    ``user.name``, so the literal key is never probed and any finding is
+    attributed to the nested one. Addressing by tokens removes the ambiguity;
+    ``name`` renders a dotted key as ``["user.name"]`` so the two stay
+    distinguishable on screen too."""
     kind: str
     name: str
     label: str
+    tokens: Tuple[Any, ...] = ()
 
 
 # Headers worth trying before the rest. Not a guess: each is a header that
@@ -3928,60 +3947,71 @@ NON_INJECTABLE_HEADERS = {
 INJECTION_POINT_KINDS = ("query", "json", "form", "cookie", "header", "path")
 
 
-def _json_path_tokens(path: str) -> List[Any]:
-    """``user.profile.name`` / ``items[0].v`` -> ``['user','profile','name']`` /
-    ``['items',0,'v']``."""
-    tokens: List[Any] = []
-    for chunk in path.split("."):
-        name, _, rest = chunk.partition("[")
-        if name:
-            tokens.append(name)
-        while rest:
-            index, _, rest = rest.partition("]")
-            if index:
-                tokens.append(int(index))
-            _, _, rest = rest.partition("[")
-    return tokens
+def _render_json_path(tokens: Tuple[Any, ...]) -> str:
+    """A readable rendering of a token address.
+
+    ``('user','profile','name')`` -> ``user.profile.name``; ``('items',0,'v')``
+    -> ``items[0].v``. A key that itself contains ``.``, ``[`` or ``]`` is
+    bracket-quoted — ``('user.name',)`` -> ``["user.name"]`` — so it can never
+    be read as the nested path of the same spelling."""
+    parts: List[str] = []
+    for token in tokens:
+        if isinstance(token, int):
+            parts.append(f"[{token}]")
+        elif any(ch in token for ch in ".[]"):
+            parts.append('["' + token.replace('"', '\\"') + '"]')
+        else:
+            parts.append(f".{token}" if parts else token)
+    rendered = "".join(parts)
+    return rendered[1:] if rendered.startswith(".") else rendered
 
 
-def _json_leaf_paths(obj: Any, limit: int = 256, max_depth: int = 64) -> List[str]:
-    """Paths to every scalar leaf of a parsed JSON body, in document order.
+def _json_leaf_tokens(obj: Any, limit: int = 256,
+                      max_depth: int = 64) -> List[Tuple[Any, ...]]:
+    """Token addresses of every scalar leaf of a parsed JSON body, in document
+    order.
 
-    Iterative and bounded for the same reason the response-channel walk is: a
-    pathological body must cost a bounded amount of work, not a RecursionError
-    that the caller reports as a delivery failure."""
-    leaves: List[str] = []
-    stack: List[Tuple[Any, str, int]] = [(obj, "", 0)]
+    Tokens rather than a joined string, because a string cannot round-trip a key
+    containing the separator. Iterative and bounded for the same reason the
+    response-channel walk is: a pathological body must cost a bounded amount of
+    work, not a RecursionError in the middle of a run."""
+    leaves: List[Tuple[Any, ...]] = []
+    stack: List[Tuple[Any, Tuple[Any, ...], int]] = [(obj, (), 0)]
     while stack and len(leaves) < limit:
         node, path, depth = stack.pop()
         if depth > max_depth:
             continue
         if isinstance(node, dict):
             for key in reversed(list(node.keys())):
-                stack.append((node[key], f"{path}.{key}" if path else str(key), depth + 1))
+                stack.append((node[key], path + (key,), depth + 1))
         elif isinstance(node, list):
             for index in range(len(node) - 1, -1, -1):
-                stack.append((node[index], f"{path}[{index}]", depth + 1))
+                stack.append((node[index], path + (index,), depth + 1))
         elif isinstance(node, str) or isinstance(node, (int, float)) and not isinstance(node, bool):
             if path:
                 leaves.append(path)
     return leaves
 
 
-def _set_json_path(obj: Any, path: str, value: str) -> bool:
-    """Set the leaf at ``path`` to ``value`` in place. False if it is not there.
+def _set_json_tokens(obj: Any, tokens: Tuple[Any, ...], value: str) -> bool:
+    """Set the leaf at ``tokens`` to ``value`` in place. False if it is not there.
 
     Replaces an existing leaf only — assigning to a dict would otherwise *create*
     a key the application never sends, which tests a field that does not exist
     and cannot say anything about the one that does."""
-    tokens = _json_path_tokens(path)
     if not tokens:
         return False
     node = obj
     for token in tokens[:-1]:
-        try:
+        if isinstance(node, dict):
+            if token not in node:
+                return False
             node = node[token]
-        except (KeyError, IndexError, TypeError):
+        elif isinstance(node, list):
+            if not isinstance(token, int) or not 0 <= token < len(node):
+                return False
+            node = node[token]
+        else:
             return False
     leaf = tokens[-1]
     if isinstance(node, dict):
@@ -4029,11 +4059,17 @@ def enumerate_injection_points(req: Dict[str, Any], kinds: Optional[Tuple[str, .
     if stripped[:1] in "{[" and "json" in selected:
         try:
             parsed = json.loads(body)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, RecursionError):
+            # RecursionError belongs here for the same reason it does in the
+            # response-channel parser: json's scanner recurses in C, and a
+            # deeply nested captured body would otherwise end `-p all` with a
+            # traceback instead of an enumeration.
             parsed = None
         if parsed is not None:
-            for path in _json_leaf_paths(parsed):
-                points.append(InjectionPoint("json", path, f"JSON field '{path}'"))
+            for tokens in _json_leaf_tokens(parsed):
+                rendered = _render_json_path(tokens)
+                points.append(InjectionPoint("json", rendered,
+                                             f"JSON field '{rendered}'", tokens))
     elif "=" in (body or "") and "form" in selected:
         for pair in body.split("&"):
             key, sep, _ = pair.partition("=")
@@ -4093,9 +4129,9 @@ def place_injection_point(target: str, headers: List[List[str]], body: str,
     if point.kind == "json":
         try:
             parsed = json.loads(body)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, RecursionError):
             return None
-        if not _set_json_path(parsed, point.name, mark):
+        if not _set_json_tokens(parsed, point.tokens, mark):
             return None
         return target, headers, json.dumps(parsed)
     if point.kind == "form":
@@ -4963,14 +4999,13 @@ def main():
                 costly = [m for m in method_names if m not in CHEAP_DETECTION_METHODS]
                 waves = [w for w in (cheap, costly) if w]
                 per_point = generator.estimate_detection_probes(
-                    to_send, method_names, detection_config)
+                    to_send, method_names, detection_config, max_payloads=args.max_payloads)
                 print(f"[detect] enumerating {len(injection_runs)} injection point(s) "
                       f"x {len(method_names)} method(s)")
-                print(f"[detect] cost: {len(injection_runs)} points x ~{per_point} probes "
+                capped = f" (capped by --max-payloads {args.max_payloads})" if args.max_payloads else ""
+                print(f"[detect] cost: {len(injection_runs)} points x ~{per_point} probes{capped} "
                       f"= at least {len(injection_runs) * (per_point + len(waves))} requests "
                       f"(each point carries its own payload-free control)")
-                if args.max_payloads:
-                    print(f"[detect] --max-payloads {args.max_payloads} caps each point.")
                 results = []
                 for point, point_url, point_method, point_data, point_headers, label in injection_runs:
                     point_results: List[Dict[str, Any]] = []

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -3903,7 +3903,15 @@ class InjectionPointPlacementTestCase(unittest.TestCase):
         self.req = parse_raw_request(RAW_CAPTURE)
 
     def _place(self, kind, name):
-        point = rcekit.InjectionPoint(kind, name, f"{kind} '{name}'")
+        if kind == "json":
+            # JSON points are addressed by tokens, so take the real enumerated
+            # point rather than hand-building one — that is the pairing that
+            # actually runs.
+            point = next((p for p in rcekit.enumerate_injection_points(self.req)
+                          if p.kind == "json" and p.name == name),
+                         rcekit.InjectionPoint("json", name, name, ()))
+        else:
+            point = rcekit.InjectionPoint(kind, name, f"{kind} '{name}'")
         return rcekit.place_injection_point(
             self.req["target"], self.req["headers"], self.req["body"], point, "FUZZ")
 
@@ -4025,26 +4033,86 @@ class EnumerationEndToEndTestCase(unittest.TestCase):
 
 
 class JsonPathTestCase(unittest.TestCase):
-    def test_tokens_split_names_and_indices(self):
-        self.assertEqual(rcekit._json_path_tokens("user.profile.name"),
-                         ["user", "profile", "name"])
-        self.assertEqual(rcekit._json_path_tokens("items[0].v"), ["items", 0, "v"])
-        self.assertEqual(rcekit._json_path_tokens("a[1][2]"), ["a", 1, 2])
-
-    def test_leaf_paths_skip_containers_booleans_and_nulls(self):
+    def test_leaf_tokens_skip_containers_booleans_and_nulls(self):
         obj = {"a": {"b": 1}, "ok": True, "none": None, "list": [{"c": "x"}]}
-        self.assertEqual(rcekit._json_leaf_paths(obj), ["a.b", "list[0].c"])
+        self.assertEqual(rcekit._json_leaf_tokens(obj), [("a", "b"), ("list", 0, "c")])
+
+    def test_rendering_is_readable_and_quotes_ambiguous_keys(self):
+        self.assertEqual(rcekit._render_json_path(("user", "profile", "name")),
+                         "user.profile.name")
+        self.assertEqual(rcekit._render_json_path(("items", 0, "v")), "items[0].v")
+        # A key containing the separator must not render as the nested path of
+        # the same spelling.
+        self.assertEqual(rcekit._render_json_path(("user.name",)), '["user.name"]')
+        self.assertNotEqual(rcekit._render_json_path(("user.name",)),
+                            rcekit._render_json_path(("user", "name")))
 
     def test_setting_a_missing_path_fails_rather_than_creating_it(self):
         obj = {"a": {"b": 1}}
-        self.assertFalse(rcekit._set_json_path(obj, "a.zzz.q", "X"))
-        self.assertFalse(rcekit._set_json_path(obj, "list[3]", "X"))
-        self.assertTrue(rcekit._set_json_path(obj, "a.b", "X"))
+        self.assertFalse(rcekit._set_json_tokens(obj, ("a", "zzz", "q"), "X"))
+        self.assertFalse(rcekit._set_json_tokens(obj, ("list", 3), "X"))
+        self.assertFalse(rcekit._set_json_tokens(obj, (), "X"))
+        self.assertTrue(rcekit._set_json_tokens(obj, ("a", "b"), "X"))
         self.assertEqual(obj["a"]["b"], "X")
 
     def test_a_deeply_nested_body_is_bounded_not_fatal(self):
         deep = json.loads("[" * 400 + '"x"' + "]" * 400)
-        self.assertEqual(rcekit._json_leaf_paths(deep, max_depth=8), [])
+        self.assertEqual(rcekit._json_leaf_tokens(deep, max_depth=8), [])
+
+
+class JsonKeyBoundaryTestCase(unittest.TestCase):
+    """A JSON key may itself contain the characters a dotted path uses.
+
+    Addressing by a joined string could not tell `{"user.name": ...}` from
+    `{"user": {"name": ...}}`: both rendered as `user.name`, so the literal key
+    was never probed and both candidates mutated the nested field — a false
+    negative and a misattributed finding at once."""
+
+    RAW = ('POST /a HTTP/1.1\r\nHost: t.example\r\nContent-Type: application/json\r\n\r\n'
+           '{"user.name": "sinkA", "user": {"name": "sinkB"}, "a[0]": "sinkC"}')
+
+    def setUp(self):
+        self.req = parse_raw_request(self.RAW)
+        self.points = [p for p in rcekit.enumerate_injection_points(self.req)
+                       if p.kind == "json"]
+
+    def _place(self, point):
+        placed = rcekit.place_injection_point(
+            self.req["target"], self.req["headers"], self.req["body"], point, "FUZZ")
+        return json.loads(placed[2]) if placed else None
+
+    def test_ambiguous_keys_get_distinct_labels(self):
+        names = [p.name for p in self.points]
+        self.assertEqual(len(names), len(set(names)), names)
+        self.assertIn('["user.name"]', names)
+        self.assertIn("user.name", names)
+        self.assertIn('["a[0]"]', names)
+
+    def test_each_candidate_reaches_its_own_leaf(self):
+        placed = {p.name: self._place(p) for p in self.points}
+        self.assertEqual(placed['["user.name"]']["user.name"], "FUZZ")
+        self.assertEqual(placed['["user.name"]']["user"]["name"], "sinkB",
+                         "the nested field must be untouched")
+        self.assertEqual(placed["user.name"]["user"]["name"], "FUZZ")
+        self.assertEqual(placed["user.name"]["user.name"], "sinkA",
+                         "the literal key must be untouched")
+        self.assertEqual(placed['["a[0]"]']["a[0]"], "FUZZ")
+
+    def test_no_candidate_is_silently_skipped(self):
+        for point in self.points:
+            self.assertIsNotNone(self._place(point), point.name)
+
+    def test_a_deeply_nested_capture_does_not_kill_enumeration(self):
+        # json.loads recurses in C, so a deep body would end `-p all` with a
+        # traceback rather than an enumeration.
+        deep = "[" * 3000 + '"x"' + "]" * 3000
+        raw = ('POST /a?q=1 HTTP/1.1\r\nHost: t.example\r\n'
+               'Content-Type: application/json\r\n\r\n' + deep)
+        points = rcekit.enumerate_injection_points(parse_raw_request(raw))
+        self.assertFalse([p for p in points if p.kind == "json"],
+                         "an unparseable body yields no JSON candidates")
+        self.assertTrue([p for p in points if p.kind == "query"],
+                        "and the rest of the request still enumerates")
 
 
 class DetectionCostEstimateTestCase(unittest.TestCase):
@@ -4077,6 +4145,22 @@ class DetectionCostEstimateTestCase(unittest.TestCase):
 
     def test_an_unknown_method_is_ignored_rather_than_fatal(self):
         self.assertEqual(self.gen.estimate_detection_probes(self.records, ["nosuchmethod"]), 0)
+
+    def test_the_estimate_honours_max_payloads(self):
+        # An estimate that ignores the cap is wrong exactly when the operator
+        # reached for the budget guard.
+        uncapped = self.gen.estimate_detection_probes(self.records, ["reflected"])
+        self.assertGreater(uncapped, 12)
+        self.assertEqual(
+            self.gen.estimate_detection_probes(self.records, ["reflected"], max_payloads=12), 12)
+
+    def test_the_capped_estimate_still_matches_a_capped_run(self):
+        with local_target(lambda *a: (200, "static")) as base:
+            results = self.gen.run_detection(
+                self.records, url=f"{base}/?x=FUZZ", methods=["reflected"], max_payloads=12)
+        self.assertEqual(
+            self.gen.estimate_detection_probes(self.records, ["reflected"], max_payloads=12),
+            len(results))
 
 
 class EvalCarrierTestCase(unittest.TestCase):

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -3816,6 +3816,269 @@ class TimingScreenDepthTestCase(unittest.TestCase):
         self.assertEqual({p.separator for p in probes}, {"| "})
 
 
+RAW_CAPTURE = (
+    "POST /cgi-bin/status?view=summary&lang=en HTTP/1.1\r\n"
+    "Host: target.example\r\n"
+    "User-Agent: Mozilla/5.0\r\n"
+    "Referer: http://target.example/\r\n"
+    "X-Trace-Id: abc\r\n"
+    "Accept-Language: en-GB\r\n"
+    "Connection: keep-alive\r\n"
+    "Cookie: sid=abc123; theme=dark\r\n"
+    "Content-Type: application/json\r\n"
+    "Content-Length: 52\r\n"
+    "\r\n"
+    '{"user": {"profile": {"name": "ali"}}, "tags": ["a", 2]}'
+)
+
+
+class InjectionPointEnumerationTestCase(unittest.TestCase):
+    """Expanding one captured request into every candidate injection point.
+
+    `-p NAME` requires the tester to already know which parameter is the sink.
+    Real captures carry ten to forty candidates, and some of the highest-value
+    classes inject through a header or a JSON leaf several levels down that no
+    top-level parameter name addresses."""
+
+    def setUp(self):
+        self.req = parse_raw_request(RAW_CAPTURE)
+
+    def _points(self, **kwargs):
+        return rcekit.enumerate_injection_points(self.req, **kwargs)
+
+    def test_every_kind_is_found(self):
+        found = {(p.kind, p.name) for p in self._points()}
+        self.assertIn(("query", "view"), found)
+        self.assertIn(("query", "lang"), found)
+        self.assertIn(("json", "user.profile.name"), found)
+        self.assertIn(("cookie", "sid"), found)
+        self.assertIn(("cookie", "theme"), found)
+        self.assertIn(("header", "User-Agent"), found)
+
+    def test_json_leaves_are_addressed_by_path_including_arrays(self):
+        names = [p.name for p in self._points() if p.kind == "json"]
+        self.assertEqual(names, ["user.profile.name", "tags[0]", "tags[1]"])
+
+    def test_order_is_query_then_body_then_cookies_then_headers(self):
+        kinds = [p.kind for p in self._points()]
+        self.assertEqual(kinds, sorted(kinds, key=lambda k: rcekit.INJECTION_POINT_KINDS.index(k)))
+
+    def test_high_yield_headers_come_first_and_the_rest_need_thorough(self):
+        fast = [p.name for p in self._points() if p.kind == "header"]
+        self.assertIn("User-Agent", fast)
+        self.assertNotIn("X-Trace-Id", fast, "fast order must not sweep every header")
+        thorough = [p.name for p in self._points(thorough=True) if p.kind == "header"]
+        self.assertIn("X-Trace-Id", thorough)
+        self.assertLess(thorough.index("User-Agent"), thorough.index("X-Trace-Id"))
+
+    def test_connection_level_headers_are_never_candidates(self):
+        # Injecting into these changes the request's plumbing rather than
+        # testing the application, and the delivery layer rebuilds two of them.
+        names = {p.name.lower() for p in self._points(thorough=True) if p.kind == "header"}
+        for excluded in ("host", "content-length", "connection", "cookie"):
+            self.assertNotIn(excluded, names)
+
+    def test_path_segments_are_opt_in(self):
+        self.assertFalse([p for p in self._points() if p.kind == "path"])
+        segments = [p for p in self._points(include_path_segments=True) if p.kind == "path"]
+        self.assertTrue(segments)
+
+    def test_kinds_can_be_narrowed(self):
+        self.assertEqual({p.kind for p in self._points(kinds=("header",))}, {"header"})
+
+    def test_a_form_body_yields_form_points_not_json(self):
+        raw = RAW_CAPTURE.split("\r\n\r\n")[0].replace(
+            "Content-Type: application/json", "Content-Type: application/x-www-form-urlencoded")
+        req = parse_raw_request(raw + "\r\n\r\nuser=ali&role=admin")
+        points = rcekit.enumerate_injection_points(req)
+        self.assertEqual([p.name for p in points if p.kind == "form"], ["user", "role"])
+        self.assertFalse([p for p in points if p.kind == "json"])
+
+
+class InjectionPointPlacementTestCase(unittest.TestCase):
+    """Each kind is rewritten in its own serialization, so the value is escaped
+    by the layer that owns it rather than blanket-encoded for all of them."""
+
+    def setUp(self):
+        self.req = parse_raw_request(RAW_CAPTURE)
+
+    def _place(self, kind, name):
+        point = rcekit.InjectionPoint(kind, name, f"{kind} '{name}'")
+        return rcekit.place_injection_point(
+            self.req["target"], self.req["headers"], self.req["body"], point, "FUZZ")
+
+    def test_query_value_is_replaced_in_place(self):
+        target, _, _ = self._place("query", "view")
+        self.assertEqual(target, "/cgi-bin/status?view=FUZZ&lang=en")
+
+    def test_a_nested_json_leaf_is_replaced_and_the_body_stays_valid_json(self):
+        _, _, body = self._place("json", "user.profile.name")
+        self.assertEqual(json.loads(body)["user"]["profile"]["name"], "FUZZ")
+        self.assertEqual(json.loads(body)["tags"], ["a", 2])
+
+    def test_a_json_array_element_is_replaced_by_index(self):
+        _, _, body = self._place("json", "tags[1]")
+        self.assertEqual(json.loads(body)["tags"], ["a", "FUZZ"])
+
+    def test_one_cookie_crumb_is_replaced_and_the_others_survive(self):
+        _, headers, _ = self._place("cookie", "theme")
+        cookie = next(v for n, v in headers if n.lower() == "cookie")
+        self.assertIn("sid=abc123", cookie)
+        self.assertIn("theme=FUZZ", cookie)
+
+    def test_a_header_value_is_replaced_whole(self):
+        _, headers, _ = self._place("header", "User-Agent")
+        self.assertEqual(dict((n, v) for n, v in headers)["User-Agent"], "FUZZ")
+
+    def test_a_path_segment_is_replaced_and_the_query_survives(self):
+        target, _, _ = self._place("path", "1")
+        self.assertEqual(target, "/FUZZ/status?view=summary&lang=en")
+
+    def test_a_point_that_is_no_longer_there_returns_none(self):
+        self.assertIsNone(self._place("query", "nosuchparam"))
+        self.assertIsNone(self._place("json", "user.missing"))
+        self.assertIsNone(self._place("header", "X-Absent"))
+
+    def test_build_request_inputs_accepts_a_point(self):
+        point = rcekit.InjectionPoint("header", "User-Agent", "header 'User-Agent'")
+        url, method, data, headers, injection = build_request_inputs(
+            RAW_CAPTURE, scheme="https", point=point)
+        self.assertEqual(url, "https://target.example/cgi-bin/status?view=summary&lang=en")
+        self.assertEqual(method, "POST")
+        self.assertEqual(injection, "header 'User-Agent'")
+        self.assertIn("User-Agent: FUZZ", headers)
+        # Host and Content-Length are rebuilt by the delivery layer.
+        self.assertFalse([h for h in headers if h.lower().startswith(("host:", "content-length:"))])
+
+    def test_a_point_wins_over_a_leftover_inline_marker(self):
+        # Otherwise enumeration would test the same place for every candidate.
+        raw = RAW_CAPTURE.replace("lang=en", "lang=FUZZ")
+        point = rcekit.InjectionPoint("query", "view", "query param 'view'")
+        url, _, _, _, injection = build_request_inputs(raw, scheme="https", point=point)
+        self.assertIn("view=FUZZ", url)
+        self.assertEqual(injection, "query param 'view'")
+
+
+class EnumerationEndToEndTestCase(unittest.TestCase):
+    """The acceptance case: a sink reachable only through a header, found with
+    `-p all` and no manual header selection."""
+
+    def _run(self, *args):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=300)
+
+    def test_a_header_only_sink_is_found_without_naming_the_header(self):
+        import os
+        import tempfile
+
+        def route(method, path, params, headers, body):
+            pipe = os.popen("echo CGI " + headers.get("User-Agent", "") + " 2>&1")
+            out = pipe.read()
+            pipe.close()
+            return 200, out
+
+        with local_target(route) as base, tempfile.TemporaryDirectory() as tmp:
+            host = base.split("//", 1)[1]
+            capture = Path(tmp) / "request.txt"
+            capture.write_text(
+                "POST /cgi-bin/status?view=summary HTTP/1.1\n"
+                f"Host: {host}\n"
+                "User-Agent: Mozilla/5.0\n"
+                "Cookie: sid=abc123\n"
+                "Content-Type: application/json\n"
+                "\n"
+                '{"user": {"name": "ali"}}\n')
+            result = self._run("--acknowledge-consent", "-r", str(capture), "-p", "all",
+                               "--methods", "reflected", "--environments", "unix",
+                               "--max-payloads", "12")
+
+        self.assertEqual(result.returncode, 0, result.stdout[-2000:])
+        # It enumerated rather than needing the sink named...
+        self.assertIn("query param 'view'", result.stdout)
+        self.assertIn("JSON field 'user.name'", result.stdout)
+        self.assertIn("cookie 'sid'", result.stdout)
+        # ...it said what the run would cost before sending it...
+        self.assertRegex(result.stdout, r"\[detect\] cost: \d+ points x ~\d+ probes")
+        # ...and the finding names the point that worked.
+        self.assertIn("CONFIRMED execution", result.stdout)
+        self.assertIn("at header 'User-Agent'", result.stdout)
+
+    def test_enumeration_without_methods_is_refused(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            capture = Path(tmp) / "request.txt"
+            capture.write_text("GET /?a=1 HTTP/1.1\nHost: t.example\n\n")
+            result = self._run("--acknowledge-consent", "-r", str(capture), "-p", "all")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("needs --methods", result.stdout)
+
+    def test_an_unknown_auto_params_kind_is_refused(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            capture = Path(tmp) / "request.txt"
+            capture.write_text("GET /?a=1 HTTP/1.1\nHost: t.example\n\n")
+            result = self._run("--acknowledge-consent", "-r", str(capture),
+                               "--auto-params", "query,bogus", "--methods", "reflected")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("bogus", result.stdout)
+
+
+class JsonPathTestCase(unittest.TestCase):
+    def test_tokens_split_names_and_indices(self):
+        self.assertEqual(rcekit._json_path_tokens("user.profile.name"),
+                         ["user", "profile", "name"])
+        self.assertEqual(rcekit._json_path_tokens("items[0].v"), ["items", 0, "v"])
+        self.assertEqual(rcekit._json_path_tokens("a[1][2]"), ["a", 1, 2])
+
+    def test_leaf_paths_skip_containers_booleans_and_nulls(self):
+        obj = {"a": {"b": 1}, "ok": True, "none": None, "list": [{"c": "x"}]}
+        self.assertEqual(rcekit._json_leaf_paths(obj), ["a.b", "list[0].c"])
+
+    def test_setting_a_missing_path_fails_rather_than_creating_it(self):
+        obj = {"a": {"b": 1}}
+        self.assertFalse(rcekit._set_json_path(obj, "a.zzz.q", "X"))
+        self.assertFalse(rcekit._set_json_path(obj, "list[3]", "X"))
+        self.assertTrue(rcekit._set_json_path(obj, "a.b", "X"))
+        self.assertEqual(obj["a"]["b"], "X")
+
+    def test_a_deeply_nested_body_is_bounded_not_fatal(self):
+        deep = json.loads("[" * 400 + '"x"' + "]" * 400)
+        self.assertEqual(rcekit._json_leaf_paths(deep, max_depth=8), [])
+
+
+class DetectionCostEstimateTestCase(unittest.TestCase):
+    """The ladder, the carriers and the candidate count each multiply request
+    volume, so the number is printed before the traffic rather than inferred
+    from it afterwards."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.records = [make_record(environment="unix", context="raw")]
+
+    def test_the_estimate_matches_what_a_run_actually_sends(self):
+        estimate = self.gen.estimate_detection_probes(self.records, ["reflected"])
+        with local_target(lambda *a: (200, "static")) as base:
+            results = self.gen.run_detection(
+                self.records, url=f"{base}/?x=FUZZ", methods=["reflected"])
+        self.assertEqual(estimate, len(results))
+
+    def test_the_estimate_sends_nothing(self):
+        # It must be safe to call before the consent-gated traffic starts.
+        estimate = self.gen.estimate_detection_probes(
+            self.records, ["reflected", "eval"], {"sink_shapes": ("sep",)})
+        self.assertGreater(estimate, 0)
+
+    def test_narrowing_the_ladder_lowers_the_estimate(self):
+        wide = self.gen.estimate_detection_probes(self.records, ["reflected"])
+        narrow = self.gen.estimate_detection_probes(
+            self.records, ["reflected"], {"sink_shapes": ("sep",)})
+        self.assertLess(narrow, wide)
+
+    def test_an_unknown_method_is_ignored_rather_than_fatal(self):
+        self.assertEqual(self.gen.estimate_detection_probes(self.records, ["nosuchmethod"]), 0)
+
+
 class EvalCarrierTestCase(unittest.TestCase):
     """Engine carriers for the `eval` probe.
 


### PR DESCRIPTION
Phase 3 of the detection coverage plan — the first half of M3.

## Why

`-p NAME` needs the tester to already know which parameter is the sink. A real capture carries ten to forty candidates, and some of the highest-value classes inject through a **header** — Shellshock through `User-Agent`, Struts2 S2-045 through `Content-Type` — or through a **JSON leaf several levels down** that no top-level parameter name addresses. Those were never tried.

This is also where the Phase 1 evidence pointed: the public detection payload for the modern expression-injection CVEs is bare arithmetic, which RCEKit already builds, so the remaining blocker was getting it to the right place.

## Acceptance

Verified end to end against a sink reachable **only** through `User-Agent`, found with no manual header selection:

```
[verify] loaded request from request.txt: enumerating 6 injection point(s)
[detect] cost: 6 points x ~61 probes = at least 372 requests (each point carries its own payload-free control)
[detect]   query param 'view': negative (61 probes)
[detect]   JSON field 'user.name': negative (61 probes)
[detect]   cookie 'sid': negative (61 probes)
[detect]   header 'User-Agent': confirmed (61 probes)  <-- CONFIRMED
...
  [reflected/unix/raw] at header 'User-Agent' ; echo RK...
```

## Each kind keeps its own encoding

| Kind | Addressed as | Rewritten by |
|---|---|---|
| `query` | parameter name | the `a=1&b=2` encoder |
| `json` | path — `user.profile.name`, `tags[1]` | the JSON encoder, re-serialised |
| `form` | field name | the `a=1&b=2` encoder |
| `cookie` | crumb name | the `Cookie` header, neighbours untouched |
| `header` | header name | single-line header escaping |
| `path` | segment index | the URL path (opt-in) |

A JSON leaf is **replaced, never created**. Assigning to a missing key would inject into a field the application never sends — a probe that cannot say anything about the parameter that does exist. My own test caught that; the first implementation happily created the key.

`Host`, `Content-Length`, `Cookie` and the hop-by-hop headers are never candidates: injecting into those changes the request's plumbing rather than testing the app, and two of them are rebuilt by the delivery layer. Path segments are opt-in because rewriting one usually just produces a 404.

## Cost is stated before the traffic

Enumeration multiplies an already-laddered probe count by the candidate count. A new `estimate_detection_probes` builds the probes and counts them **without firing any**, sharing the carrier reduction with the run — so the number printed comes from the same logic that decides what gets sent. A test asserts the estimate equals what a real run sends.

`--max-points` (default 40) bounds the candidate list and reports what it dropped; `--point-order fast|thorough` decides whether headers are the curated high-yield list or all of them; `--verify-delay` paces the whole enumeration.

## Two behavioural decisions

- **Each candidate carries its own control.** Differencing a header probe against a query probe's control would compare two different responses and prove nothing.
- **Cheap methods first, and a candidate stops at its first confirmation.** `reflected` and `eval` cost one response each; `time` sleeps and `oob` waits for a callback, and on a candidate that has already proven execution those buy a second name for the same finding. Clean candidates still get every method. **Single-point runs are unchanged** and still run everything — this is scoped to the budget-sensitive mode, unlike the Phase 10 short-circuit we agreed against.

## Tests

28 new tests: enumeration order and per-kind placement, the header allow/deny lists, JSON path addressing including arrays and the replace-never-create rule, a bounded walk for a pathological body, the cost estimate matching an actual run, and three end-to-end CLI runs (the header-only sink, enumeration refused without `--methods`, an unknown kind refused by name).

```
python -m unittest discover -s tests
Ran 404 tests in 147.127s

OK
```

## Compatibility

Additive. Every existing command line behaves identically — enumeration only engages on `-p all` / `--auto-params`. Version 2.27.0 → 2.28.0 (MINOR), README badge, CHANGELOG and `docs/reference.md` updated.

Phase 13 (generalised read-back for `file`) is the other half of M3 and is not in this PR.