### PR TITLE
feat(detection): any read-back channel, not just a writable web root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,24 @@ file back — on exactly the internal, no-egress targets the method exists for.
   write directory: the web-root form confirms **0** — reporting an exploitable
   target clean — and the general form confirms **7**.
 
+### Fixed
+
+- **The read-back fetch now carries the run's headers**, so an authenticated
+  download, export, attachment or LFI handler can actually be read. It went out
+  bare, which barely mattered while the channel had to be a web root — static
+  file serving is rarely authenticated — and became the likely case the moment
+  the channel could be an application endpoint. Measured against a handler
+  behind a bearer token: the write executed on every probe and the verdict was
+  `negative`, "token absent from the fetched file". Now 7 confirmations on the
+  same target.
+- **Credentials are carried only to the same origin.** A read-back URL on
+  another host is someone else's server, and replaying the target's session
+  cookie or bearer token to it would leak the credential, so those headers are
+  dropped there while the rest still go — and the run says so, because the
+  symptom would otherwise look like a clean target. `Content-Type` and
+  `Content-Length` are dropped from the fetch too: they describe a body the GET
+  does not have.
+
 ### Changed
 
 - **`--webroot` / `--web-base-url` are now the web-root alias** for the general

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ formats, or the template schema.
 
 ## [Unreleased]
 
+## [2.29.0] — 2026-08-17
+
+Generalised read-back for the `file` method. It required a writable **web root**
+the tester already knew, which ruled out every other way a target can hand a
+file back — on exactly the internal, no-egress targets the method exists for.
+
+### Added
+
+- **`--file-write-path DIR` + `--file-read-url URL`** name the two halves of the
+  read-back channel directly, so an LFI endpoint, a download or export handler,
+  an attachment fetcher or a `/tmp`-backed preview all work. The template takes
+  `{name}` (the filename), `{path}` (the full server-side path) and `{path_enc}`
+  (that path percent-encoded); only those three are substituted, so a URL that
+  legitimately contains braces survives unchanged.
+
+  Measured against a target with a download handler and nothing serving the
+  write directory: the web-root form confirms **0** — reporting an exploitable
+  target clean — and the general form confirms **7**.
+
+### Changed
+
+- **`--webroot` / `--web-base-url` are now the web-root alias** for the general
+  form: a web root is just the case where the read URL is the base plus the
+  filename. Existing command lines are unaffected. Both are resolved in one
+  place inside the method, so the alias and the general form cannot drift — and
+  the gate, the pre-flight banner and the blind-sink advice all ask that same
+  resolver instead of testing for the webroot pair.
+- `blind_sink_advice` reads its flags defensively, so an args-like object
+  missing a newer field costs a line of advice rather than a traceback.
+
 ## [2.28.0] — 2026-08-17
 
 Injection-point enumeration. `-p NAME` needed the tester to already know which
@@ -561,7 +591,8 @@ this file and have not been restated here.
 - **[2.7.0]**
 - **[2.1.0]**
 
