### PR TITLE
README rewrite — a tagline that defines rather than promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ formats, or the template schema.
 
 ## [Unreleased]
 
+## [2.34.1] — 2026-08-17
+
+Documentation only; no behaviour change.
+
+### Changed
+
+- **New tagline: "`confirmed` means the target executed the input. `negative`
+  means the probes reached it."** The old one — "prove RCE, don't guess it" —
+  claimed the tool always proves. It does not, and does not need to: the value
+  is that each verdict has a mechanical meaning, in both directions. A promise
+  can be broken; a definition cannot.
+
+  Both halves name their actor and object on purpose. "Executed" alone reads as
+  though *RCEKit* executed something; the claim is about the target. And
+  `confirmed`/`negative` are the verdict values as the code spells them, not
+  looser words like "clean".
+
+- **The README caught up with the engine.** It still described "two verdict
+  tiers" when there are seven, and the comparison table predated the last five
+  releases. Rewritten around what a verdict asserts, with the tier table as the
+  centrepiece and a section on the half no other tool has: `error` and
+  `nothing-tested` exist so a run that tested nothing is never reported as
+  clean.
+
+  The comparison table gains the classes added since it was written — Windows
+  `cmd.exe`/PowerShell sinks, upload → write-then-execute, second-order
+  execution, query-language bridges and deserialization sinks — and the "reach
+  for something else" note now says plainly that sqlmap owns the database and
+  RCEKit's bridges only prove the OS is reachable from a text parameter.
+
+### Fixed
+
+- Two claims in the engagement-controls table were wrong and are now accurate:
+  the observed-channel fetch sends **no** credentials unless given a request with
+  `--observe-request` (only the `file` read-back inherits them, same-origin), and
+  an unanswered `--observe-url` is a warning about a partly blinded run rather
+  than a `nothing-tested` verdict.
+- The "mechanisms that produce `inconclusive`" list said four and listed five.
+
 ## [2.34.0] — 2026-08-17
 
 Deserialization **sink** detection, and a verdict that is deliberately not RCE.
@@ -899,7 +938,8 @@ this file and have not been restated here.
 - **[2.7.0]**
 - **[2.1.0]**
 
