### PR TITLE
Phase 4 — the second-order / observed-channel oracle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,63 @@ formats, or the template schema.
 
 ## [Unreleased]
 
+## [2.32.0] — 2026-08-17
+
+The second-order oracle. Execution frequently happens on a **different request**
+than injection — stored SSTI rendered on a profile page, a payload written to a
+log a template engine later renders, a queued job run asynchronously. The engine
+diffs the response it injected into, so every one of those read `negative`
+however exploitable the target was.
+
+### Added
+
+- **`--observe-url URL`** names the endpoint where the execution surfaces. It is
+  read after each probe and then polled after the batch, and a probe whose
+  computed value turns up there is upgraded to `confirmed`.
+
+  It stays fully differential, which is why it reaches `confirmed` rather than
+  `needs-review`: the value was computed locally from operands random to that
+  probe, it must be absent from a snapshot of the endpoint taken **before any
+  probe was sent**, and — the rule that carries the weight — a probe's value is
+  looked for there **only when the probe's own payload does not contain it**.
+
+  Without that last rule the oracle would be a false-positive generator: `file`
+  and `oob` expect a random token that sits verbatim in the payload, so a target
+  that merely stores the payload and renders it back would hand that token
+  straight to the observed page and every such probe would confirm without
+  executing anything. Measured against a store-and-echo target: **0**
+  confirmations. The computed-value methods pass the same rule for the opposite
+  reason — reflection returns `$((a+b))`, never the sum — so it selects them
+  without naming them, and a method added later inherits the right answer.
+
+- **`--observe-request FILE`** takes a captured request instead, for the common
+  case where the page a stored payload renders on is behind a login. It needs no
+  `FUZZ` marker: the observed endpoint is read, never injected into.
+
+- **`--observe-poll` / `--observe-timeout`** control the polling window
+  (defaults 5s and 60s). One poll always happens, even at a zero timeout.
+
+- Every probe result carries an `observe_status` in `--detect-json`:
+  `confirmed`, `polled` (read, value not there), `in-control`, `not-observed`
+  (not eligible) or `unreachable`. When the endpoint never answered, the run
+  says so outright — negatives decided without ever reading the observed channel
+  are not second-order negatives.
+
+### Changed
+
+- The observed channel is read once after **each** probe as well as polled after
+  the batch, so a run with `--observe-url` sends roughly twice the requests.
+  Batch-then-poll alone is only correct for a channel that *accumulates* (a log,
+  a comment list); where the store overwrites — a profile field, which is the
+  shape this oracle most exists for — every probe but the last is gone by the
+  time the batch poll runs, and the oracle confirmed nothing. The extra read is
+  skipped for probes that are already confirmed in-band or not eligible, so
+  `file` and `oob` add none.
+
+Observing is additive throughout: the in-band verdict is computed exactly as
+before and only a non-`confirmed` one can be upgraded, so a run without the flag
+is byte-for-byte unchanged and a run with it can only gain findings.
+
 ## [2.31.0] — 2026-08-17
 
 The `write` method: a write primitive proven to be RCE by executing what it
@@ -727,7 +784,8 @@ this file and have not been restated here.
 - **[2.7.0]**
 - **[2.1.0]**
 