-[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.28.0...HEAD
+[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.29.0...HEAD
+[2.29.0]: https://github.com/kabiri-labs/rcekit/compare/v2.28.0...v2.29.0
 [2.28.0]: https://github.com/kabiri-labs/rcekit/compare/v2.27.0...v2.28.0
 [2.27.0]: https://github.com/kabiri-labs/rcekit/compare/v2.26.0...v2.27.0
 [2.26.0]: https://github.com/kabiri-labs/rcekit/compare/v2.25.0...v2.26.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.28.0** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.29.0** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -45,8 +45,10 @@ starting point — this page is for looking things up once you know what you wan
 | Option | Description | Default |
 |---|---|---|
 | `--methods` | Comma-separated: `reflected`, `eval`, `file`, `oob`, `time` | None |
-| `--webroot` | (`file`) server-side directory the target writes and serves | None |
-| `--web-base-url` | (`file`) base URL that serves `--webroot` | None |
+| `--file-write-path` | (`file`) server-side directory the target can write to, e.g. `/tmp` | None |
+| `--file-read-url` | (`file`) URL template that reads it back: `{name}`, `{path}`, `{path_enc}` | None |
+| `--webroot` | (`file`) web-root alias for `--file-write-path` | None |
+| `--web-base-url` | (`file`) web-root alias for `--file-read-url '<base>/{name}'` | None |
 | `--oob-host` | (`oob`) host the **target** calls back to; required for `oob` | None |
 | `--time-base` | (`time`) base delay `N`; the regression fires `0/N/2N` | `2.0` |
 | `--separators` | Break-out separators for shell probes; `\n` = newline | `; `, `\| `, `\|\| `, `&& `, newline |
@@ -107,6 +109,49 @@ depth and `--probe-depth` changes nothing for it.
 sweep, and it does not narrow the separator screen `--methods time` runs: both
 depths try every candidate break-out, because dropping one is not a saving in
 requests but a blind spot. Use `--separators` to narrow that deliberately.
+
+### File-based confirmation, and what counts as read-back
+
+`--methods file` makes the target write a random token to a file and then
+fetches it back. The token is present only if the command executed *and* the
+write landed somewhere readable — the confirmation channel is the target's own
+read-back path, so no external listener is needed.
+
+That path **does not have to be a web root**. Name the two halves directly:
+
+```bash
+# An LFI / download / export handler that takes a server-side path
+python rcekit.py --acknowledge-consent --verify-url "https://target/lookup?host=FUZZ" \
+  --methods file \
+  --file-write-path /tmp \
+  --file-read-url "https://target/download?f={path_enc}"
+```
+
+| Placeholder | Expands to | Suits |
+|---|---|---|
+| `{name}` | the generated filename | a handler that takes a filename |
+| `{path}` | the full server-side path | an LFI-style parameter |
+| `{path_enc}` | that path, percent-encoded | a handler that rejects raw separators |
+
+Only those three are substituted, so a URL that legitimately contains braces
+survives unchanged.
+
+`--webroot` + `--web-base-url` remain as the **web-root alias** — a web root is
+just the case where the read URL is the base plus the filename, so
+`--webroot DIR --web-base-url BASE` is exactly
+`--file-write-path DIR --file-read-url 'BASE/{name}'`. Existing command lines
+are unaffected. The alias and the general form are resolved in one place, so
+they cannot drift.
+
+Why it matters: requiring a writable web root ruled out the LFI endpoint, the
+download handler, the attachment fetcher and the `/tmp`-backed preview — on
+exactly the internal, no-egress targets this method exists for. Measured against
+a target with a download handler and nothing serving the write directory, the
+web-root form confirms 0 and the general form confirms 7.
+
+This method changes target state (one file per confirmed probe), so it stays
+gated on the operator naming both halves, and **every finding prints its own
+cleanup command**.
 
 ### Enumerating injection points
 

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.28.0"
+__version__ = "2.29.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -3110,26 +3110,65 @@ class ReflectedMath(DetectionMethod):
 
 class FileBased(DetectionMethod):
     """Self-OOB confirmation for internal / no-egress targets. The probe makes
-    the target *write* a random token to a web-reachable file, then a followup
-    request fetches that file: the token is present only if the command executed
-    AND the write landed under the web root. No external listener is needed —
-    the confirmation channel is the target's own web server.
+    the target *write* a random token to a file it can also serve back, then a
+    followup request fetches it: the token is present only if the command
+    executed AND the write landed somewhere readable. No external listener is
+    needed — the confirmation channel is the target's own read-back path.
 
-    This changes target state (one file per confirmed probe), so it is gated on
-    ``--webroot`` + ``--web-base-url`` (the operator names the write location and
-    fetch base) and every finding carries an explicit cleanup command."""
+    That path does not have to be a web root. An LFI endpoint, a download or
+    export handler, an attachment fetcher and a ``/tmp``-backed preview are all
+    read-back channels, and requiring a writable web root ruled every one of
+    them out — on exactly the internal, no-egress targets this method exists
+    for. ``--file-write-path`` and ``--file-read-url`` name the two halves
+    directly; ``--webroot``/``--web-base-url`` remain as the convenience alias
+    that builds them for the web-root case.
+
+    This changes target state (one file per confirmed probe), so it stays gated
+    on the operator naming both halves, and every finding carries an explicit
+    cleanup command."""
     name = "file"
     tier = "confirmed"
 
+    def _channel(self) -> Optional[Tuple[str, str]]:
+        """``(write_path, read_url_template)``, or ``None`` when not configured.
+
+        ``--webroot``/``--web-base-url`` are resolved here rather than at the
+        CLI so the alias and the general form cannot drift: a web root is just
+        the case where the read URL is the base plus the filename."""
+        write_path = self.config.get("file_write_path") or self.config.get("webroot")
+        read_url = self.config.get("file_read_url")
+        if not read_url and self.config.get("web_base_url"):
+            read_url = self.config["web_base_url"].rstrip("/") + "/{name}"
+        if not (write_path and read_url):
+            return None
+        return str(write_path), str(read_url)
+
     def applicable(self, record: "PayloadRecord") -> bool:
-        if not (self.config.get("webroot") and self.config.get("web_base_url")):
+        if self._channel() is None:
             return False
         return record.environment in SHELL_CAPABLE_ENVIRONMENTS
 
+    @staticmethod
+    def _render_read_url(template: str, path: str, name: str) -> str:
+        """Fill a read-back template.
+
+        ``{name}`` suits a handler that takes a filename, ``{path}`` an LFI-style
+        parameter that takes the whole server-side path, and ``{path_enc}`` the
+        same percent-encoded for a handler that rejects raw separators. Only
+        these three are substituted, so a URL containing other braces survives
+        unchanged."""
+        return (template
+                .replace("{path_enc}", urllib.parse.quote(path, safe=""))
+                .replace("{path}", path)
+                .replace("{name}", name))
+
     def build_probes(self, record: "PayloadRecord", rng: "random.Random") -> List[Probe]:
-        webroot = self.config["webroot"].rstrip("/")
-        base = self.config["web_base_url"].rstrip("/")
+        channel = self._channel()
+        if channel is None:
+            return []
+        write_root, read_template = channel
         windows = record.environment == "windows"
+        write_root = write_root.rstrip("\\") if windows else write_root.rstrip("/")
         probes: List[Probe] = []
         # One filename and token per separator. Sharing them would make every
         # probe's followup succeed as soon as any one separator wrote the file,
@@ -3141,15 +3180,16 @@ class FileBased(DetectionMethod):
             token = self._tag(rng) + "".join(rng.choice(string.ascii_uppercase + string.digits)
                                              for _ in range(10))
             if windows:
-                write_path = f"{webroot}\\{name}"
+                write_path = f"{write_root}\\{name}"
                 core = f"echo {token}>{write_path}"
                 cleanup = f"del {write_path}"
             else:
-                write_path = f"{webroot}/{name}"
+                write_path = f"{write_root}/{name}"
                 core = f"echo {token} > {write_path}"
                 cleanup = f"rm -f {write_path}"
             body = core if separator is None else f"{separator}{core}"
-            followup = {"url": f"{base}/{name}", "cleanup": cleanup, "path": write_path}
+            followup = {"url": self._render_read_url(read_template, write_path, name),
+                        "cleanup": cleanup, "path": write_path}
             # The write uses a `>` redirect, which ${IFS} would turn into an
             # ambiguous redirect, so this probe stays canonical under --evade low.
             probes.append(Probe(payload=self._wrap_context(record, body),
@@ -3161,7 +3201,8 @@ class FileBased(DetectionMethod):
             return Verdict("error", f"write request never reached the target ({obs.body[:120]})")
         if obs.followup_body is None:
             return Verdict("negative",
-                           "could not fetch the written file (no write, wrong web root, or blocked)")
+                           "could not fetch the written file (no write, wrong write path or "
+                           "read-back URL, or blocked)")
         if not self._search(probe.expected, obs.followup_body):
             return Verdict("negative", "token absent from the fetched file")
         # The token is random, so its presence anywhere in the payload-free
@@ -3778,11 +3819,14 @@ def blind_sink_advice(method_names: List[str], args: Any) -> List[str]:
     # to run is its own small version of the problem this function exists for.
     lines.append("[detect]   --methods oob --oob-host HOST --verify-active-risk intrusive   "
                  "(needs egress from the target; confirms)")
-    if not (args.webroot and args.web_base_url):
-        lines.append("[detect]   --methods file --webroot DIR --web-base-url URL   "
-                     "(needs a writable web root; confirms)")
+    if not ((getattr(args, "webroot", None) and getattr(args, "web_base_url", None))
+            or (getattr(args, "file_write_path", None)
+                and getattr(args, "file_read_url", None))):
+        lines.append("[detect]   --methods file --file-write-path DIR --file-read-url URL   "
+                     "(needs somewhere writable the target can also read back -- a web root, an "
+                     "LFI endpoint, a download handler; confirms)")
     lines.append("[detect]   --methods time                     "
-                 "(no egress and no web root needed; needs-review only)")
+                 "(no egress and no read-back needed; needs-review only)")
     return lines
 
 
@@ -4441,10 +4485,24 @@ def main():
                              "a request carrying credential headers over plain http is flagged.")
     parser.add_argument("--webroot", default=None,
                         help="(file-based detection) server-side directory the target can write to and "
-                             "serve, e.g. /var/www/html. Required with --methods file.")
+                             "serve, e.g. /var/www/html. Convenience alias for --file-write-path "
+                             "when the read-back channel is a web root.")
     parser.add_argument("--web-base-url", default=None,
                         help="(file-based detection) base URL that serves --webroot, e.g. "
-                             "https://target.example. Required with --methods file.")
+                             "https://target.example. Convenience alias for "
+                             "--file-read-url '<base>/{name}'.")
+    parser.add_argument("--file-write-path", default=None, metavar="DIR",
+                        help="(--methods file) server-side directory the target can write to, e.g. "
+                             "/tmp. Pairs with --file-read-url. Unlike --webroot this does not have "
+                             "to be served by a web server — anything the target can read back works.")
+    parser.add_argument("--file-read-url", default=None, metavar="URL",
+                        help="(--methods file) URL template that reads the written file back. "
+                             "Placeholders: {name} (filename), {path} (full server-side path), "
+                             "{path_enc} (that path percent-encoded). This is what generalises the "
+                             "method past a writable web root — an LFI endpoint, a download/export "
+                             "handler or an attachment fetcher is a read-back channel too, e.g. "
+                             "--file-write-path /tmp --file-read-url "
+                             "'https://target/download?f={path_enc}'.")
     parser.add_argument("--time-base", type=float, default=2.0,
                         help="(time-based detection) base delay N in seconds; the regression fires "
                              "0/N/2N and requires the response time to track it (default: 2.0).")
@@ -4478,8 +4536,8 @@ def main():
                         help="Comma-separated RCE detection methods to run against --verify-url/-r instead of "
                              "the classic per-payload oracle. Available: reflected (results-based execution "
                              "proof via computed arithmetic); eval (SSTI/SpEL/OGNL/Groovy/raw-eval via a "
-                             "computed product); file (self-OOB write+fetch, needs --webroot and "
-                             "--web-base-url); oob (DNS/HTTP callback to the built-in listener, needs "
+                             "computed product); file (self-OOB write+read-back, needs --file-write-path "
+                             "and --file-read-url, or the --webroot/--web-base-url alias); oob (DNS/HTTP callback to the built-in listener, needs "
                              "--oob-host — the only confirmed-tier method for a fully blind sink); "
                              "time (hardened blind-timing regression, needs-review only). "
                              "Opt-in and additive: when omitted, verification keeps its existing behaviour "
@@ -4915,6 +4973,8 @@ def main():
                       f"Available: {', '.join(sorted(DETECTION_METHODS))}.")
                 return 1
             detection_config = {"webroot": args.webroot, "web_base_url": args.web_base_url,
+                                "file_write_path": args.file_write_path,
+                                "file_read_url": args.file_read_url,
                                 "time_base": args.time_base, "evade": args.evade,
                                 "sink_raw": sink_raw, "separators": separators,
                                 "sink_shapes": sink_shapes, "eval_engines": eval_engines,
@@ -4957,12 +5017,15 @@ def main():
                 for line in oob_channel_warnings(args, dns_up):
                     print(line)
             if "file" in method_names:
-                if not (args.webroot and args.web_base_url):
+                file_channel = FileBased(generator, detection_config)._channel()
+                if file_channel is None:
                     print("[!] --methods file writes a file to the target and fetches it back, so it "
-                          "needs both --webroot (server-side write dir) and --web-base-url (fetch base).")
+                          "needs both halves: --file-write-path DIR and --file-read-url URL "
+                          "(or the web-root alias --webroot DIR --web-base-url URL).")
                     return 1
-                print(f"[detect] file-based method WRITES to {args.webroot} on the target and fetches via "
-                      f"{args.web_base_url}; each confirmed finding lists a cleanup command.")
+                print(f"[detect] file-based method WRITES to {file_channel[0]} on the target and "
+                      f"reads it back via {file_channel[1]}; each confirmed finding lists a "
+                      "cleanup command.")
             if set(method_names) & SHELL_PROBE_METHODS:
                 # The ladder multiplies request count, so say which shapes are
                 # about to be tried before trying them. An operator on a
@@ -5074,8 +5137,10 @@ def main():
                         print(f"[!] {', '.join(shell_methods)} {verb} an environment whose runtime "
                               "reaches a shell. Add --environments unix if the sink shells out, or "
                               f"use --methods {EvalExpr.name} for a template/expression sink.")
-                    if FileBased.name in method_names and not (args.webroot and args.web_base_url):
-                        print("[!] --methods file also needs --webroot and --web-base-url.")
+                    if (FileBased.name in method_names
+                            and FileBased(generator, detection_config)._channel() is None):
+                        print("[!] --methods file also needs --file-write-path and --file-read-url "
+                              "(or --webroot and --web-base-url).")
                 return 1
             confirmed = [r for r in results if r["verdict"] == "confirmed"]
             if confirmed:

--- a/rcekit.py
+++ b/rcekit.py
@@ -1980,6 +1980,54 @@ class RCEKit:
                 extra.append(dataclass_replace(record, context=context))
         return extra
 
+    @staticmethod
+    def same_origin(first: str, second: str) -> bool:
+        """Whether two URLs share scheme, host and effective port."""
+        default_ports = {"http": 80, "https": 443}
+
+        def origin(url: str):
+            parts = urllib.parse.urlsplit(url)
+            scheme = (parts.scheme or "").lower()
+            try:
+                port = parts.port
+            except ValueError:  # malformed port -- treat as its own origin
+                return None
+            return scheme, (parts.hostname or "").lower(), port or default_ports.get(scheme)
+
+        left, right = origin(first), origin(second)
+        return left is not None and left == right
+
+    def _followup_headers(self, request_url: str, followup_url: str,
+                          headers: Optional[List[str]]) -> Optional[List[str]]:
+        """Headers to carry on a read-back fetch.
+
+        The write executes with the run's headers; the fetch used to go out bare.
+        With a web root that rarely mattered -- static file serving is usually
+        unauthenticated. A generalised read-back channel is an *application*
+        endpoint (a download, export or attachment handler, an LFI parameter),
+        and those are usually behind a session. The write would succeed, the
+        fetch would get a 401, and the verdict would be ``negative`` on an
+        exploitable target.
+
+        Credentials are carried only to the **same origin** as the request under
+        test. A read-back URL on another host is someone else's server, and
+        replaying the target's session cookie or bearer token to it would leak
+        the credential -- so those headers are dropped there and the rest still
+        go. Content-Type and Content-Length describe a body this GET does not
+        have."""
+        if not headers:
+            return None
+        same = self.same_origin(request_url, followup_url)
+        kept: List[str] = []
+        for header in headers:
+            name = header.partition(":")[0].strip().lower()
+            if name in {"content-type", "content-length"}:
+                continue
+            if not same and name in self.SENSITIVE_HEADERS:
+                continue
+            kept.append(header)
+        return kept or None
+
     def _detection_carriers(self, records: Iterator[PayloadRecord],
                             config: Dict[str, Any]) -> List[PayloadRecord]:
         """Reduce the selected records to distinct ``(environment, context)``
@@ -2165,7 +2213,9 @@ class RCEKit:
                     followup_body: Optional[str] = None
                     if probe.followup and probe.followup.get("url"):
                         f_status, f_body, _ = self._fire(
-                            "", probe.followup["url"], "GET", None, None, "raw", "raw", timeout)
+                            "", probe.followup["url"], "GET", None,
+                            self._followup_headers(url, probe.followup["url"], headers),
+                            "raw", "raw", timeout)
                         followup_body = f_body if f_status is not None else None
                     obs = Observation(status=status, body=body, control_body=control_body,
                                       elapsed=elapsed, followup_body=followup_body,
@@ -5026,6 +5076,19 @@ def main():
                 print(f"[detect] file-based method WRITES to {file_channel[0]} on the target and "
                       f"reads it back via {file_channel[1]}; each confirmed finding lists a "
                       "cleanup command.")
+                # The read-back fetch carries the run's headers so an
+                # authenticated download/export/LFI handler can be reached --
+                # but only to the same origin. Say so when that costs the
+                # credentials, because the symptom otherwise is a `negative` on
+                # a target that executed the write perfectly.
+                sensitive = [name for name in
+                             (h.partition(":")[0].strip() for h in (verify_headers or []))
+                             if name.lower() in RCEKit.SENSITIVE_HEADERS]
+                if sensitive and not RCEKit.same_origin(verify_url, file_channel[1]):
+                    print(f"[!] The read-back URL is a different origin from the target, so "
+                          f"{', '.join(sorted(set(sensitive)))} will NOT be sent with it — "
+                          "replaying a credential to another host would leak it. If that read-back "
+                          "endpoint needs authentication, point it at the target's own origin.")
             if set(method_names) & SHELL_PROBE_METHODS:
                 # The ladder multiplies request count, so say which shapes are
                 # about to be tried before trying them. An operator on a

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -3986,6 +3986,82 @@ class FileReadBackTestCase(unittest.TestCase):
                 config={"webroot": writedir, "web_base_url": f"{base}/files"}, timeout=15)
         self.assertTrue([r for r in results if r["verdict"] == "confirmed"])
 
+    # -- authentication on the read-back fetch -------------------------------
+
+    def test_same_origin_read_back_carries_the_runs_headers(self):
+        # The write executes with the run's headers; the fetch used to go bare.
+        # A generalised read-back channel is an application endpoint, and those
+        # are usually behind a session.
+        kept = self.gen._followup_headers(
+            "http://t/a", "http://t/download",
+            ["Authorization: Bearer x", "Cookie: sid=y", "Accept: */*"])
+        self.assertEqual(kept, ["Authorization: Bearer x", "Cookie: sid=y", "Accept: */*"])
+
+    def test_cross_origin_read_back_never_carries_credentials(self):
+        # Replaying the target's session to another host would leak it.
+        kept = self.gen._followup_headers(
+            "http://t/a", "http://elsewhere/download",
+            ["Authorization: Bearer x", "Cookie: sid=y", "Accept: */*"])
+        self.assertEqual(kept, ["Accept: */*"])
+
+    def test_body_headers_are_not_carried_on_the_get(self):
+        kept = self.gen._followup_headers(
+            "http://t/a", "http://t/b",
+            ["Content-Type: application/json", "Content-Length: 12", "Accept: */*"])
+        self.assertEqual(kept, ["Accept: */*"])
+
+    def test_no_headers_stays_none(self):
+        self.assertIsNone(self.gen._followup_headers("http://t/a", "http://t/b", None))
+        self.assertIsNone(self.gen._followup_headers("http://t/a", "http://t/b", []))
+        self.assertIsNone(self.gen._followup_headers(
+            "http://t/a", "http://x/b", ["Authorization: only-this"]))
+
+    def test_same_origin_compares_scheme_host_and_effective_port(self):
+        same = RCEKit.same_origin
+        self.assertTrue(same("https://t/a", "https://t:443/b"))
+        self.assertTrue(same("http://T/a", "http://t:80/b"))
+        self.assertFalse(same("http://t/a", "https://t/b"))
+        self.assertFalse(same("http://t/a", "http://t:8080/b"))
+        self.assertFalse(same("http://t/a", "http://other/b"))
+        self.assertFalse(same("http://t/a", "http://t:notaport/b"))
+
+    def test_an_authenticated_read_back_handler_confirms(self):
+        # End to end: the write lands, the protected fetch authenticates, and the
+        # token comes back. Without the headers this returned `negative` on a
+        # target that had executed every probe.
+        import os
+        import tempfile
+        writedir = tempfile.mkdtemp()
+
+        def route(method, path, params, headers, body):
+            if path == "/download":
+                if headers.get("Authorization") != "Bearer s3cr3t":
+                    return 401, "unauthorized"
+                served = params.get("f", "")
+                if served and os.path.exists(served):
+                    with open(served) as handle:
+                        return 200, handle.read()
+                return 200, "missing"
+            pipe = os.popen("echo LOOKUP " + params.get("host", "") + " 2>&1")
+            out = pipe.read()
+            pipe.close()
+            return 200, out
+
+        with local_target(route) as base:
+            config = {"file_write_path": writedir,
+                      "file_read_url": base + "/download?f={path_enc}"}
+            authed = self.gen.run_detection(
+                [self.rec], url=f"{base}/?host=FUZZ", methods=["file"],
+                headers=["Authorization: Bearer s3cr3t"], config=config, timeout=15)
+            bare = self.gen.run_detection(
+                [self.rec], url=f"{base}/?host=FUZZ", methods=["file"],
+                config=config, timeout=15)
+
+        self.assertTrue([r for r in authed if r["verdict"] == "confirmed"],
+                        "the read-back fetch must authenticate like the write did")
+        self.assertFalse([r for r in bare if r["verdict"] == "confirmed"],
+                         "precondition: without the credential the handler refuses")
+
     def test_a_clean_target_stays_negative_through_the_new_channel(self):
         import tempfile
         writedir = tempfile.mkdtemp()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -3472,9 +3472,12 @@ class BlindSinkAdviceTestCase(unittest.TestCase):
     "no execution confirmed" reads exactly like a clean target."""
 
     class _Args:
-        def __init__(self, webroot=None, web_base_url=None):
+        def __init__(self, webroot=None, web_base_url=None,
+                     file_write_path=None, file_read_url=None):
             self.webroot = webroot
             self.web_base_url = web_base_url
+            self.file_write_path = file_write_path
+            self.file_read_url = file_read_url
 
     def test_in_band_only_runs_get_the_advice(self):
         lines = rcekit.blind_sink_advice(["reflected", "eval"], self._Args())
@@ -3830,6 +3833,168 @@ RAW_CAPTURE = (
     "\r\n"
     '{"user": {"profile": {"name": "ali"}}, "tags": ["a", 2]}'
 )
+
+
+class FileReadBackTestCase(unittest.TestCase):
+    """The `file` method's read-back channel does not have to be a web root.
+
+    An LFI endpoint, a download or export handler, an attachment fetcher and a
+    /tmp-backed preview are all read-back channels. Requiring a writable web
+    root ruled every one of them out — on exactly the internal, no-egress
+    targets this method exists for."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.rec = make_record(environment="unix", context="raw")
+
+    def _channel(self, config):
+        return FileBased(self.gen, config)._channel()
+
+    # -- resolving the two halves -------------------------------------------
+
+    def test_the_explicit_pair_is_used_as_given(self):
+        self.assertEqual(
+            self._channel({"file_write_path": "/tmp",
+                           "file_read_url": "http://t/dl?f={path}"}),
+            ("/tmp", "http://t/dl?f={path}"))
+
+    def test_the_webroot_alias_builds_the_same_shape(self):
+        # Backward compatibility: a web root is just the case where the read URL
+        # is the base plus the filename.
+        self.assertEqual(
+            self._channel({"webroot": "/var/www/html", "web_base_url": "http://t/"}),
+            ("/var/www/html", "http://t/{name}"))
+
+    def test_half_a_channel_is_not_a_channel(self):
+        for config in ({"file_write_path": "/tmp"}, {"file_read_url": "http://t/{name}"},
+                       {"webroot": "/var/www"}, {"web_base_url": "http://t"}, {}):
+            self.assertIsNone(self._channel(config), config)
+            self.assertFalse(FileBased(self.gen, config).applicable(self.rec), config)
+            import random as _random
+            self.assertEqual(FileBased(self.gen, config).build_probes(
+                self.rec, _random.Random(1)), [], config)
+
+    def test_the_explicit_flags_win_over_the_alias(self):
+        self.assertEqual(
+            self._channel({"webroot": "/var/www", "web_base_url": "http://t",
+                           "file_write_path": "/tmp",
+                           "file_read_url": "http://t/dl?f={path}"}),
+            ("/tmp", "http://t/dl?f={path}"))
+
+    # -- template rendering --------------------------------------------------
+
+    def test_every_placeholder_is_substituted(self):
+        render = FileBased._render_read_url
+        self.assertEqual(render("http://t/{name}", "/tmp/a.txt", "a.txt"), "http://t/a.txt")
+        self.assertEqual(render("http://t/dl?f={path}", "/tmp/a.txt", "a.txt"),
+                         "http://t/dl?f=/tmp/a.txt")
+        self.assertEqual(render("http://t/dl?f={path_enc}", "/tmp/a.txt", "a.txt"),
+                         "http://t/dl?f=%2Ftmp%2Fa.txt")
+
+    def test_other_braces_in_the_url_survive(self):
+        # Only the three placeholders are substituted, so a URL that legitimately
+        # contains braces is not mangled.
+        self.assertEqual(
+            FileBased._render_read_url("http://t/dl?q={\"a\":1}&f={name}", "/tmp/a.txt", "a.txt"),
+            "http://t/dl?q={\"a\":1}&f=a.txt")
+
+    # -- probe construction --------------------------------------------------
+
+    def _probes(self, config, environment="unix"):
+        import random as _random
+        return FileBased(self.gen, config).build_probes(
+            make_record(environment=environment, context="raw"), _random.Random(3))
+
+    def test_the_written_path_and_the_read_url_agree(self):
+        probes = self._probes({"file_write_path": "/tmp",
+                               "file_read_url": "http://t/dl?f={path}"})
+        self.assertTrue(probes)
+        for probe in probes:
+            path = probe.followup["path"]
+            self.assertTrue(path.startswith("/tmp/"))
+            self.assertEqual(probe.followup["url"], f"http://t/dl?f={path}")
+            self.assertIn(path, probe.followup["cleanup"])
+
+    def test_a_trailing_separator_on_the_write_path_is_not_doubled(self):
+        probe = self._probes({"file_write_path": "/tmp/",
+                              "file_read_url": "http://t/{name}"})[0]
+        self.assertNotIn("//", probe.followup["path"])
+
+    def test_windows_writes_with_a_backslash_and_cleans_up_with_del(self):
+        probe = self._probes({"file_write_path": "C:\\inetpub\\",
+                              "file_read_url": "http://t/{name}"}, environment="windows")[0]
+        self.assertTrue(probe.followup["path"].startswith("C:\\inetpub\\"))
+        self.assertNotIn("\\\\", probe.followup["path"])
+        self.assertTrue(probe.followup["cleanup"].startswith("del "))
+
+    def test_the_token_is_never_in_the_payload(self):
+        # The oracle is unchanged: the token appears only if the target wrote it.
+        for probe in self._probes({"file_write_path": "/tmp",
+                                   "file_read_url": "http://t/{name}"}):
+            self.assertIn(probe.expected, probe.payload,
+                          "the write command carries the token by construction")
+            self.assertNotIn(probe.expected, probe.followup["url"])
+
+    # -- end to end ----------------------------------------------------------
+
+    def _target(self, writedir, serve_webroot):
+        import os
+
+        def route(method, path, params, headers, body):
+            if path == "/download":
+                served = params.get("f", "")
+                if served and os.path.exists(served):
+                    with open(served) as handle:
+                        return 200, handle.read()
+                return 200, "no such export"
+            if serve_webroot and path.startswith("/files/"):
+                served = os.path.join(writedir, os.path.basename(path))
+                if os.path.exists(served):
+                    with open(served) as handle:
+                        return 200, handle.read()
+                return 404, "not found"
+            pipe = os.popen("echo LOOKUP " + params.get("host", "") + " 2>&1")
+            out = pipe.read()
+            pipe.close()
+            return 200, out
+        return route
+
+    def test_a_download_handler_is_a_read_back_channel(self):
+        # The case the method could not reach before: somewhere writable that no
+        # web server serves, plus a handler that reads a path back.
+        import tempfile
+        writedir = tempfile.mkdtemp()
+        with local_target(self._target(writedir, serve_webroot=False)) as base:
+            without = self.gen.run_detection(
+                [self.rec], url=f"{base}/?host=FUZZ", methods=["file"],
+                config={"webroot": writedir, "web_base_url": f"{base}/files"}, timeout=15)
+            with_channel = self.gen.run_detection(
+                [self.rec], url=f"{base}/?host=FUZZ", methods=["file"],
+                config={"file_write_path": writedir,
+                        "file_read_url": base + "/download?f={path_enc}"}, timeout=15)
+        self.assertFalse([r for r in without if r["verdict"] == "confirmed"],
+                         "precondition: nothing serves the write directory")
+        self.assertTrue([r for r in with_channel if r["verdict"] == "confirmed"],
+                        "a download handler must work as the read-back channel")
+
+    def test_the_webroot_alias_still_confirms_on_a_web_root(self):
+        import tempfile
+        writedir = tempfile.mkdtemp()
+        with local_target(self._target(writedir, serve_webroot=True)) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/?host=FUZZ", methods=["file"],
+                config={"webroot": writedir, "web_base_url": f"{base}/files"}, timeout=15)
+        self.assertTrue([r for r in results if r["verdict"] == "confirmed"])
+
+    def test_a_clean_target_stays_negative_through_the_new_channel(self):
+        import tempfile
+        writedir = tempfile.mkdtemp()
+        with local_target(lambda *a: (200, "<html>static</html>")) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/?host=FUZZ", methods=["file"],
+                config={"file_write_path": writedir,
+                        "file_read_url": base + "/download?f={path_enc}"}, timeout=15)
+        self.assertFalse([r for r in results if r["verdict"] == "confirmed"])
 
 
 class InjectionPointEnumerationTestCase(unittest.TestCase):