-[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.34.0...HEAD
+[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.34.1...HEAD
+[2.34.1]: https://github.com/kabiri-labs/rcekit/compare/v2.34.0...v2.34.1
 [2.34.0]: https://github.com/kabiri-labs/rcekit/compare/v2.33.0...v2.34.0
 [2.33.0]: https://github.com/kabiri-labs/rcekit/compare/v2.32.0...v2.33.0
 [2.32.0]: https://github.com/kabiri-labs/rcekit/compare/v2.31.0...v2.32.0

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
-# RCEKit — prove RCE, don't guess it
+# RCEKit
 
-**Version 2.34.0** · MIT · Python 3.8+ · zero third-party dependencies
+**`confirmed` means the target executed the input. `negative` means the probes reached it.**
+
+**Version 2.34.1** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
-testing, red teaming, and security research. Point it at a target you are allowed
-to test — a URL or a captured HTTP request — and it tells you what **actually
-executed**, backed by proof, not a "maybe".
+testing, red teaming and security research. Point it at a target you are allowed
+to test — a URL or a captured HTTP request — and every finding comes back with
+the tier it earned.
 
-A **`confirmed`** verdict means the target *computed or executed a value only
-execution could produce* — random arithmetic, a template evaluation, a written
-token — checked against a payload-free control. Reflection, coincidence, and
-jitter can't fake it, so `confirmed` is something you can put in a report.
+Every `confirmed` rests on a value RCEKit generated at random for that probe and
+that reflection cannot produce: a computed result present in the response and
+absent from a payload-free control, or an out-of-band callback carrying a token
+only the target ever held. Weaker signals keep their own tiers and are never
+promoted into it. And a run that could not test something never reports it as
+clean.
 
 ---
 
@@ -99,8 +103,7 @@ python rcekit.py --acknowledge-consent \
       (target computed 'RKYZRIP854822RKFWVFSRKBWOOCRKYZRIP' — random operands, absent from control)
 ```
 
-No external infrastructure, no config file. If nothing is vulnerable you get a
-clean `negative`, not a false alarm. That's the whole idea.
+No external infrastructure, no config file.
 
 **Don't take the GIFs on trust** — [reproduce them yourself](docs/verify-it-yourself.md)
 against dockerised Webmin and Struts2 targets in about five minutes.
@@ -111,25 +114,98 @@ one worked example each.
 
 ---
 
-## Why RCEKit
+## What a verdict means
 
-Finding an RCE *candidate* is easy. **Proving it** — reliably, without crying
-wolf — is the hard part:
+Finding an RCE *candidate* is easy. Reporting one that survives someone else's
+retest is the hard part, and it fails in two directions: a "possibly vulnerable"
+that turns out to be reflection, and a "not vulnerable" from a run that never
+actually tested anything.
 
-- Scanners flag "possibly vulnerable" and bury the real finding under false positives.
-- Blind RCE usually forces you to stand up interactsh/Collaborator just to confirm.
-- Each RCE class (command injection, SSTI, code injection) needs a different confirmation trick.
-- A report full of "maybe" findings wastes triage time and burns your credibility.
+RCEKit answers with **seven verdicts that are never collapsed into each other**:
 
-RCEKit answers with **two verdict tiers that are never merged**:
+| Verdict | What it asserts |
+|---|---|
+| **`confirmed`** | The target executed the input. It returned a value it could not produce otherwise — computed from operands random to that probe — and that value is absent from a payload-free control. |
+| **`deserialization-sink`** | The target reconstructed an attacker-supplied object graph. Proven, but about a *different property*: reaching RCE from there depends on classpath gadgets, so it is never called RCE. |
+| **`needs-review`** | A real signal that is not proof on its own — a linear timing regression, a parser fingerprint. Worth your time, never worth the word "confirmed". |
+| **`inconclusive`** | The evidence appeared, but could not be attributed to execution — the payload-free control carried it too. |
+| **`negative`** | Probes were built, reached the target, and found nothing. |
+| **`error`** | Nothing reached the target. |
+| **`nothing-tested`** | No probes were built at all. |
 
-| Tier | Meaning |
-|------|---------|
-| **`confirmed`** | Execution proven — the target returned a value it could only produce by executing your input, and that value is absent from a payload-free control. |
-| **`needs-review`** | A real candidate worth a look (e.g. a blind timing signal), but not proof on its own. |
+The moment `confirmed` and `maybe` blur, `confirmed` stops meaning anything — so
+nothing is ever promoted upward. A timing regression stays `needs-review` however
+clean the slope. A deserialization callback stays `deserialization-sink` however
+certain you are that the classpath is exploitable.
 
-Anything else is `negative` or `inconclusive`. The moment "confirmed" and "maybe"
-blur together, "confirmed" loses its meaning — so RCEKit keeps them apart, by design.
+### The other half: a run that tested nothing is never clean
+
+The last two rows are the ones other tools do not have, and they matter more than
+they look. A scanner that could not reach the target, or built no probes because
+your flags excluded every one of them, has learned **nothing** about the target —
+and printing `negative` there is a lie that reads exactly like safety.
+
+So `error` and `nothing-tested` are first-class verdicts, the run exits non-zero,
+and RCEKit says which of them happened and why:
+
+```
+[!] No probes were built, so NOTHING WAS TESTED — this is not a negative result.
+[!] None of the selected methods (reflected, file) apply to environment(s): sql.
+```
+
+It fires wherever a run can quietly become empty: a method that does not apply to
+the selected environments, a `--sink-shape` rung the chosen shell has no syntax
+for, a `--bridges` selection entirely held back by the safety ceiling, a request
+body that broke delivery before it arrived.
+
+A run that was only *partly* blinded gets the same treatment one level down. If
+you asked for a second-order oracle and the observed endpoint never answered, the
+probe verdicts still stand — but the run tells you they were decided without ever
+reading the channel you pointed it at, rather than letting them pass for a
+second-order negative.
+
+---
+
+## What it confirms
+
+One CLI, one `--methods` flag, covering the main paths to RCE:
+
+| RCE class | `--methods` | How RCEKit proves it |
+|-----------|-------------|----------------------|
+| **OS command injection** | `reflected` | Makes the shell compute `$((a+b))` on random operands and collapse `$(echo TAG)`; confirms the *result*, never the literal expression. Written in the sink's own dialect — POSIX, `cmd.exe` or PowerShell. |
+| **Code / expression injection** — SSTI, SpEL, OGNL, Groovy, `eval()` (CWE-94) | `eval` | Injects `a*b` in every common template syntax (`${…}` `{{…}}` `#{…}` `%{…}` `<%=…%>` `@(…)`, bare); confirms the **product** appears while the literal `a*b` does not. |
+| **Blind command injection** (no output) | `time` | Fires a controlled `0/N/2N` delay series and confirms the response time tracks the delay **linearly**; reported `needs-review` — jitter can't fake it, but timing isn't a computed value. |
+| **Internal / no-egress** targets | `file` | Writes a random token and fetches it back through *any* read-back path — a web root, an LFI parameter, a download or export handler, a `/tmp`-backed preview. Proves execution **plus** a write primitive, with no external listener. |
+| **Upload / write primitive** — PUT-a-JSP, unchecked upload (CWE-434) | `write` | Writes a one-liner that *computes* a product through your own upload request, then fetches the file: the product is `confirmed` RCE, the source coming back verbatim is `needs-review` — arbitrary file write, served but not interpreted. |
+| **Deserialization sinks** — fastjson, shiro, weblogic (CWE-502) | `deser` | Proves the endpoint **deserializes** attacker data, via a non-executing DNS gadget or an error-shape differential. Reported as `deserialization-sink`, **never** as RCE. |
+| **Blind / out-of-band** — Log4Shell/JNDI, exfil, async | *(OOB listener)* | Built-in HTTP/DNS listener receives callbacks and correlates each to the exact payload. |
+
+Three things widen where those methods can reach, without changing what any of
+them will call `confirmed`:
+
+- **Second-order execution** (`--observe-url`) — when the payload lands on one
+  request and runs on another: stored SSTI rendered on a profile page, a payload
+  written to a log a template engine later renders, a queued job. The observed
+  endpoint is differenced against a snapshot taken *before* any probe was sent.
+- **Query-language bridges** (`--bridges`) — `COPY … FROM PROGRAM`,
+  `xp_cmdshell`, `expect://`. A bridge is a carrier, not an oracle: it wraps the
+  command the methods already build, so the same tiers apply through it.
+- **Injection-point enumeration** (`-p all`) — query, JSON leaves, form fields,
+  cookies, headers and path segments, each encoded for where it lands, with the
+  probe cost printed before anything fires.
+
+Mix methods freely: `--methods reflected,eval,time` runs all three and reports each
+tier separately.
+
+> **Honest scope.** RCEKit confirms RCE that is reachable by **injecting into a
+> request** and interpreted by a shell or an evaluator. It does **not** cover
+> memory-corruption bugs (buffer overflow, UAF) or argument injection into a
+> no-shell `argv` array — those are different problems. **Deserialization gadget
+> chains stay out of scope too**: `--methods deser` proves an endpoint
+> *deserializes* attacker data and says so in its own tier, but which gadget (if
+> any) turns that into execution depends on the target's classpath, and RCEKit
+> does not claim to know. It aims to be excellent at the injection-driven RCE
+> classes above rather than mediocre at everything.
 
 ---
 
@@ -151,7 +227,12 @@ one:
 | Expression injection / SSTI | ✅ | via its eval-based technique | ✅ *(its whole scope)* | per template |
 | Blind — timing | ✅ *as a separate tier* | ✅ | ✅ | — |
 | Blind — out-of-band | ✅ *built-in listener* | — | — | via [interactsh](https://github.com/projectdiscovery/interactsh) |
-| No-egress — write &amp; fetch back | ✅ | ✅ | — | — |
+| No-egress — write &amp; fetch back | ✅ *any read-back path* | ✅ *(web root)* | — | — |
+| `cmd.exe` and PowerShell sinks | ✅ *per-dialect probes* | ✅ *(cmd)* | — | per template |
+| Upload → write-then-execute | ✅ *write vs. execute, separate tiers* | — | — | per template |
+| Second-order — lands here, runs there | ✅ | — | — | — |
+| Query-language bridge to the OS | ✅ | — | — | per template |
+| Deserialization sink | ✅ *own tier, never called RCE* | — | — | per template |
 | **All of the above, one CLI, one run** | **✅** | — | — | — |
 
 <sub>Coverage per each project's own documented technique list. SSTImap is the
@@ -175,7 +256,7 @@ be attributed to execution:
 [detect] sent 13 probes: confirmed=0, inconclusive=2, negative=11
 ```
 
-Those two would have been someone else's finding. Four mechanisms produce that
+Those two would have been someone else's finding. Five mechanisms produce that
 verdict, and they run on every confirmation:
 
 - **A payload-free control request.** Evidence must be present *with* the payload
@@ -196,9 +277,9 @@ verdict, and they run on every confirmation:
   differential is applied to every channel too, so widening where RCEKit looks
   does not widen what it will call `confirmed`.
 
-And timing **never self-confirms**: a linear `0/N/2N` regression is capped at
-`needs-review` and reported in its own tier, because it produces no computed
-value. `confirmed` and `maybe` are never merged into one word.
+The same instinct runs the other way. Timing **never self-confirms**, a
+deserialization callback is **never** called RCE, and a run that built no probes
+is **never** called negative.
 
 ### 3. It is built for an authorised engagement, not a lab
 
@@ -208,9 +289,10 @@ rather than in your notes:
 | | |
 |---|---|
 | **Consent gate** | Nothing exploitative generates or fires without `--acknowledge-consent`. |
-| **Execution plan** | Prints the exact payload count, safety tiers and any outbound callback destinations **before** the first request goes out. |
-| **Safe by default** | Reverse shells, credential access, cloud metadata, lateral movement and container escape are held back until you raise `--verify-active-risk`; persistence and backdoors need a second flag on top. |
-| **Cleanup commands** | The `file` method changes target state, so every finding prints the exact `rm`/`del` to undo it — paste it into the report. |
+| **Execution plan** | Prints the exact probe count, sink shapes, safety tiers and any outbound callback destinations **before** the first request goes out. |
+| **Safe by default** | Reverse shells, credential access, cloud metadata, lateral movement and container escape are held back until you raise `--verify-active-risk`; persistence and backdoors need a second flag on top. Bridges that create an object on the target are held to the same ceiling. |
+| **Cleanup commands** | `file`, `write` and the stateful bridges change target state, so every finding — including a `needs-review` — prints what to run to undo it. |
+| **Credentials stay put** | The `file` read-back fetch carries the run's `Authorization`/`Cookie` headers only to the *same origin*, and says so out loud when it withholds them. The observed-channel fetch sends none at all unless you hand it a request with `--observe-request`. |
 | **Redacted audit trail** | Every run lands in `exploit_audit.log`, recording that a credential header was sent, never its value. |
 | **Watermarking** | `--watermark` stamps a traceable token into each payload, so a payload found in the client's logs months later is attributable to your run. |
 | **No third-party callbacks** | The OOB listener is yours. Nothing is routed through a public interaction server, which some engagements forbid outright. |
@@ -222,36 +304,10 @@ Want a shell rather than a verdict? commix and SSTImap continue into
 post-exploitation; RCEKit stops at proof by design. Sweeping thousands of hosts
 for known CVEs? That is Nuclei's job — and RCEKit *writes* Nuclei templates
 (`--output-format nuclei`), so it feeds your scanner instead of competing with it.
-
----
-
-## What it confirms
-
-One CLI, one `--methods` flag, covering the main paths to RCE:
-
-| RCE class | `--methods` | How RCEKit proves it |
-|-----------|-------------|----------------------|
-| **OS command injection** | `reflected` | Makes the shell compute `$((a+b))` on random operands and collapse `$(echo TAG)`; confirms the *result*, never the literal expression. |
-| **Code / expression injection** — SSTI, SpEL, OGNL, Groovy, `eval()` (CWE-94) | `eval` | Injects `a*b` in every common template syntax (`${…}` `{{…}}` `#{…}` `%{…}` `<%=…%>` `@(…)`, bare); confirms the **product** appears while the literal `a*b` does not. |
-| **Blind command injection** (no output) | `time` | Fires a controlled `0/N/2N` delay series and confirms the response time tracks the delay **linearly**; reported `needs-review` (jitter can't fake it, but timing isn't a computed value). |
-| **Internal / no-egress** targets | `file` | Writes a random token to a web-reachable file and fetches it back — proving execution **plus** a write primitive, with no external listener. |
-| **Upload / write primitive** — PUT-a-JSP, unchecked upload (CWE-434) | `write` | Writes a one-liner that *computes* a product through your own upload request, then fetches the file: the product is `confirmed` RCE, the source coming back verbatim is `needs-review` (arbitrary file write, not execution). |
-| **Deserialization sinks** — fastjson, shiro, weblogic (CWE-502) | `deser` | Proves the endpoint **deserializes** attacker data, via a non-executing DNS gadget or an error-shape differential. Reported as `deserialization-sink`, **never** as RCE: reaching execution depends on classpath gadgets. |
-| **Blind / out-of-band** — Log4Shell/JNDI, exfil, async | *(OOB listener)* | Built-in HTTP/DNS listener receives callbacks and correlates each to the exact payload. |
-
-Mix them freely: `--methods reflected,eval,time` runs all three and reports each
-tier separately. If a combination builds no probes at all, RCEKit says so and
-exits non-zero — a run that tested nothing is never reported as a clean result.
-
-> **Honest scope.** RCEKit confirms RCE that is reachable by **injecting into a
-> request** and interpreted by a shell or an evaluator. It does **not** cover
-> memory-corruption bugs (buffer overflow, UAF) or argument injection into a
-> no-shell `argv` array — those are different problems. **Deserialization gadget
-> chains stay out of scope too**: `--methods deser` proves an endpoint
-> *deserializes* attacker data and says so in its own tier, but which gadget (if
-> any) turns that into execution depends on the target's classpath, and RCEKit
-> does not claim to know. It aims to be excellent at the injection-driven RCE
-> classes above rather than mediocre at everything.
+Already know the injection is SQL and want the database itself?
+[sqlmap](https://github.com/sqlmapproject/sqlmap) owns that ground — RCEKit's
+bridges exist to prove the **OS** is reachable from a text parameter, not to
+exploit the database.
 
 ---
 
@@ -276,6 +332,7 @@ what it sends, and how to read what comes back.
 | The request stores a file instead of running anything | [Upload and write-primitive targets](docs/guide.md#upload-and-write-primitive-targets) |
 | The payload runs later, on a different request | [When execution happens on another request](docs/guide.md#when-execution-happens-on-another-request) |
 | The injection point is SQL and the sink is the database host | [Query-language bridges](docs/reference.md#query-language-bridges) |
+| The endpoint takes a serialized object | [Deserialization sinks](docs/reference.md#deserialization-sinks-and-the-verdict-that-is-not-rce) |
 | The sink is behind a login or a file upload | [Multi-step chains](docs/guide.md#multi-step-chains) |
 | I got `needs-review` / `inconclusive` / `error` | [Reading the results](docs/guide.md#reading-the-results) |
 | It says the corpus is unusable | [Troubleshooting](docs/guide.md#troubleshooting) |
@@ -307,6 +364,9 @@ what it sends, and how to read what comes back.
   fired without `--verify-allow-destructive`. An **execution plan** prints exactly
   what will be sent before anything fires.
 - **Safety tiers** — `safe` / `intrusive` / `stateful`, filtered by `--max-safety`.
+  A method or bridge that leaves something behind is held to the same ordering as
+  every corpus payload, and the pre-flight names the tier each held-back item
+  actually needs.
 - **Audit &amp; logging** — every exploitation/verification run is recorded in
   `exploit_audit.log`; `--watermark` embeds a traceable token; execution logs go to
   `rcekit.log`.

--- a/rcekit.py
+++ b/rcekit.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.34.0"
+__version__ = "2.34.1"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -167,6 +167,7 @@ class ComparisonSectionTestCase(unittest.TestCase):
         "tplmap": "github.com/epinna/tplmap",
         "Nuclei": "github.com/projectdiscovery/nuclei",
         "interactsh": "github.com/projectdiscovery/interactsh",
+        "sqlmap": "github.com/sqlmapproject/sqlmap",
     }
 
     @classmethod
@@ -192,7 +193,7 @@ class ComparisonSectionTestCase(unittest.TestCase):
 
     def test_no_unvetted_project_is_named(self):
         """Adding a rival to the table means adding it here — and linking it."""
-        for rival in ("sqlmap", "metasploit", "burp suite", "acunetix", "tplmap2"):
+        for rival in ("metasploit", "burp suite", "acunetix", "tplmap2"):
             self.assertNotIn(
                 rival, self.section.lower(),
                 f"'{rival}' appears in the comparison but is not in PROJECTS",


### PR DESCRIPTION
Documentation only; no behaviour change.

## The tagline

**Before:** *prove RCE, don't guess it*
**After:** **`confirmed` means the target executed the input. `negative` means the probes reached it.**

The old one claims the tool always proves. It does not, and does not need to — the value is that each verdict has a mechanical meaning, in **both** directions. A promise can be broken; a definition cannot.

Both halves name their actor and object deliberately. "Executed" alone reads as though *RCEKit* executed something; the claim is about the target. And `confirmed` / `negative` are the verdict values as the code spells them, not looser words like "clean".

### One draft that had to be thrown out

An earlier version read *"no `confirmed` without a control differential"* — sharper, more technical, and **false**. Of the four paths that emit `confirmed`, three run the control differential (`_confirm_computed`, `FileBased`, `WriteThenExecute`) but `OobCallback` proves by a random token arriving out of band, with no control request at all. A tagline must not make a claim one of the methods breaks. The mechanism is now stated one line below the tagline, correctly, for both cases.

## The page had fallen behind the engine

It still described **"two verdict tiers"** when there are seven, and the comparison table predated the last five releases.

Rewritten around *what a verdict asserts*, with the tier table as the centrepiece:

| Verdict | What it asserts |
|---|---|
| `confirmed` | the target executed the input |
| `deserialization-sink` | proven — but about a different property |
| `needs-review` | a real signal, not proof |
| `inconclusive` | evidence appeared, could not be attributed |
| `negative` | probes reached the target and found nothing |
| `error` | nothing reached the target |
| `nothing-tested` | no probes were built |

…followed by a section on the half no other tool has: **`error` and `nothing-tested` exist so a run that tested nothing is never reported as clean**, with the conditions that trigger it and the non-zero exit.

## Comparison

Gains the classes added since it was last written — Windows `cmd.exe`/PowerShell sinks, upload → write-then-execute, second-order execution, query-language bridges, deserialization sinks. Second-order is the row where every other column is a dash.

The "reach for something else" note now says plainly that [sqlmap](https://github.com/sqlmapproject/sqlmap) owns the database and RCEKit's bridges only prove the **OS** is reachable from a text parameter. Naming a new rival means vetting it, so sqlmap joins `ComparisonSectionTestCase.PROJECTS` with its link — which is exactly the extension path that test was built for.

## Fixed while writing it

Two claims in the engagement-controls table were wrong, caught by checking them against the code rather than trusting the draft:

- The observed-channel fetch sends **no** credentials unless you hand it a request with `--observe-request`; only the `file` read-back inherits them, same-origin.
- An unanswered `--observe-url` is a **warning about a partly blinded run**, not a `nothing-tested` verdict. The two are now described separately.

Also: the "mechanisms that produce `inconclusive`" list said *four* and listed *five*.

## Verification

506 tests pass, including the doc-consistency suite: every CLI flag documented, every `docs/*.md` linked, every relative link and anchor resolving, the CHANGELOG's newest entry matching `__version__`, and the comparison naming no unvetted project.

---

**Note:** the GitHub repository *description* is separate metadata and I cannot set it from here. Suggested text (317 of 350 chars):

> Confirmed means executed. An RCE detection & confirmation toolkit for authorised pentesting — point it at a URL or a captured request and every finding comes back with the tier it earned. Nothing is called confirmed without execution-grade proof, and a run that tested nothing never reads as clean. Zero dependencies.