-[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.31.0...HEAD
+[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.32.0...HEAD
+[2.32.0]: https://github.com/kabiri-labs/rcekit/compare/v2.31.0...v2.32.0
 [2.31.0]: https://github.com/kabiri-labs/rcekit/compare/v2.30.0...v2.31.0
 [2.30.0]: https://github.com/kabiri-labs/rcekit/compare/v2.29.0...v2.30.0
 [2.29.0]: https://github.com/kabiri-labs/rcekit/compare/v2.28.0...v2.29.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RCEKit — prove RCE, don't guess it
 
-**Version 2.31.0** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.32.0** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming, and security research. Point it at a target you are allowed
@@ -270,6 +270,7 @@ what it sends, and how to read what comes back.
 | No output comes back at all | [Blind targets](docs/guide.md#blind-targets) |
 | No output *and* no egress | [No-egress targets](docs/guide.md#no-egress-targets) |
 | The request stores a file instead of running anything | [Upload and write-primitive targets](docs/guide.md#upload-and-write-primitive-targets) |
+| The payload runs later, on a different request | [When execution happens on another request](docs/guide.md#when-execution-happens-on-another-request) |
 | The sink is behind a login or a file upload | [Multi-step chains](docs/guide.md#multi-step-chains) |
 | I got `needs-review` / `inconclusive` / `error` | [Reading the results](docs/guide.md#reading-the-results) |
 | It says the corpus is unusable | [Troubleshooting](docs/guide.md#troubleshooting) |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -22,6 +22,7 @@ only ever run it against systems you are authorised to test.
 - [Blind targets](#blind-targets)
 - [No-egress targets](#no-egress-targets)
 - [Upload and write-primitive targets](#upload-and-write-primitive-targets)
+- [When execution happens on another request](#when-execution-happens-on-another-request)
 - [Out-of-band callbacks](#out-of-band-callbacks)
 - [Multi-step chains](#multi-step-chains)
 - [Reading the results](#reading-the-results)
@@ -455,6 +456,47 @@ finding (both tiers) prints a cleanup line naming it.
 read-back URL, so a `.jsp` costs one request; with no extension to read it
 writes all five languages, which is three requests because `jsp`, `aspx` and
 `erb` share the `<%= %>` delimiters.
+
+---
+
+## When execution happens on another request
+
+You inject into `POST /bio` and the response says `saved`. Nothing to diff, so
+the run comes back `negative` — and the payload runs half a second later, when
+somebody loads the profile page. Stored SSTI, a payload written to a log a
+template renders, a queued job: same shape every time.
+
+`--observe-url` points at the place it surfaces:
+
+```bash
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/bio?bio=FUZZ" --methods eval \
+  --observe-url "https://target.example/profile/42"
+```
+
+If that page needs a session, hand it a captured request instead — it takes no
+`FUZZ` marker, because it is read, never injected into:
+
+```bash
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target.example/bio?bio=FUZZ" --methods eval \
+  --observe-request profile.txt --observe-poll 10 --observe-timeout 120
+```
+
+This still reaches `confirmed` rather than `needs-review`, and the reason is
+worth knowing: the value is computed by RCEKit from operands random to that
+probe, it must be absent from a snapshot of the observed page taken *before any
+probe was sent*, and it is only looked for there when the probe's own payload
+does not already contain it. That last rule is why `file` and `oob` sit this out
+— their expected value is a token that rides in the payload, so a page that
+simply stores and re-renders your input would hand it back and "confirm" nothing.
+
+Two costs to know about. The observed page is read once after **each** probe as
+well as polled after the batch, because a store that *overwrites* (a profile
+field) keeps only the last probe by the time a batch poll runs — so a run with
+`--observe-url` sends roughly twice the requests. And if that endpoint never
+answers, RCEKit says so loudly rather than letting the negatives read as a
+second-order result.
 
 ---
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -10,6 +10,7 @@ starting point — this page is for looking things up once you know what you wan
 - [Detection methods](#detection-methods)
 - [Sink shape](#sink-shape)
 - [The sink shell](#the-sink-shell)
+- [Second-order execution](#second-order-execution-the-observed-channel)
 - [Safety &amp; consent](#safety--consent)
 - [Out-of-band listener](#out-of-band-listener)
 - [Generation &amp; output](#generation--output)
@@ -52,6 +53,10 @@ starting point — this page is for looking things up once you know what you wan
 | `--web-base-url` | (`file`) web-root alias for `--file-read-url '<base>/{name}'` | None |
 | `--write-url-template` | (`write`) URL the file your request stores is served at; required for `write` | None |
 | `--write-lang` | (`write`) File types to write: `auto`, or any of `jsp`, `jspx`, `php`, `aspx`, `erb` | `auto` |
+| `--observe-url` | Second-order: endpoint polled for the computed value after the probes | None |
+| `--observe-request` | Raw HTTP request for that endpoint instead of `--observe-url` (no marker) | None |
+| `--observe-poll` | Seconds between polls of the observed endpoint | `5` |
+| `--observe-timeout` | Stop polling after this many seconds; one poll always happens | `60` |
 | `--oob-host` | (`oob`) host the **target** calls back to; required for `oob` | None |
 | `--time-base` | (`time`) base delay `N`; the regression fires `0/N/2N` | `2.0` |
 | `--separators` | Break-out separators for shell probes; `\n` = newline | `; `, `\| `, `\|\| `, `&& `, newline |
@@ -163,6 +168,66 @@ web-root form confirms 0 and the general form confirms 7.
 This method changes target state (one file per confirmed probe), so it stays
 gated on the operator naming both halves, and **every finding prints its own
 cleanup command**.
+
+### Second-order execution: the observed channel
+
+Execution frequently happens on a **different request** than injection — stored
+SSTI rendered on a profile page, a payload written to a log a template engine
+later renders, a queued job run asynchronously. The engine diffs the response it
+injected into, so every one of those reads `negative` however exploitable the
+target is.
+
+`--observe-url` names the endpoint where the execution surfaces:
+
+```bash
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target/bio?bio=FUZZ" --methods eval \
+  --observe-url "https://target/profile/42"
+
+# ...or a captured request, when that page needs a session
+python rcekit.py --acknowledge-consent \
+  --verify-url "https://target/bio?bio=FUZZ" --methods eval \
+  --observe-request profile.txt --observe-poll 10 --observe-timeout 120
+```
+
+**It is still fully differential**, which is why it can legitimately reach
+`confirmed` rather than `needs-review`:
+
+- the value was computed by RCEKit from operands random to this probe;
+- it is absent from a snapshot of that endpoint taken **before any probe was
+  sent** — after would already contain what the control is meant to rule out;
+- and a probe's value is looked for there **only when the probe's own payload
+  does not contain it**.
+
+That last rule is the one that matters. `file` and `oob` expect a random *token*
+that sits verbatim in the payload, so a target that merely stores the payload
+and renders it back would hand that token straight to the observed page and every
+such probe would confirm without executing anything. The computed-value methods
+are safe for the opposite reason — reflection returns `$((a+b))`, never the sum —
+so the rule selects them without naming them, and a method added later inherits
+the right answer.
+
+The channel is read **twice**, because the two real shapes need different
+things:
+
+| Store shape | Example | Read by |
+|---|---|---|
+| overwrite | a profile field, a single setting | one read after **each** probe |
+| append / async | a log, a comment list, a queued job | the polling loop after the batch |
+
+Without the per-probe read, an overwriting store keeps only the last probe by the
+time a batch poll runs, so the oracle would confirm nothing on the shape it most
+exists for. The cost is one extra request per probe — and only for probes that
+are eligible at all and not already confirmed in-band, so `file` and `oob` add
+nothing.
+
+Observing is **additive**: the in-band verdict is computed exactly as before and
+only a non-`confirmed` one can be upgraded, so a run without the flag is
+unchanged and a run with it can only gain findings. Each probe's result carries
+an `observe_status` in `--detect-json` — `confirmed`, `polled` (read, value not
+there), `in-control`, `not-observed` (not eligible) or `unreachable`. If the
+endpoint never answered, the run says so outright: negatives decided without ever
+reading the observed channel are not second-order negatives.
 
 ### Write-then-execute: proving a write primitive is RCE
 

--- a/rcekit.py
+++ b/rcekit.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.31.0"
+__version__ = "2.32.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -169,6 +169,46 @@ def parse_sink_env(value: Optional[str]) -> Optional[str]:
         raise ValueError(f"unknown sink environment: {value}; "
                          f"choose from auto, {', '.join(SINK_ENVIRONMENTS)}")
     return value
+
+
+def observe_request(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """The observed endpoint as a ready-to-fire request, or ``None``.
+
+    One place resolves ``--observe-url`` and ``--observe-request`` so the two
+    forms cannot drift: the captured-request form exists because the page a
+    stored payload renders on is usually behind a login, and a URL alone cannot
+    carry that session."""
+    url = config.get("observe_url")
+    if not url:
+        return None
+    return {
+        "url": str(url),
+        "method": config.get("observe_method") or "GET",
+        "data": config.get("observe_data"),
+        "headers": config.get("observe_headers"),
+        "poll": config.get("observe_poll"),
+        "timeout": config.get("observe_timeout"),
+    }
+
+
+def build_plain_request(text: str, scheme: Optional[str] = None
+                        ) -> Tuple[str, str, Optional[str], List[str]]:
+    """``(url, method, data, headers)`` from a raw HTTP request with **no**
+    injection point.
+
+    :func:`build_request_inputs` requires a marker because its job is to place a
+    payload. The observed endpoint is the opposite: it is read, never injected
+    into, so requiring a marker there would mean inventing one."""
+    req = parse_raw_request(text)
+    host = req["host"]
+    if not host:
+        raise ValueError("raw request has no Host header; cannot build an absolute URL")
+    if scheme is None:
+        scheme = _infer_request_scheme(host)
+    headers = [f"{name}: {value}" for name, value in req["headers"]
+               if name.lower() not in {"host", "content-length"}]
+    return (f"{scheme}://{host}{req['target']}", req["method"],
+            req["body"] or None, headers)
 
 
 def parse_write_langs(value: Optional[str]) -> Optional[Tuple[str, ...]]:
@@ -2311,6 +2351,18 @@ class RCEKit:
             f"rcekit-control-{self._generate_canary()}", url, method, data, headers,
             url_location, resolved_body_location, timeout)
 
+        # The observed channel's control has to be taken *before* any probe is
+        # sent, not after: the whole premise is that a probe changes what that
+        # endpoint renders, so a control taken afterwards would already contain
+        # what it is supposed to rule out.
+        observe = observe_request(config or {})
+        observe_control: List[Tuple[str, str]] = []
+        observe_reached = False
+        if observe is not None:
+            o_status, o_body, o_channels, _ = self._fire_observed(observe, timeout)
+            observe_reached = o_status is not None
+            observe_control = o_channels or ([("response body", o_body)] if o_body else [])
+
         # Reduce records to distinct (environment, context) carriers so the same
         # probe shape is not refired for every payload sharing that carrier.
         carriers = self._detection_carriers(records, config or {})
@@ -2414,11 +2466,155 @@ class RCEKit:
                     if probe.followup and probe.followup.get("cleanup"):
                         result["cleanup"] = probe.followup["cleanup"]
                     results.append(result)
+                    # Read the observed channel now, before the next probe.
+                    # Batch-then-poll alone is only correct for a channel that
+                    # *accumulates* (a log, a comment list): where the store
+                    # overwrites -- a profile field, a single setting, which is
+                    # the shape the acceptance case uses -- every probe but the
+                    # last is gone by the time the batch poll runs, so the one
+                    # oracle this mode exists for confirmed nothing. One extra
+                    # request, and only for a probe that could actually be
+                    # judged there: already-confirmed probes and probes whose
+                    # value rides in their own payload are skipped.
+                    if (observe is not None and verdict.status != "confirmed"
+                            and self._observable(result)):
+                        o_status, o_body, o_chans, _ = self._fire_observed(observe, timeout)
+                        if o_status is not None:
+                            observe_reached = True
+                            self._observe_match(
+                                result, o_chans or ([("response body", o_body)] if o_body else []),
+                                observe_control, observe["url"])
                     if delay:
                         time.sleep(delay)
                     if max_payloads and len(results) >= max_payloads:
-                        return results
+                        return self._resolve_observed(
+                            results, observe, observe_control, observe_reached, timeout)
+        return self._resolve_observed(
+            results, observe, observe_control, observe_reached, timeout)
+
+    # A probe's expected value may only be looked for on the observed channel
+    # when the payload does not already carry it. That single rule is what keeps
+    # the second-order oracle differential, and it is not a detail: `file` and
+    # `oob` expect a random *token* that sits verbatim in the payload, so a
+    # target that merely stores the payload and renders it on the observed page
+    # would hand back that token by reflection and every one of those probes
+    # would read as confirmed. The computed-value methods are safe for the
+    # opposite reason -- reflection returns `$((a+b))`, never the sum -- so the
+    # rule selects them without naming them, and a method added later inherits
+    # the right answer instead of the current one.
+    @staticmethod
+    def _observable(result: Dict[str, Any]) -> bool:
+        expected = result.get("expected") or ""
+        return bool(expected) and expected not in (result.get("payload") or "")
+
+    def _fire_observed(self, observe: Dict[str, Any], timeout: float
+                       ) -> Tuple[Optional[int], str, List[Tuple[str, str]], float]:
+        """One request to the observed endpoint. No payload is substituted: this
+        is a plain read of the place the execution is expected to surface."""
+        return self._fire_channels(
+            "", observe["url"], observe.get("method") or "GET", observe.get("data"),
+            observe.get("headers"), "raw", "raw", timeout)
+
+    def _resolve_observed(self, results: List[Dict[str, Any]],
+                          observe: Optional[Dict[str, Any]],
+                          observe_control: List[Tuple[str, str]],
+                          observe_reached: bool,
+                          timeout: float) -> List[Dict[str, Any]]:
+        """Poll the observed channel and upgrade the probes whose value lands there.
+
+        Execution frequently happens on a *different* request than injection:
+        stored SSTI rendered on a profile page, a payload written to a log a
+        template engine later renders, a queued job run asynchronously. The
+        engine diffs the response it injected into, so every one of those read
+        `negative` however exploitable the target was.
+
+        Additive by construction. The in-band verdict is computed exactly as
+        before and only a non-`confirmed` one can be upgraded here, so a run
+        without ``--observe-url`` behaves identically and a run with it can only
+        gain findings.
+
+        Still fully differential, which is why this can legitimately reach
+        `confirmed`: the value was computed locally from random operands, it is
+        absent from the endpoint's pre-injection control, and (see
+        :meth:`_observable`) it cannot have arrived by the payload being stored
+        and echoed. Each probe carries its own operands, so a value left behind
+        by an earlier probe cannot confirm a later one."""
+        import time
+        if observe is None:
+            return results
+        for result in results:
+            result.setdefault("observe_status", "not-observed")
+        pending = [r for r in results
+                   if r["verdict"] != "confirmed" and self._observable(r)
+                   and r.get("observe_status") != "in-control"]
+        # `or` would be wrong here and was: a deliberate --observe-timeout 0
+        # ("read it once, do not wait") is falsy, so it fell through to the
+        # 60-second default and the run polled a dead endpoint for a minute.
+        limit = observe.get("timeout")
+        deadline = time.time() + (60.0 if limit is None else float(limit))
+        gap = observe.get("poll")
+        interval = max(0.5, 5.0 if gap is None else float(gap))
+        # At least one poll always happens, even with a zero timeout: an
+        # observed run that polled zero times and reported negatives would be
+        # the "tested nothing, looks clean" failure in a new place.
+        while True:
+            status, body, channels, _ = self._fire_observed(observe, timeout)
+            if status is not None:
+                observe_reached = True
+                searched = channels or ([("response body", body)] if body else [])
+                for result in list(pending):
+                    if self._observe_match(result, searched, observe_control, observe["url"]):
+                        pending.remove(result)
+                    elif result.get("observe_status") == "in-control":
+                        pending.remove(result)
+            if not pending or time.time() >= deadline:
+                break
+            time.sleep(interval)
+        if not observe_reached:
+            # The operator asked for a channel that never answered. Saying so is
+            # the point: the run's negatives were decided without ever reading
+            # the place the execution was expected to appear.
+            for result in results:
+                result["observe_status"] = "unreachable"
         return results
+
+    def _observe_match(self, result: Dict[str, Any], searched: List[Tuple[str, str]],
+                       observe_control: List[Tuple[str, str]], observe_url: str) -> bool:
+        """Upgrade ``result`` if its computed value is on the observed channel.
+
+        Returns whether it was upgraded. The differential is applied here and
+        nowhere else, so the per-probe read and the post-batch poll cannot
+        disagree about what counts as proof."""
+        where = self._observed_hit(result["expected"], searched)
+        if where is None:
+            # Read, and the value was not there. Recorded distinctly from
+            # "never looked": an operator reading --detect-json has to be able
+            # to tell a probe the observed channel cleared from one it never saw.
+            result["observe_status"] = "polled"
+            return False
+        if self._observed_hit(result["expected"], observe_control) is not None:
+            result["observe_status"] = "in-control"
+            return False
+        channel_note = "" if where == "response body" else f" in {where}"
+        result["verdict"] = "confirmed"
+        result["observe_status"] = "confirmed"
+        result["detail"] = (
+            f"target computed {result['expected']!r} on the OBSERVED channel"
+            f"{channel_note} ({observe_url}) -- second-order execution: the value is absent "
+            "from that endpoint's pre-injection control and cannot be reflected, since the "
+            "payload never carried it")
+        return True
+
+    def _observed_hit(self, expected: str,
+                      channels: List[Tuple[str, str]]) -> Optional[str]:
+        """The channel of ``channels`` carrying ``expected``, or ``None``.
+
+        Uses the same encoded-aware search every verdict uses, so a stored
+        channel that base64/hex/url/html-wraps what it renders confirms too."""
+        for name, text in channels:
+            if expected and self._encoded_search(re.escape(expected), text):
+                return name
+        return None
 
     def run_verification_chain(self, records: Iterator[PayloadRecord], chain: Dict[str, Any],
                                delay: float = 0.0, timeout: float = 20.0,
@@ -5096,6 +5292,24 @@ def main():
                              "command; sq/dq break out of a surrounding quote; subshell reaches a "
                              "quoted value through $(...) and backticks without closing the quote. "
                              "Narrow it to cut request count once the sink's shape is known.")
+    parser.add_argument("--observe-url", default=None, metavar="URL",
+                        help="(--methods) Second-order execution: an endpoint POLLED for the "
+                             "computed value after the probes are sent. Use it when execution "
+                             "happens on a different request than injection -- stored SSTI "
+                             "rendered on a profile page, a payload written to a log a template "
+                             "later renders, a queued job. Still differential, so it reaches "
+                             "confirmed: the value must be absent from this endpoint's "
+                             "pre-injection control.")
+    parser.add_argument("--observe-request", default=None, metavar="FILE",
+                        help="(--methods) Raw HTTP request for the observed endpoint, instead of "
+                             "--observe-url. No FUZZ marker: it is read, never injected into. Use "
+                             "this when the page the payload renders on needs a session.")
+    parser.add_argument("--observe-poll", type=float, default=5.0, metavar="SECONDS",
+                        help="(--observe-url) Seconds between polls of the observed endpoint "
+                             "(default 5).")
+    parser.add_argument("--observe-timeout", type=float, default=60.0, metavar="SECONDS",
+                        help="(--observe-url) Stop polling the observed endpoint after this many "
+                             "seconds (default 60). One poll always happens, even at 0.")
     parser.add_argument("--write-url-template", default=None, metavar="URL",
                         help="(--methods write) URL the file written through the injection point "
                              "is served at, e.g. https://target/uploads/rcekit-probe.jsp. Required "
@@ -5188,6 +5402,23 @@ def main():
     except ValueError as exc:
         print(f"[!] {exc}")
         return 1
+    # The observed endpoint, from either form. Resolved once, here, so the run
+    # and the pre-flight plan describe the same request.
+    observe_url = from_profile(args.observe_url, "observe_url")
+    observe_method, observe_data, observe_headers = "GET", None, None
+    if args.observe_request:
+        if observe_url:
+            print("[!] --observe-url and --observe-request name the same endpoint two ways; "
+                  "pass one.")
+            return 1
+        try:
+            with open(args.observe_request, "r", encoding="utf-8") as observe_fh:
+                observe_raw = observe_fh.read()
+            observe_url, observe_method, observe_data, observe_headers = build_plain_request(
+                observe_raw, args.request_scheme)
+        except (OSError, ValueError) as exc:
+            print(f"[!] Unable to use --observe-request {args.observe_request}: {exc}")
+            return 1
     eval_engines_raw = from_profile(args.eval_engines, "eval_engines")
     if isinstance(eval_engines_raw, str):
         eval_engines_raw = None if eval_engines_raw.strip() == "auto" else [
@@ -5494,6 +5725,12 @@ def main():
                                 "sink_shapes": sink_shapes, "sink_env": sink_env,
                                 "write_read_url": args.write_url_template,
                                 "write_langs": write_langs,
+                                "observe_url": observe_url,
+                                "observe_method": observe_method,
+                                "observe_data": observe_data,
+                                "observe_headers": observe_headers,
+                                "observe_poll": args.observe_poll,
+                                "observe_timeout": args.observe_timeout,
                                 "eval_engines": eval_engines,
                                 "probe_depth": args.probe_depth,
                                 "contexts_explicit": bool(selected_contexts),
@@ -5580,6 +5817,13 @@ def main():
                           f"the write is attempted at each of {len(injection_runs)} candidate "
                           "point(s). Narrow with -p/--max-points if that is more target state "
                           "than you intend to change.")
+            if observe_url:
+                print(f"[detect] observing {observe_url} for second-order execution: polled every "
+                      f"{args.observe_poll:g}s for up to {args.observe_timeout:g}s after the "
+                      "probes are sent, differenced against a snapshot taken before any probe.")
+                print("[detect]   only probes whose expected value is NOT in their own payload "
+                      "are looked for there -- a stored payload rendered back would otherwise "
+                      "confirm by reflection.")
             if set(method_names) & SHELL_PROBE_METHODS:
                 # The ladder multiplies request count, so say which shapes are
                 # about to be tried before trying them. An operator on a
@@ -5730,6 +5974,13 @@ def main():
                     # only under CONFIRMED would leave it there unmentioned.
                     if result.get("cleanup"):
                         print(f"      cleanup: {result['cleanup']}")
+            if observe_url and all(r.get("observe_status") == "unreachable" for r in results):
+                # The operator asked for a channel that never answered, so the
+                # verdicts below were decided without ever reading the place the
+                # execution was expected to appear.
+                print(f"\n[!] The OBSERVED endpoint ({observe_url}) never answered, so nothing "
+                      "was read from it. Any negative below was decided from the injected "
+                      "response alone — that is not a second-order result.")
             if not confirmed:
                 errored = [r for r in results if r["verdict"] == "error"]
                 if errored:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -5579,5 +5579,227 @@ class WriteThenExecuteTestCase(unittest.TestCase):
         self.assertIn("write", rcekit.STATE_CHANGING_METHODS)
 
 
+class ObservedChannelTestCase(unittest.TestCase):
+    """Second-order execution: the probe lands on one request and runs on another.
+
+    Stored SSTI rendered on a profile page, a payload written to a log a
+    template engine later renders, a queued job. The engine diffs the response
+    it injected into, so every one of these read `negative` however exploitable
+    the target was.
+
+    It stays fully differential — which is why it can legitimately reach
+    `confirmed` — and the rule that keeps it so is that a probe's value is
+    looked for on the observed channel **only when the payload does not already
+    carry it**. Without that rule, `file` and `oob` (whose expected value is a
+    token sitting verbatim in the payload) would confirm on any target that
+    merely stores the payload and renders it back."""
+
+    def setUp(self):
+        self.gen = RCEKit()
+        self.rec = make_record(environment="unix", context="raw")
+
+    @staticmethod
+    def _render_ssti(text):
+        return re.sub(r"\{\{\s*(\d+)\*(\d+)\s*\}\}",
+                      lambda m: str(int(m.group(1)) * int(m.group(2))), text)
+
+    def _stored_route(self, render, store="overwrite", seed=""):
+        """A target that stores on one path and shows it on another.
+
+        `overwrite` is the shape the acceptance case uses (a profile field);
+        `append` is the log/comment-list shape. They exercise different halves
+        of the machinery, so both are modelled."""
+        held = {"value": seed}
+
+        def route(method, path, params, headers, body):
+            if path == "/profile":
+                return 200, "<h1>bio</h1>" + render(held["value"])
+            if store == "append":
+                held["value"] += "\n" + params.get("bio", "")
+            else:
+                held["value"] = params.get("bio", "")
+            return 200, "saved"
+
+        return route
+
+    # -- the eligibility rule ------------------------------------------------
+
+    def test_only_a_value_absent_from_its_own_payload_is_observable(self):
+        observable = {"expected": "RKA123RKB", "payload": "RKA$((1+2))RKB"}
+        reflected_token = {"expected": "RKTOKEN", "payload": "echo RKTOKEN > /tmp/x"}
+        self.assertTrue(RCEKit._observable(observable))
+        self.assertFalse(RCEKit._observable(reflected_token))
+        self.assertFalse(RCEKit._observable({"expected": "", "payload": "sleep 2"}))
+
+    def test_a_store_and_echo_target_confirms_nothing(self):
+        """The false-positive vector, driven end to end.
+
+        The app stores the payload and renders it verbatim — no evaluation
+        anywhere. Every probe's payload comes back on the observed page, so a
+        naive implementation would confirm all of them."""
+        with local_target(self._stored_route(lambda text: text)) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/bio?bio=FUZZ", methods=["eval"],
+                max_payloads=12,
+                config={"observe_url": f"{base}/profile", "observe_poll": 0.2,
+                        "observe_timeout": 0.5})
+        self.assertFalse([r for r in results if r["verdict"] == "confirmed"],
+                         "a target that only echoes the payload must not confirm")
+        self.assertEqual({r["observe_status"] for r in results}, {"polled"})
+
+    # -- the two channel shapes ----------------------------------------------
+
+    def test_stored_ssti_on_an_overwriting_field_confirms(self):
+        """The acceptance case: inject on POST, execution renders on GET.
+
+        The store *overwrites*, so every probe but the last is gone by the time
+        a post-batch poll would run — the observed channel has to be read
+        between probes or this oracle confirms nothing on the shape it exists
+        for."""
+        with local_target(self._stored_route(self._render_ssti)) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/bio?bio=FUZZ", methods=["eval"],
+                max_payloads=12,
+                config={"observe_url": f"{base}/profile", "observe_poll": 0.2,
+                        "observe_timeout": 1.0})
+        confirmed = [r for r in results if r["verdict"] == "confirmed"]
+        self.assertTrue(confirmed, results)
+        self.assertEqual(rcekit.overall_detection_verdict(results), "confirmed")
+        self.assertIn("OBSERVED channel", confirmed[0]["detail"])
+        self.assertEqual(confirmed[0]["observe_status"], "confirmed")
+
+    def test_an_appending_channel_confirms_after_the_batch(self):
+        with local_target(self._stored_route(self._render_ssti, store="append")) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/bio?bio=FUZZ", methods=["eval"],
+                max_payloads=12,
+                config={"observe_url": f"{base}/profile", "observe_poll": 0.2,
+                        "observe_timeout": 1.0})
+        self.assertEqual(rcekit.overall_detection_verdict(results), "confirmed")
+
+    # -- the differential ----------------------------------------------------
+
+    def test_a_value_already_in_the_pre_injection_control_does_not_confirm(self):
+        """The control is taken before any probe, and it has to be.
+
+        The premise is that a probe changes what the endpoint renders, so a
+        control taken afterwards would already contain what it is meant to rule
+        out."""
+        method = rcekit.ReflectedMath(self.gen, {})
+        result = {"verdict": "negative", "expected": "RKA999RKB",
+                  "payload": "RKA$((1+2))RKB", "detail": ""}
+        control = [("response body", "nightly report: RKA999RKB")]
+        upgraded = self.gen._observe_match(
+            result, [("response body", "RKA999RKB")], control, "http://t/o")
+        self.assertFalse(upgraded)
+        self.assertEqual(result["verdict"], "negative")
+        self.assertEqual(result["observe_status"], "in-control")
+        del method
+
+    def test_one_probes_leftover_value_cannot_confirm_another(self):
+        # Each probe carries its own operands, so a value an earlier probe left
+        # on a shared channel does not match a later probe's expectation.
+        first = {"verdict": "negative", "expected": "RKA111RKB",
+                 "payload": "RKA$((1+2))RKB", "detail": ""}
+        second = {"verdict": "negative", "expected": "RKC222RKD",
+                  "payload": "RKC$((3+4))RKD", "detail": ""}
+        channels = [("response body", "RKA111RKB")]
+        self.assertTrue(self.gen._observe_match(first, channels, [], "http://t/o"))
+        self.assertFalse(self.gen._observe_match(second, channels, [], "http://t/o"))
+
+    # -- it is additive ------------------------------------------------------
+
+    def test_a_run_without_the_flag_is_unchanged(self):
+        with local_target(self._stored_route(self._render_ssti)) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/bio?bio=FUZZ", methods=["eval"])
+        self.assertTrue(results)
+        # No observe bookkeeping at all, and no second-order confirmation: the
+        # in-band response says "saved" and nothing else.
+        self.assertFalse([r for r in results if "observe_status" in r])
+        self.assertFalse([r for r in results if r["verdict"] == "confirmed"])
+
+    def test_an_in_band_confirmation_is_never_downgraded(self):
+        # Only a non-confirmed verdict can be upgraded, so observing can add
+        # findings and never remove one.
+        def route(method, path, params, headers, body):
+            if path == "/observe":
+                return 200, "nothing here"
+            return 200, "PING " + self._render_ssti(params.get("q", ""))
+
+        with local_target(route) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/search?q=FUZZ", methods=["eval"],
+                max_payloads=12,
+                config={"observe_url": f"{base}/observe", "observe_poll": 0.2,
+                        "observe_timeout": 0.5})
+        confirmed = [r for r in results if r["verdict"] == "confirmed"]
+        self.assertTrue(confirmed)
+        for result in confirmed:
+            self.assertNotIn("OBSERVED", result["detail"])
+
+    # -- failure modes -------------------------------------------------------
+
+    def test_an_unreachable_observed_endpoint_is_reported_as_such(self):
+        """A run that never read the channel is not a second-order negative.
+
+        The same failure this project keeps finding: the operator asked for an
+        oracle, it never ran, and the verdicts below were decided without it."""
+        with local_target(self._stored_route(self._render_ssti)) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/bio?bio=FUZZ", methods=["eval"],
+                max_payloads=6,
+                config={"observe_url": "http://127.0.0.1:1/gone", "observe_poll": 0.2,
+                        "observe_timeout": 0})
+        self.assertTrue(results)
+        self.assertEqual({r["observe_status"] for r in results}, {"unreachable"})
+
+    def test_a_zero_timeout_reads_once_and_does_not_wait(self):
+        """`--observe-timeout 0` means "read it once", not "use the default".
+
+        It is falsy, so an `or`-style default silently turned a deliberate
+        no-wait read into a full minute of polling — measured against a dead
+        endpoint, where the run then took 60 seconds to say nothing."""
+        import time as _time
+        started = _time.time()
+        with local_target(self._stored_route(self._render_ssti)) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/bio?bio=FUZZ", methods=["eval"], max_payloads=4,
+                config={"observe_url": "http://127.0.0.1:1/gone", "observe_timeout": 0})
+        self.assertLess(_time.time() - started, 20)
+        self.assertEqual({r["observe_status"] for r in results}, {"unreachable"})
+
+    def test_one_poll_always_happens_even_at_a_zero_timeout(self):
+        with local_target(self._stored_route(self._render_ssti, store="append")) as base:
+            results = self.gen.run_detection(
+                [self.rec], url=f"{base}/bio?bio=FUZZ", methods=["eval"],
+                max_payloads=6,
+                config={"observe_url": f"{base}/profile", "observe_timeout": 0})
+        self.assertNotIn("unreachable", {r["observe_status"] for r in results})
+
+    # -- request building ----------------------------------------------------
+
+    def test_observe_request_resolves_both_forms_in_one_place(self):
+        self.assertIsNone(rcekit.observe_request({}))
+        built = rcekit.observe_request({"observe_url": "https://t/p", "observe_poll": 3})
+        self.assertEqual(built["url"], "https://t/p")
+        self.assertEqual(built["method"], "GET")
+        self.assertEqual(built["poll"], 3)
+
+    def test_a_captured_request_needs_no_injection_marker(self):
+        # build_request_inputs requires a marker because its job is to place a
+        # payload; the observed endpoint is read, never injected into.
+        raw = ("GET /profile/42 HTTP/1.1\r\n"
+               "Host: target.example\r\n"
+               "Cookie: session=abc\r\n\r\n")
+        url, method, data, headers = rcekit.build_plain_request(raw, "https")
+        self.assertEqual(url, "https://target.example/profile/42")
+        self.assertEqual(method, "GET")
+        self.assertIsNone(data)
+        self.assertIn("Cookie: session=abc", headers)
+        with self.assertRaises(ValueError):
+            rcekit.build_plain_request("GET /x HTTP/1.1\r\n\r\n")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## The gap

Execution frequently happens on a **different request** than injection. You inject into `POST /bio`, the response says `saved`, and the payload runs half a second later when somebody loads the profile page. Stored SSTI, a payload written to a log a template engine renders, a queued job — same shape every time. The engine diffs the response it injected into, so every one of these read `negative` however exploitable the target was.

## What changed

`--observe-url URL` names the endpoint where execution surfaces. A probe whose computed value turns up there is upgraded to `confirmed`.

It stays **fully differential**, which is why it earns `confirmed` rather than `needs-review`:

1. the value was computed by RCEKit from operands random to that probe;
2. it must be absent from a snapshot of the endpoint taken **before any probe was sent** — a control taken afterwards would already contain what it is meant to rule out;
3. a probe's value is looked for there **only when the probe's own payload does not contain it**.

### Rule 3 is the one that carries the weight

`file` and `oob` expect a random *token* that sits verbatim in the payload. Without this rule, a target that merely stores the payload and renders it back hands that token straight to the observed page, and every one of those probes confirms having executed nothing.

Driven end to end against a store-and-echo target (stores the input, renders it verbatim, evaluates nothing): **0 confirmations**, every probe `observe_status: polled`.

The computed-value methods pass the same rule for the opposite reason — reflection returns the literal expression, never the sum — so the rule selects them without naming them, and a method added later inherits the right answer instead of the current one.

## The channel is read twice, and it has to be

| Store shape | Example | Read by |
|---|---|---|
| overwrite | a profile field, a single setting | one read after **each** probe |
| append / async | a log, a comment list, a queued job | the polling loop after the batch |

My first implementation was batch-then-poll only. Measured against the acceptance case — `POST /bio` overwrites, `GET /profile` renders — it confirmed **nothing**: every probe but the last is gone by the time a batch poll runs. With the per-probe read it confirms. Both shapes now have an end-to-end test.

The cost is one extra request per probe, and it is printed in the pre-flight plan. It is skipped for probes already confirmed in-band or not eligible at all, so `file` and `oob` add none.

## Also

- **`--observe-request FILE`** takes a captured request instead — the page a stored payload renders on is usually behind a login. No `FUZZ` marker: the observed endpoint is read, never injected into.
- **`--observe-poll` / `--observe-timeout`** (5s / 60s). One poll always happens, even at zero.
- Every result carries an `observe_status` in `--detect-json`: `confirmed`, `polled` (read, value not there), `in-control`, `not-observed`, `unreachable`. **If the endpoint never answered the run says so outright** — negatives decided without ever reading the observed channel are not second-order negatives.

## A bug found while writing the tests

`--observe-timeout 0` means "read it once, do not wait". It is falsy, so `observe.get("timeout") or 60.0` turned it into the 60-second default, and a run against a dead endpoint took a full minute to say nothing. The test that pins it fails on the duration, not just the outcome.

## Invariants

- Additive: only a non-`confirmed` in-band verdict can be upgraded, so a run without the flag is unchanged and a run with it can only gain findings. A test asserts an in-band confirmation is never rewritten.
- Each probe carries its own operands, so a value an earlier probe left on a shared channel cannot confirm a later one — tested.
- Zero third-party deps, Python 3.8+, corpus untouched.

## Verification

479 tests pass (`python -m unittest discover -s tests`), 13 of them new.