### PR TITLE
Phase 2 — the `write` method (write-then-execute proof)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,63 @@ formats, or the template schema.
 
 ## [Unreleased]
 
+## [2.31.0] — 2026-08-17
+
+The `write` method: a write primitive proven to be RCE by executing what it
+wrote. A whole family of targets was invisible — `tomcat/CVE-2017-12615` (PUT a
+JSP), `activemq/CVE-2016-3088`, `weblogic/CVE-2018-2894` — because the vulnerable
+request *stores a file* rather than evaluating anything. Nothing is computed in
+its response, so `reflected` and `eval` correctly returned `negative` on targets
+that are fully exploitable.
+
+### Added
+
+- **`--methods write`** — the inverse of `file`. `file` assumes execution exists
+  and uses a write as proof of it; `write` assumes a write primitive exists and
+  uses execution of the written file as proof of RCE. The probe is the file's
+  *content*: a one-liner computing a product on random operands, delivered
+  through the ordinary injection point.
+
+  The fetched file is read in three tiers, and the middle one is the reason the
+  method exists:
+
+  | fetched file contains | verdict | means |
+  |---|---|---|
+  | the product | `confirmed` | written **and** executed |
+  | the one-liner, verbatim | `needs-review` | arbitrary file write, not interpreted |
+  | neither | `negative` | no write, or not served there |
+
+  An upload directory that is served but not interpreted is a real finding and
+  is not remote code execution, so the tiers are never merged.
+
+- **`--write-url-template URL`** names where the stored file is served — the
+  channel the proof comes back on, and the flag the method is gated on.
+
+- **`--write-lang`** picks the file types: `auto` (default) reads the extension
+  off the read-back URL, or name any of `jsp`, `jspx`, `php`, `aspx`, `erb`.
+  `jsp`/`aspx`/`erb` share the `<%= %>` delimiters, so their probes are
+  byte-identical and cost one request between them; with no extension to read,
+  `auto` writes all five in three requests.
+
+### Changed
+
+- **A `needs-review` finding now prints its cleanup line too.** It used to
+  appear only under `confirmed`, which was already thin and is wrong for this
+  method: a `write` reaching `needs-review` means the file *is* on the target,
+  just not interpreted, so the artifact would have been left there unmentioned.
+
+- The write method's operands are drawn once per run rather than once per
+  carrier, so the file is written once instead of once for each of the ~13
+  `(environment, context)` carriers. For a state-changing method that is not a
+  request-count saving, it is a blast radius. Still fresh per run, which is what
+  makes the product unforgeable.
+
+- The write method declines the break-out contexts (`sql`, `javascript`,
+  `shell_*`, …) and keeps the transport ones. Its payload is a whole file body:
+  there is nothing to break out of, and wrapping it in `'; … -- ` would write a
+  broken file. A run narrowed past `raw` and the transport contexts is told so
+  rather than reporting a clean negative.
+
 ## [2.30.0] — 2026-08-17
 
 Per-dialect shell probes. `$((a+b))`, `sleep` and `$(echo TAG)` are POSIX
@@ -670,7 +727,8 @@ this file and have not been restated here.
 - **[2.7.0]**
 - **[2.1.0]**
 