### PR DESCRIPTION
Phase 13 — the second half of M3, and the last item in it.

## Why

`--methods file` proves execution by making the target write a random token and then fetching it back. It required that fetch to be a **web root** the tester already knew, which ruled out every other way a target hands a file back: an LFI endpoint, a download or export handler, an attachment fetcher, a `/tmp`-backed preview. Those are the norm on exactly the internal, no-egress targets this method exists for.

## Measured

Against a target with a download handler and **nothing serving the write directory**:

```
webroot form           probes=10  confirmed=0
generalised read-back  probes=10  confirmed=7
```

Zero — on a target that was executing every probe.

## The two halves

```bash
python rcekit.py --acknowledge-consent --verify-url "https://target/lookup?host=FUZZ" \
  --methods file \
  --file-write-path /tmp \
  --file-read-url "https://target/download?f={path_enc}"
```

| Placeholder | Expands to | Suits |
|---|---|---|
| `{name}` | the generated filename | a handler that takes a filename |
| `{path}` | the full server-side path | an LFI-style parameter |
| `{path_enc}` | that path, percent-encoded | a handler that rejects raw separators |

Only those three are substituted, so a URL that legitimately contains braces survives unchanged.

## Backward compatibility

`--webroot` + `--web-base-url` remain as the **web-root alias**: a web root is just the case where the read URL is the base plus the filename, so `--webroot DIR --web-base-url BASE` is exactly `--file-write-path DIR --file-read-url 'BASE/{name}'`. **No existing command line changes behaviour**, and a test asserts the alias still confirms against a real web root.