-[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.30.0...HEAD
+[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.31.0...HEAD
+[2.31.0]: https://github.com/kabiri-labs/rcekit/compare/v2.30.0...v2.31.0
 [2.30.0]: https://github.com/kabiri-labs/rcekit/compare/v2.29.0...v2.30.0
 [2.29.0]: https://github.com/kabiri-labs/rcekit/compare/v2.28.0...v2.29.0
 [2.28.0]: https://github.com/kabiri-labs/rcekit/compare/v2.27.0...v2.28.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.30.0** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.31.0** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed
@@ -235,6 +235,7 @@ One CLI, one `--methods` flag, covering the main paths to RCE:
 | **Code / expression injection** — SSTI, SpEL, OGNL, Groovy, `eval()` (CWE-94) | `eval` | Injects `a*b` in every common template syntax (`${…}` `{{…}}` `#{…}` `%{…}` `<%=…%>` `@(…)`, bare); confirms the **product** appears while the literal `a*b` does not. |
 | **Blind command injection** (no output) | `time` | Fires a controlled `0/N/2N` delay series and confirms the response time tracks the delay **linearly**; reported `needs-review` (jitter can't fake it, but timing isn't a computed value). |
 | **Internal / no-egress** targets | `file` | Writes a random token to a web-reachable file and fetches it back — proving execution **plus** a write primitive, with no external listener. |
+| **Upload / write primitive** — PUT-a-JSP, unchecked upload (CWE-434) | `write` | Writes a one-liner that *computes* a product through your own upload request, then fetches the file: the product is `confirmed` RCE, the source coming back verbatim is `needs-review` (arbitrary file write, not execution). |
 | **Blind / out-of-band** — Log4Shell/JNDI, exfil, async | *(OOB listener)* | Built-in HTTP/DNS listener receives callbacks and correlates each to the exact payload. |
 
 Mix them freely: `--methods reflected,eval,time` runs all three and reports each
@@ -268,6 +269,7 @@ what it sends, and how to read what comes back.
 | There's a WAF | [Working around a WAF](docs/guide.md#working-around-a-waf) |
 | No output comes back at all | [Blind targets](docs/guide.md#blind-targets) |
 | No output *and* no egress | [No-egress targets](docs/guide.md#no-egress-targets) |
+| The request stores a file instead of running anything | [Upload and write-primitive targets](docs/guide.md#upload-and-write-primitive-targets) |
 | The sink is behind a login or a file upload | [Multi-step chains](docs/guide.md#multi-step-chains) |
 | I got `needs-review` / `inconclusive` / `error` | [Reading the results](docs/guide.md#reading-the-results) |
 | It says the corpus is unusable | [Troubleshooting](docs/guide.md#troubleshooting) |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -21,6 +21,7 @@ only ever run it against systems you are authorised to test.
 - [Working around a WAF](#working-around-a-waf)
 - [Blind targets](#blind-targets)
 - [No-egress targets](#no-egress-targets)
+- [Upload and write-primitive targets](#upload-and-write-primitive-targets)
 - [Out-of-band callbacks](#out-of-band-callbacks)
 - [Multi-step chains](#multi-step-chains)
 - [Reading the results](#reading-the-results)
@@ -413,6 +414,47 @@ paste it into the report so the client can verify the target was left clean.
 
 A stale file can't produce a false positive: both the filename and the token are
 freshly random each run.
+
+---
+
+## Upload and write-primitive targets
+
+Some vulnerable requests do not evaluate anything — they **store a file**. A PUT
+that lands a `.jsp` in the web root, an upload endpoint that does not check the
+extension, an export handler that writes where you point it. Nothing in the
+response is computed, so `reflected` and `eval` correctly return `negative` on a
+target you can fully own.
+
+`--methods write` inverts the question. It writes a one-liner that *computes* a
+product, then fetches the file back and reads which of three things happened:
+
+| The fetched file contains | Verdict | What you have |
+|---|---|---|
+| the product | `confirmed` | remote code execution |
+| the one-liner, verbatim | `needs-review` | arbitrary file write — served, not interpreted |
+| neither | `negative` | no write, or the file is not served there |
+
+That middle row is the one to know about. An upload directory that is served but
+not interpreted is a real finding and it is **not** RCE, so RCEKit reports it in
+its own tier rather than rounding it up or down.
+
+```bash
+# put-jsp.txt is your own captured request; FUZZ marks the body
+python rcekit.py --acknowledge-consent \
+  -r put-jsp.txt --methods write \
+  --write-url-template "https://target.example/uploads/rcekit-probe.jsp"
+```
+
+**You choose the filename, RCEKit chooses the content.** Delivery substitutes one
+injection point, and this class of target needs two — the name in the request
+line, the content in the body — so put the name in your request and point
+`--write-url-template` at exactly that file. One artifact per run, and every
+finding (both tiers) prints a cleanup line naming it.
+
+`--write-lang` narrows the file types. `auto` reads the extension off the
+read-back URL, so a `.jsp` costs one request; with no extension to read it
+writes all five languages, which is three requests because `jsp`, `aspx` and
+`erb` share the `<%= %>` delimiters.
 
 ---
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -45,11 +45,13 @@ starting point — this page is for looking things up once you know what you wan
 
 | Option | Description | Default |
 |---|---|---|
-| `--methods` | Comma-separated: `reflected`, `eval`, `file`, `oob`, `time` | None |
+| `--methods` | Comma-separated: `reflected`, `eval`, `file`, `write`, `oob`, `time` | None |
 | `--file-write-path` | (`file`) server-side directory the target can write to, e.g. `/tmp` | None |
 | `--file-read-url` | (`file`) URL template that reads it back: `{name}`, `{path}`, `{path_enc}` | None |
 | `--webroot` | (`file`) web-root alias for `--file-write-path` | None |
 | `--web-base-url` | (`file`) web-root alias for `--file-read-url '<base>/{name}'` | None |
+| `--write-url-template` | (`write`) URL the file your request stores is served at; required for `write` | None |
+| `--write-lang` | (`write`) File types to write: `auto`, or any of `jsp`, `jspx`, `php`, `aspx`, `erb` | `auto` |
 | `--oob-host` | (`oob`) host the **target** calls back to; required for `oob` | None |
 | `--time-base` | (`time`) base delay `N`; the regression fires `0/N/2N` | `2.0` |
 | `--separators` | Break-out separators for shell probes; `\n` = newline | `; `, `\| `, `\|\| `, `&& `, newline |
@@ -69,6 +71,7 @@ starting point — this page is for looking things up once you know what you wan
 | `reflected` | OS command injection, via computed arithmetic | `confirmed` |
 | `eval` | SSTI / SpEL / OGNL / Groovy / raw `eval()`, via a computed product | `confirmed` |
 | `file` | Execution + a write primitive, via write-and-fetch | `confirmed` |
+| `write` | A write primitive proven to be RCE, by executing the written file | `confirmed`, or `needs-review` for a write that is served but not interpreted |
 | `oob` | Blind execution, via a DNS/HTTP callback carrying a per-probe token | `confirmed` |
 | `time` | Blind execution, via a `0/N/2N` regression | `needs-review` only |
 
@@ -160,6 +163,57 @@ web-root form confirms 0 and the general form confirms 7.
 This method changes target state (one file per confirmed probe), so it stays
 gated on the operator naming both halves, and **every finding prints its own
 cleanup command**.
+
+### Write-then-execute: proving a write primitive is RCE
+
+`--methods write` is the **inverse** of `file`, and it covers a class the others
+are structurally blind to. `file` assumes execution exists and uses a write as
+proof of it. `write` assumes a **write primitive** exists — the vulnerable
+request *stores* a file rather than evaluating anything — and uses execution of
+the written file as proof of RCE. `tomcat/CVE-2017-12615` (PUT a JSP),
+`activemq/CVE-2016-3088` and `weblogic/CVE-2018-2894` are all in this family.
+Nothing in the vulnerable response is computed, so `reflected` and `eval`
+correctly return `negative` on a target that is fully exploitable.
+
+The probe is the file's *content*: a one-liner that computes a product on random
+operands, delivered through the ordinary injection point. RCEKit then fetches the
+file and reads the answer in three tiers:
+
+| The fetched file contains | Verdict | Means |
+|---|---|---|
+| the product | `confirmed` | the file was written **and** executed |
+| the one-liner, verbatim | `needs-review` | arbitrary file write; the directory is served but not interpreted |
+| neither | `negative` | no write, or the file is not served at that URL |
+
+The middle row is the reason the method exists, and it is never merged into
+either neighbour: an upload directory that is served but not interpreted is a
+real finding and is not remote code execution.
+
+```bash
+# Your own request writes the file; --write-url-template says where it lands
+python rcekit.py --acknowledge-consent \
+  -r put-jsp.txt --methods write \
+  --write-url-template "https://target/uploads/rcekit-probe.jsp"
+```
+
+**The filename is yours, not RCEKit's.** Delivery substitutes one injection
+point, and every target in this class needs two locations — the name in the
+request line or a form field, the content in the body — so RCEKit writes the
+content into whatever file your own request already names. That also means one
+artifact per run rather than one per probe, which is the right trade for a
+method that changes target state.
+
+`--write-lang` picks the file types; `auto` reads the extension off the read-back
+URL. `jsp`, `aspx` and `erb` share the `<%= %>` delimiters, so their probes are
+byte-identical and cost one request between them; `php` is `<?= ?>`; `jspx` is
+XML (`<jsp:expression>`) because a `.jspx` container parses the file as a
+document and never sees scriptlet delimiters. With no extension to read, `auto`
+writes all five — three requests.
+
+Like `file`, this method changes target state, so it stays gated on the read-back
+URL being named, prints what it is about to do first, and attaches a cleanup line
+to **both** the `confirmed` and the `needs-review` tiers — a `needs-review` here
+means the file is on the target, just not interpreted.
 
 ### Enumerating injection points
 

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.30.0"
+__version__ = "2.31.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -140,9 +140,17 @@ SINK_SHAPE_CONTEXTS = SINK_SHAPE_CONTEXTS_BY_ENV["unix"]
 CHEAP_DETECTION_METHODS = {"reflected", "eval"}
 
 # Methods whose probes are shell commands, and so ride the sink-shape ladder.
-# `eval` is deliberately absent: its probes are template/expression syntax, not
-# shell, so no separator or quote break-out applies to them.
+# `eval` and `write` are deliberately absent: their probes are template /
+# expression syntax and file content, not shell, so no separator or quote
+# break-out applies to them.
 SHELL_PROBE_METHODS = {"reflected", "file", "time", "oob"}
+
+# Methods that leave something behind on the target. Both need the operator to
+# name a write path and a read-back URL, both print what they are about to do
+# before doing it, and every finding they report carries a cleanup line -- so
+# the list exists to keep those three obligations from drifting apart as
+# methods are added.
+STATE_CHANGING_METHODS = {"file", "write"}
 
 
 def parse_sink_env(value: Optional[str]) -> Optional[str]:
@@ -161,6 +169,23 @@ def parse_sink_env(value: Optional[str]) -> Optional[str]:
         raise ValueError(f"unknown sink environment: {value}; "
                          f"choose from auto, {', '.join(SINK_ENVIRONMENTS)}")
     return value
+
+
+def parse_write_langs(value: Optional[str]) -> Optional[Tuple[str, ...]]:
+    """``--write-lang`` -> the file types to write, or ``None`` for ``auto``.
+
+    Raises ``ValueError`` naming the offending value. A typo here would narrow
+    the run to nothing and report a clean negative from a run that wrote no
+    file at all."""
+    if not value or value.strip().lower() == "auto":
+        return None
+    names = tuple(part.strip().lower() for part in value.split(",") if part.strip())
+    known = set(WriteThenExecute.LANGUAGES)
+    unknown = [name for name in names if name not in known]
+    if unknown:
+        raise ValueError(f"unknown write language(s): {', '.join(unknown)}; "
+                         f"choose from auto, {', '.join(sorted(known))}")
+    return names or None
 
 
 def sink_env_for(record: "PayloadRecord", config: Dict[str, Any]) -> str:
@@ -3473,6 +3498,190 @@ class FileBased(DetectionMethod):
                        f"target wrote and served token {probe.expected!r} (execution + write primitive)")
 
 
+class WriteThenExecute(DetectionMethod):
+    """The inverse of :class:`FileBased`, for the class where nothing computes.
+
+    ``file`` assumes execution exists and uses a write as proof of it. This
+    method assumes a **write primitive** exists — the vulnerable request stores
+    a file rather than evaluating anything — and uses *execution of the written
+    file* as proof of RCE. A whole family of targets is invisible without it:
+    ``tomcat/CVE-2017-12615`` (PUT a JSP), ``activemq/CVE-2016-3088``,
+    ``weblogic/CVE-2018-2894``. Nothing in the vulnerable response is computed,
+    so ``reflected`` and ``eval`` correctly report ``negative`` and the target is
+    exploitable anyway.
+
+    The probe is the file's *content*: a language one-liner that computes a
+    product on random operands, delivered through the ordinary injection point.
+    RCEKit then fetches the file back and reads the answer in three tiers, which
+    is the whole value of the method:
+
+    ==============================  ===============  ==================================
+    fetched file contains           verdict          means
+    ==============================  ===============  ==================================
+    the product                     ``confirmed``    the file was written AND executed
+    the one-liner, verbatim         ``needs-review`` arbitrary file write, no execution
+    neither                         ``negative``     no write, or it is not served here
+    ==============================  ===============  ==================================
+
+    Collapsing the middle row into either neighbour would be a lie in one
+    direction or the other: an upload directory that is served but not
+    interpreted is a real finding and not remote code execution.
+
+    The filename is the operator's, not RCEKit's. Delivery substitutes one
+    injection point, and every target in this class needs two locations (the
+    name in the request line or a form field, the content in the body) — so
+    RCEKit writes the content the operator's own request already names, and
+    ``--write-url-template`` says where that lands. One artifact per run rather
+    than one per probe is also the right trade for a state-changing method."""
+    name = "write"
+    tier = "confirmed"
+
+    # One entry per file type whose interpreter is reachable by writing a file.
+    # `exts` drives `--write-lang auto`; `template` takes {t1}/{t2} (boundary
+    # tags) and {expr} (the arithmetic).
+    #
+    # JSP, ASPX and ERB share the `<%= %>` delimiters, so their probes are
+    # byte-identical and the engine's per-payload de-duplication fires them as
+    # one request. They stay separate names because `auto` narrows by extension,
+    # and because a contributor adding a fourth `<%= %>` dialect should not have
+    # to discover that by reading the payloads.
+    LANGUAGES = {
+        "jsp": {"exts": ("jsp",), "template": "{t1}<%= {expr} %>{t2}"},
+        "aspx": {"exts": ("aspx", "asp", "ashx"), "template": "{t1}<%= {expr} %>{t2}"},
+        "erb": {"exts": ("erb", "rhtml"), "template": "{t1}<%= {expr} %>{t2}"},
+        "php": {"exts": ("php", "php3", "php4", "php5", "php7", "phtml", "phar"),
+                "template": "{t1}<?= {expr} ?>{t2}"},
+        # .jspx is XML, so the scriptlet delimiters are not available at all --
+        # the container parses the file as a document and `<%=` is character
+        # data. It is the one shape here that is not a delimiter swap.
+        "jspx": {"exts": ("jspx",),
+                 "template": ('<jsp:root xmlns:jsp="http://java.sun.com/JSP/Page" '
+                              'version="2.0"><jsp:expression>'
+                              '"{t1}"+({expr})+"{t2}"</jsp:expression></jsp:root>')},
+    }
+
+    # Contexts whose wrapping makes sense for a file *body*. A break-out context
+    # exists to escape a surrounding command or query; there is no surrounding
+    # anything here -- the payload is the whole file -- so wrapping it in
+    # `'; ... -- ` would write a broken file and prove nothing. The transport
+    # contexts are the opposite case and are kept: a payload delivered in a JSON
+    # or XML body has to survive that serialization to land intact.
+    PLAIN_CONTEXT = "raw"
+
+    def __init__(self, gen: "RCEKit", config: Optional[Dict[str, Any]] = None):
+        super().__init__(gen, config)
+        # Operands are drawn once per method instance rather than per carrier.
+        # Every carrier then yields byte-identical content and the engine's
+        # de-duplication collapses them to one write. Per-carrier operands would
+        # be `random` in the same sense and would also write the file ~13 times
+        # -- for a state-changing method that is not a cost, it is a blast
+        # radius. Still fresh per run, which is what makes the product
+        # unforgeable.
+        self._operands: Optional[Tuple[int, int, str, str]] = None
+
+    def _channel(self) -> Optional[str]:
+        """The URL the written file is served at, or ``None`` when unset."""
+        template = self.config.get("write_read_url")
+        return str(template) if template else None
+
+    def applicable(self, record: "PayloadRecord") -> bool:
+        if self._channel() is None:
+            return False
+        return (record.context == self.PLAIN_CONTEXT
+                or record.context in self.gen.transport_contexts)
+
+    def _selected_languages(self) -> List[str]:
+        """Which file types to write, honouring ``--write-lang``.
+
+        ``auto`` reads the extension off the read-back URL: the operator already
+        said where the file is served, and that URL carries the one fact that
+        decides which interpreter is on the other side. When it carries no
+        extension RCEKit cannot know, so it writes all of them rather than
+        guessing -- which costs three requests, not five, because three of the
+        five templates are the same bytes."""
+        wanted = self.config.get("write_langs")
+        if wanted:
+            return [name for name in self.LANGUAGES if name in wanted]
+        url = self._channel() or ""
+        # Only the path, so a `?file=x.jsp` query does not fool it into matching
+        # a fragment or another parameter's value.
+        path = urllib.parse.urlsplit(url).path
+        _, _, extension = path.rpartition(".")
+        extension = extension.strip("/").lower()
+        if extension:
+            inferred = [name for name, spec in self.LANGUAGES.items()
+                        if extension in spec["exts"]]
+            if inferred:
+                return inferred
+        return list(self.LANGUAGES)
+
+    def build_probes(self, record: "PayloadRecord", rng: "random.Random") -> List[Probe]:
+        read_url = self._channel()
+        if read_url is None:
+            return []
+        if self._operands is None:
+            self._operands = (rng.randint(10000, 99999), rng.randint(10000, 99999),
+                              self._tag(rng), self._tag(rng))
+        a, b, t1, t2 = self._operands
+        expr = f"{a}*{b}"
+        product = a * b
+        followup = {
+            "url": read_url,
+            # Not a shell command: RCEKit knows the URL the operator named, not
+            # the server-side path, and printing a plausible-looking `rm -f`
+            # built from a guess would be worse than saying what is true.
+            "cleanup": f"remove the file the target serves at {read_url}",
+        }
+        # Languages that share a template share a probe. Naming them together
+        # keeps the finding honest: those bytes are one request, and which
+        # interpreter ran them is not something the response can distinguish --
+        # reporting `jsp` for a confirmation an ASP.NET host produced would be a
+        # guess dressed as evidence.
+        by_body: "Dict[str, List[str]]" = {}
+        for name in self._selected_languages():
+            body = self.LANGUAGES[name]["template"].format(t1=t1, t2=t2, expr=expr)
+            by_body.setdefault(body, []).append(name)
+        probes: List[Probe] = []
+        for body, names in by_body.items():
+            probes.append(Probe(payload=self._wrap_context(record, body),
+                                expected=f"{t1}{product}{t2}",
+                                # The source form. Its presence in the fetched
+                                # file is what separates "written but served as
+                                # text" from "not written at all".
+                                forbidden=body,
+                                carrier="/".join(names), followup=followup))
+        return probes
+
+    def confirm(self, obs: "Observation", probe: "Probe") -> Verdict:
+        if obs.status is None:
+            return Verdict("error", f"write request never reached the target ({obs.body[:120]})")
+        if obs.followup_body is None:
+            return Verdict("error", "could not fetch the written file back "
+                                    "(the read-back URL never answered)")
+        if self._search(probe.expected, obs.followup_body):
+            # Same differential as every other computed-value method: a product
+            # on random operands that is already present without the payload is
+            # not attributable to execution, wherever it turned up.
+            if self._search_channels(probe.expected,
+                                     self._channels_of(obs.control_body, obs.control_channels)):
+                return Verdict("inconclusive",
+                               "the computed value is also present without the payload")
+            return Verdict("confirmed",
+                           f"target wrote and then EXECUTED a {probe.carrier} file: it computed "
+                           f"{probe.expected!r} from random operands the file itself carried")
+        if probe.forbidden and self._search(probe.forbidden, obs.followup_body):
+            # Deliberately not merged into either neighbour. The write landed
+            # and is served, which is a real finding; the interpreter did not
+            # run it, which means this is not remote code execution.
+            return Verdict("needs-review",
+                           "ARBITRARY FILE WRITE confirmed -- the written file is served back "
+                           f"verbatim ({probe.carrier} source, not executed), so the upload "
+                           "directory is reachable but not interpreted")
+        return Verdict("negative",
+                       "neither the computed value nor the written source came back from the "
+                       "read-back URL (no write, or the file is not served there)")
+
+
 class ParametricTime(DetectionMethod):
     """Hardened blind timing. Instead of a single margin over one slow response,
     fire a controlled series of delays (``d ∈ {0, N, 2N}``, each repeated) and
@@ -3982,6 +4191,7 @@ class OobCallback(DetectionMethod):
 DETECTION_METHODS = {
     ReflectedMath.name: ReflectedMath,
     FileBased.name: FileBased,
+    WriteThenExecute.name: WriteThenExecute,
     ParametricTime.name: ParametricTime,
     EvalExpr.name: EvalExpr,
     OobCallback.name: OobCallback,
@@ -4886,6 +5096,20 @@ def main():
                              "command; sq/dq break out of a surrounding quote; subshell reaches a "
                              "quoted value through $(...) and backticks without closing the quote. "
                              "Narrow it to cut request count once the sink's shape is known.")
+    parser.add_argument("--write-url-template", default=None, metavar="URL",
+                        help="(--methods write) URL the file written through the injection point "
+                             "is served at, e.g. https://target/uploads/rcekit-probe.jsp. Required "
+                             "for the write method: it is the channel the proof comes back on. "
+                             "The filename is yours — it is whatever your own request writes — so "
+                             "point this at exactly that file.")
+    parser.add_argument("--write-lang", default=None, metavar="LANGS",
+                        help="(--methods write) File types to write, comma-separated: auto "
+                             "(default, inferred from the --write-url-template extension) or any "
+                             f"of {', '.join(sorted(WriteThenExecute.LANGUAGES))}. jsp/aspx/erb "
+                             # argparse %-expands help text, so the delimiters
+                             # are doubled here and appear singly in --help.
+                             "share the <%%= %%> delimiters, so naming all three still costs one "
+                             "request.")
     parser.add_argument("--sink-env", default=None, metavar="ENV",
                         help="(--methods) Which shell runs the injected command: "
                              f"auto (default) or one of {', '.join(SINK_ENVIRONMENTS)}. "
@@ -4960,6 +5184,7 @@ def main():
     try:
         sink_shapes = parse_sink_shapes(from_profile(args.sink_shape, "sink_shape"))
         sink_env = parse_sink_env(from_profile(args.sink_env, "sink_env"))
+        write_langs = parse_write_langs(from_profile(args.write_lang, "write_lang"))
     except ValueError as exc:
         print(f"[!] {exc}")
         return 1
@@ -5267,6 +5492,8 @@ def main():
                                 "time_base": args.time_base, "evade": args.evade,
                                 "sink_raw": sink_raw, "separators": separators,
                                 "sink_shapes": sink_shapes, "sink_env": sink_env,
+                                "write_read_url": args.write_url_template,
+                                "write_langs": write_langs,
                                 "eval_engines": eval_engines,
                                 "probe_depth": args.probe_depth,
                                 "contexts_explicit": bool(selected_contexts),
@@ -5329,6 +5556,30 @@ def main():
                           f"{', '.join(sorted(set(sensitive)))} will NOT be sent with it — "
                           "replaying a credential to another host would leak it. If that read-back "
                           "endpoint needs authentication, point it at the target's own origin.")
+            if WriteThenExecute.name in method_names:
+                writer = WriteThenExecute(generator, detection_config)
+                if writer._channel() is None:
+                    print("[!] --methods write stores a file on the target through your own "
+                          "request and then fetches it back, so it needs --write-url-template "
+                          "URL: the address that file is served at. RCEKit does not choose the "
+                          "filename -- your request does -- so point it at exactly that file.")
+                    return 1
+                languages = writer._selected_languages()
+                print(f"[detect] write method STORES a file on the target (written by your own "
+                      f"request) and reads it back from {writer._channel()}; "
+                      f"language(s): {', '.join(languages)}. Every finding lists a cleanup line.")
+                print("[detect]   a computed value in the fetched file is CONFIRMED execution; "
+                      "the source coming back verbatim is NEEDS-REVIEW (arbitrary file write, "
+                      "not proven RCE) -- the two are never merged.")
+                if injection_runs:
+                    # Enumeration multiplies a read-only probe by the candidate
+                    # count; multiplying a *write* by it is a different kind of
+                    # cost, and one the operator should have said yes to rather
+                    # than discovered in the target's upload directory.
+                    print(f"[!] --methods write is combined with injection-point enumeration, so "
+                          f"the write is attempted at each of {len(injection_runs)} candidate "
+                          "point(s). Narrow with -p/--max-points if that is more target state "
+                          "than you intend to change.")
             if set(method_names) & SHELL_PROBE_METHODS:
                 # The ladder multiplies request count, so say which shapes are
                 # about to be tried before trying them. An operator on a
@@ -5445,6 +5696,16 @@ def main():
                             and FileBased(generator, detection_config)._channel() is None):
                         print("[!] --methods file also needs --file-write-path and --file-read-url "
                               "(or --webroot and --web-base-url).")
+                    if WriteThenExecute.name in method_names:
+                        # Its probes are a file body, so the break-out contexts
+                        # are the ones it deliberately declines: wrapping a whole
+                        # file in `'; ... -- ` writes a broken file. Narrowing
+                        # --contexts past raw/transport leaves it nothing to
+                        # carry, and that must not read as a clean negative.
+                        print("[!] --methods write carries a file body, so it applies only to the "
+                              "raw context and the transport contexts "
+                              f"({', '.join(sorted(generator.transport_contexts))}); a --contexts "
+                              "narrowed past those leaves it nothing to write.")
                 return 1
             confirmed = [r for r in results if r["verdict"] == "confirmed"]
             if confirmed:
@@ -5463,6 +5724,12 @@ def main():
                     at = f" at {result['point']}" if result.get("point") else ""
                     print(f"  [{result['method']}/{result['environment']}/{result['context']}]{at} "
                           f"{result['payload']}   ({result['detail']})")
+                    # A needs-review from a state-changing method still left the
+                    # artifact behind: `write` reaching this tier means the file
+                    # IS on the target, just not interpreted. Printing cleanup
+                    # only under CONFIRMED would leave it there unmentioned.
+                    if result.get("cleanup"):
+                        print(f"      cleanup: {result['cleanup']}")
             if not confirmed:
                 errored = [r for r in results if r["verdict"] == "error"]
                 if errored:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -5373,5 +5373,211 @@ class SinkEnvDialectTestCase(unittest.TestCase):
         self.assertEqual(rcekit.overall_detection_verdict(results), "nothing-tested")
 
 
+class WriteThenExecuteTestCase(unittest.TestCase):
+    """The `write` method: a write primitive proven to be RCE by executing it.
+
+    The inverse of `file`. Nothing in the vulnerable response is computed — the
+    request stores a file — so `reflected` and `eval` correctly report
+    `negative` on a target that is fully exploitable. The three tiers this
+    method separates are the whole point, and merging any two of them would be
+    a lie in one direction or the other."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.rec = make_record(environment="unix", context="raw")
+        self.read_url = "/uploads/rcekit-probe.jsp"
+
+    def _method(self, **config):
+        config.setdefault("write_read_url", "https://target.example/uploads/probe.jsp")
+        return rcekit.WriteThenExecute(self.gen, config)
+
+    def _probes(self, method=None, record=None, seed=4):
+        import random as _random
+        return (method or self._method()).build_probes(
+            record or self.rec, _random.Random(seed))
+
+    def _store_target(self, mode):
+        """A target with a write primitive, in one of three postures.
+
+        `exec` interprets the stored file, `verbatim` serves it as text, and
+        `nowrite` stores nothing at all — the three outcomes the method has to
+        tell apart."""
+        store = {}
+
+        def route(method, path, params, headers, body):
+            if path == self.read_url:
+                content = store.get("file")
+                if content is None:
+                    return 404, "Not Found"
+                if mode == "exec":
+                    return 200, re.sub(r"<%=\s*(\d+)\*(\d+)\s*%>",
+                                       lambda m: str(int(m.group(1)) * int(m.group(2))),
+                                       content)
+                return 200, content
+            if mode != "nowrite":
+                store["file"] = params.get("content", "")
+            return 200, "stored"
+
+        return route
+
+    # -- probe shape ---------------------------------------------------------
+
+    def test_the_probe_is_a_file_body_not_a_shell_command(self):
+        for probe in self._probes():
+            self.assertNotIn(";", probe.payload.split("<")[0])
+            self.assertFalse(probe.payload.startswith(("; ", "| ", "&& ")))
+
+    def test_the_product_is_computed_locally_from_random_operands(self):
+        for probe in self._probes():
+            operands = re.search(r"(\d{5})\*(\d{5})", probe.payload)
+            self.assertIsNotNone(operands, probe.payload)
+            product = int(operands.group(1)) * int(operands.group(2))
+            self.assertIn(str(product), probe.expected)
+            # Reflection returns the one-liner, never the product.
+            self.assertNotIn(str(product), probe.payload)
+
+    def test_operands_are_drawn_once_per_run_not_once_per_carrier(self):
+        """One write, not one per carrier.
+
+        Carriers reduce to (environment, context) pairs and there are a dozen
+        of them with the raw context alone. Fresh operands per carrier would be
+        random in the same sense and would also write the file a dozen times —
+        for a state-changing method that is not a cost, it is a blast radius."""
+        method = self._method()
+        first = [p.payload for p in self._probes(method)]
+        second = [p.payload for p in self._probes(
+            method, make_record(environment="php", context="raw"))]
+        self.assertEqual(first, second)
+        # A fresh run does draw new operands: the instance is what pins them,
+        # not the method.
+        self.assertNotEqual(
+            first, [p.payload for p in self._probes(self._method(), seed=9)])
+
+    def test_languages_sharing_a_template_share_a_probe(self):
+        method = self._method(write_read_url="https://target.example/download?id=7")
+        carriers = [p.carrier for p in self._probes(method)]
+        # Which interpreter ran identical bytes is not something the response
+        # can distinguish, so the finding names all of them rather than guessing.
+        self.assertIn("jsp/aspx/erb", carriers)
+        self.assertEqual(len(carriers), 3, carriers)
+
+    def test_auto_infers_the_language_from_the_read_back_url(self):
+        cases = [("https://t/x/probe.jsp", ["jsp"]), ("https://t/a.phtml", ["php"]),
+                 ("https://t/a.jspx", ["jspx"]), ("https://t/a.aspx", ["aspx"])]
+        for url, expected in cases:
+            with self.subTest(url=url):
+                self.assertEqual(self._method(write_read_url=url)._selected_languages(),
+                                 expected)
+
+    def test_an_extension_it_cannot_read_writes_every_language(self):
+        # Guessing would be worse than paying for three requests.
+        method = self._method(write_read_url="https://t/download?file=probe.jsp")
+        self.assertEqual(len(method._selected_languages()), len(method.LANGUAGES))
+
+    def test_parse_write_langs_refuses_a_typo(self):
+        self.assertIsNone(rcekit.parse_write_langs(None))
+        self.assertIsNone(rcekit.parse_write_langs("auto"))
+        self.assertEqual(rcekit.parse_write_langs("jsp, php"), ("jsp", "php"))
+        with self.assertRaises(ValueError) as caught:
+            rcekit.parse_write_langs("jsp,jsp2")
+        self.assertIn("jsp2", str(caught.exception))
+
+    # -- applicability -------------------------------------------------------
+
+    def test_it_needs_the_read_back_url(self):
+        self.assertFalse(rcekit.WriteThenExecute(self.gen, {}).applicable(self.rec))
+        self.assertEqual(
+            self._probes(rcekit.WriteThenExecute(self.gen, {})), [])
+
+    def test_it_declines_the_break_out_contexts_and_keeps_the_transport_ones(self):
+        # The payload is the whole file, so there is no surrounding command or
+        # query to break out of; wrapping it in "'; ... -- " writes a broken
+        # file. A transport context is the opposite case — the payload has to
+        # survive that serialization to land intact.
+        method = self._method()
+        for context in ("sql", "javascript", "php", "shell_single_quoted", "attribute"):
+            with self.subTest(context=context):
+                self.assertFalse(method.applicable(make_record(context=context)))
+        for context in ("raw", "json", "xml", "yaml"):
+            with self.subTest(context=context):
+                self.assertTrue(method.applicable(make_record(context=context)))
+
+    def test_a_json_body_still_lands_intact(self):
+        method = self._method(write_read_url="https://t/a.jspx")
+        probe = self._probes(method, make_record(context="json"))[0]
+        self.assertIn(chr(92) + '"', probe.payload)
+        # The fetched file carries the decoded content, so that is what the
+        # verbatim check must look for.
+        self.assertNotIn(chr(92) + '"', probe.forbidden)
+
+    # -- the three tiers -----------------------------------------------------
+
+    def test_an_interpreted_upload_directory_is_confirmed(self):
+        with local_target(self._store_target("exec")) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/upload?content=FUZZ", methods=["write"],
+                config={"write_read_url": base + self.read_url})
+        self.assertEqual(rcekit.overall_detection_verdict(results), "confirmed")
+        confirmed = [r for r in results if r["verdict"] == "confirmed"]
+        self.assertTrue(confirmed)
+        self.assertIn("EXECUTED", confirmed[0]["detail"])
+        self.assertIn("remove the file", confirmed[0]["cleanup"])
+
+    def test_a_served_but_uninterpreted_directory_is_needs_review(self):
+        """The distinction the method exists for.
+
+        An upload directory that is served but not interpreted is a real
+        finding and is not remote code execution. Calling it `confirmed` would
+        break the guarantee the whole tool rests on; calling it `negative`
+        would throw away an arbitrary file write."""
+        with local_target(self._store_target("verbatim")) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/upload?content=FUZZ", methods=["write"],
+                config={"write_read_url": base + self.read_url})
+        self.assertEqual(rcekit.overall_detection_verdict(results), "needs-review")
+        self.assertFalse([r for r in results if r["verdict"] == "confirmed"])
+        review = [r for r in results if r["verdict"] == "needs-review"]
+        self.assertTrue(review)
+        self.assertIn("ARBITRARY FILE WRITE", review[0]["detail"])
+        # The artifact is on the target either way, so the cleanup line rides
+        # with this tier too.
+        self.assertIn("remove the file", review[0]["cleanup"])
+
+    def test_a_target_that_stores_nothing_is_negative(self):
+        with local_target(self._store_target("nowrite")) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/upload?content=FUZZ", methods=["write"],
+                config={"write_read_url": base + self.read_url})
+        self.assertEqual(rcekit.overall_detection_verdict(results), "negative")
+        self.assertTrue(results)
+
+    def test_a_read_back_url_that_never_answers_is_an_error_not_a_negative(self):
+        # A delivery failure on the confirmation channel says nothing about the
+        # target, and reporting it as `negative` would be the same defect this
+        # project keeps finding under a new name.
+        with local_target(self._store_target("exec")) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/upload?content=FUZZ", methods=["write"],
+                config={"write_read_url": "http://127.0.0.1:1/nothing-here.jsp"})
+        self.assertEqual(rcekit.overall_detection_verdict(results), "error")
+        self.assertTrue(all(r["verdict"] == "error" for r in results), results)
+
+    def test_a_control_that_already_carries_the_value_is_inconclusive(self):
+        # The differential still governs: a computed value present without the
+        # payload is not attributable to execution.
+        method = self._method()
+        probe = self._probes(method)[0]
+        obs = Observation(status=200, body="", control_body=probe.expected,
+                          followup_body=probe.expected)
+        self.assertEqual(method.confirm(obs, probe).status, "inconclusive")
+
+    def test_the_write_method_does_not_ride_the_sink_shape_ladder(self):
+        # Its probes are file content, not shell, so no separator or quote
+        # break-out applies — the same reason `eval` is absent.
+        self.assertNotIn("write", rcekit.SHELL_PROBE_METHODS)
+        self.assertNotIn("write", rcekit.CHEAP_DETECTION_METHODS)
+        self.assertIn("write", rcekit.STATE_CHANGING_METHODS)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Stacked on #58 — base it to `main` once that merges.

## The gap

A whole family of targets is invisible today, and not because of a filter or an encoding. The vulnerable request **stores a file**; it does not evaluate anything. `tomcat/CVE-2017-12615` (PUT a JSP), `activemq/CVE-2016-3088`, `weblogic/CVE-2018-2894`. Nothing in the response is computed, so `reflected` and `eval` correctly return `negative` on a target that is fully exploitable.

## What changed

`--methods write` is the **inverse** of `file`:

| | assumes | proves it with |
|---|---|---|
| `file` | execution exists | a write |
| `write` | a write primitive exists | executing what was written |

The probe is the file's *content* — a one-liner computing a product on random operands — delivered through the ordinary injection point. RCEKit fetches the file back and reads it in three tiers:

| the fetched file contains | verdict | means |
|---|---|---|
| the product | `confirmed` | written **and** executed |
| the one-liner, verbatim | `needs-review` | arbitrary file write; served but not interpreted |
| neither | `negative` | no write, or not served at that URL |

**The middle row is the reason the method exists**, and it is never merged into either neighbour. An upload directory that is served but not interpreted is a real finding and it is not remote code execution — calling it `confirmed` would break the guarantee the whole tool rests on, calling it `negative` would throw away an arbitrary file write.

## The filename is the operator's

Delivery substitutes **one** injection point, and every target in this class needs two locations — the name in the request line or a form field, the content in the body. So RCEKit writes the content into whatever file the operator's own request already names, and `--write-url-template` says where that lands. That also means one artifact per run rather than one per probe, which is the right trade for a method that changes target state.

For the same reason the operands are drawn **once per run rather than once per carrier**: carriers reduce to `(environment, context)` pairs and there are ~13 with the raw context alone. Fresh-per-carrier operands would be random in exactly the same sense and would also write the file thirteen times. That is not a request-count saving, it is a blast radius.

## Flags

- `--write-url-template URL` — required; the channel the proof comes back on.
- `--write-lang` — `auto` (default) reads the extension off that URL.

| language | one-liner shape |
|---|---|
| `jsp`, `aspx`, `erb` | the `<%= %>` scriptlet delimiters — byte-identical, so all three cost **one** request between them |
| `php` | the PHP short-echo tag |
| `jspx` | XML: a `jsp:expression` element, the one shape here that is not a delimiter swap, because a `.jspx` container parses the file as a document and never sees scriptlet delimiters |

With no extension to read, `auto` writes all five in three requests.

## Invariants

- `confirmed` means executed: the product only appears if an interpreter evaluated the expression, the operands are fresh per run, and the payload-free control differential still applies.
- The two tiers are never merged — that is the whole deliverable here.
- `write` is absent from `SHELL_PROBE_METHODS` (its probes are file content, not shell, so no separator or quote break-out applies) and absent from `CHEAP_DETECTION_METHODS`.
- It declines the break-out contexts and keeps the transport ones: the payload is a whole file body, so there is nothing to break out of, and wrapping it in a `sql` or `javascript` break-out would write a broken file. A run narrowed past `raw` and the transport contexts is **told so** rather than reporting a clean negative.
- A read-back URL that never answers is `error`, not `negative`.
- Zero third-party deps, Python 3.8+, corpus untouched.

## One behaviour change beyond the method

**A `needs-review` finding now prints its cleanup line too.** It used to appear only under `confirmed`. That was already thin and is plainly wrong for this method: a `write` reaching `needs-review` means the file *is* on the target, just not interpreted — the artifact would have been left there unmentioned.

## Verification

466 tests pass (`python -m unittest discover -s tests`), 16 of them new. The end-to-end tests drive one target in three postures — interprets the stored file, serves it verbatim, stores nothing — and assert the three tiers, plus a fourth for a read-back URL that never answers.