Both forms resolve through one `_channel()` inside the method. That matters beyond tidiness: the gate, the pre-flight banner and the blind-sink advice each used to test for the webroot pair themselves, so three call sites could have disagreed about what "configured" means. They all ask the resolver now.

`blind_sink_advice` also reads its flags defensively — it takes an args-like object, and a missing newer field should cost a line of advice rather than a traceback. Its test stub was updated to stay faithful to the real shape.

## Unchanged by design

The method still changes target state, so it stays gated on the operator naming **both** halves, and every finding still prints its own cleanup command. The oracle is untouched: a random token, present only if the target wrote it, differenced against the payload-free control across every channel.

## Tests

13 new tests: channel resolution for both forms and their precedence, half a channel being no channel (no probes built, not an empty run reported as negative), template placeholders and brace survival, write-path/read-URL agreement, Windows separators and `del` cleanup, and three end-to-end runs — a download handler confirming, the web-root alias still confirming on a real web root, and a clean target staying negative through the new channel.

```
python -m unittest discover -s tests
Ran 423 tests in 149.959s

OK
```

## Compatibility

Additive. Version 2.28.0 → 2.29.0 (MINOR), README badge, CHANGELOG and `docs/reference.md` updated.

This completes M3. Next per the plan is M4: Phase 2 (write-then-execute) + Phase 11 (Windows/PowerShell computed-value cores).