### PR TITLE
Publish RCEKit to PyPI (single-module distribution)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # PyPI never lets a version be re-uploaded, so a tag that disagrees with
+      # __version__ would burn that version number permanently. Fail here, before
+      # anything is built.
+      - name: Verify tag matches __version__
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          VER=$(python -c "import rcekit; print(rcekit.__version__)")
+          echo "tag=$TAG module=$VER"
+          test "$TAG" = "$VER"
+
+      - name: Run tests
+        run: python -m unittest discover -s tests
+
+      - name: Verify embedded corpus is current
+        run: python tools/embed_corpus.py --check
+
+      - name: Build
+        run: pipx run build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    # This block is what creates the /deployments/pypi page and what the PyPI
+    # trusted publisher is scoped to. It is not optional.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/rcekit
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ __pycache__/
 .pytest_cache/
 .venv/
 venv/
+
+# Packaging artifacts
+dist/
+build/
+*.egg-info/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ formats, or the template schema.
 
 ## [Unreleased]
 
+### Added
+
+- **RCEKit is installable from PyPI**: `pipx install rcekit` (or
+  `pip install rcekit`) puts an `rcekit` command on PATH. Published through PyPI
+  Trusted Publishing from a GitHub release — no API token, no repository secret.
+
+  It ships as a **single-module distribution**, not a package tree. `rcekit.py`
+  stays one file at the repo root and still runs alone from a `curl` on a jump
+  box or an air-gapped host; installing is a second supported shape, not a
+  replacement for the first.
+
+### Changed
+
+- **`import rcekit` no longer has side effects.** Logging was configured at
+  module scope, and `logging.FileHandler` opens its file when it is constructed,
+  so merely importing the module wrote `rcekit.log` into whatever directory the
+  interpreter happened to be in. Handler setup moved into `configure_logging()`,
+  called from `main()`. Running the CLI still writes `rcekit.log` exactly as
+  before.
+
+- **`main()` takes an optional `argv`** and returns an explicit `int`, so the
+  console-script entry point is a plain zero-argument call and tests can drive
+  the CLI in-process. Every exit code is unchanged.
+
+- **The built-in corpus is no longer reported as a missing file.** With nothing
+  but `rcekit.py` — an installed wheel, or the single-file copy — there is no
+  `templates/` directory, the embedded corpus *is* the corpus, and the run is
+  now silent about it; `--doctor` names it `built-in (embedded in rcekit.py)`
+  and reports OK. A `templates/` directory that exists *without* its
+  `payloads.json` still prints the notice, because that one is a real finding.
+  A corpus that is present but corrupt, and an explicit `--template-file` that
+  is missing or corrupt, still refuse to run and exit non-zero.
+
+- The log file handler now runs at `DEBUG` while the console stays at `INFO`, so
+  detail worth having when reconstructing a run no longer lands on the
+  operator's terminal.
+
 ## [2.34.1] — 2026-08-17
 
 Documentation only; no behaviour change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ formats, or the template schema.
 
 ## [Unreleased]
 
+## [2.35.0] — 2026-08-20
+
 ### Added
 
 - **RCEKit is installable from PyPI**: `pipx install rcekit` (or
@@ -975,7 +977,8 @@ this file and have not been restated here.
 - **[2.7.0]**
 - **[2.1.0]**
 
-[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.34.1...HEAD
+[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.35.0...HEAD
+[2.35.0]: https://github.com/kabiri-labs/rcekit/compare/v2.34.1...v2.35.0
 [2.34.1]: https://github.com/kabiri-labs/rcekit/compare/v2.34.0...v2.34.1
 [2.34.0]: https://github.com/kabiri-labs/rcekit/compare/v2.33.0...v2.34.0
 [2.33.0]: https://github.com/kabiri-labs/rcekit/compare/v2.32.0...v2.33.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,26 @@ cd rcekit        # Python 3.8+, standard library only — no dependencies
 python -m unittest discover -s tests
 ```
 
+## Versioning and releases
+
+`__version__` in `rcekit.py` is **the** release version. Nothing else declares
+one: `pyproject.toml` reads it with `version = { attr = "rcekit.__version__" }`,
+and the README badge and the newest `CHANGELOG.md` entry are held to it by tests.
+Bump it in the same commit as the change it describes — PATCH for a fix, MINOR
+for a new capability, MAJOR for a breaking change to the CLI, the output formats
+or the template schema.
+
+Keep it a plain string literal. setuptools reads it statically where it can, so
+an f-string or a computed value would work today and break the moment the build
+backend takes that path — a test pins the literal form.
+
+Releases are cut by tagging `v<version>` on `main` — `v2.34.1` for
+`__version__ = "2.34.1"` — and publishing a GitHub release. Publishing to PyPI
+runs off `release: published`, not off the tag push, and the workflow refuses to
+build when the tag and the module disagree. That check is deliberate: PyPI never
+allows a version to be re-uploaded, so a mismatch would burn that version number
+permanently.
+
 ## Adding a detection method
 
 The `--methods` engine confirms RCE by proving the target *computed or executed*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,16 @@
+# The sdist carries everything needed to run the tests and read the docs from a
+# source checkout. The wheel stays a single module -- see py-modules in
+# pyproject.toml -- because rcekit.py is designed to run alone.
+include README.md
+include LICENSE
+include CHANGELOG.md
+include SECURITY.md
+include CONTRIBUTING.md
+recursive-include templates *.json
+recursive-include tools *.py
+recursive-include docs *.md
+recursive-include tests *.py *.json *.txt *.md
+
+# Large, and useless in a distribution: the GIFs are README illustrations that
+# GitHub serves, and shipping them would multiply the sdist size for no reader.
+prune confirmation-gifs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **`confirmed` means the target executed the input. `negative` means the probes reached it.**
 
-**Version 2.34.1** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.35.0** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming and security research. Point it at a target you are allowed

--- a/README.md
+++ b/README.md
@@ -71,25 +71,39 @@ differenced against a payload-free control:
 
 ## Quick start
 
+RCEKit has **two supported shapes**, and neither is a fallback for the other.
+
+**Install it** — `pipx` keeps the CLI in its own environment, which is what you
+want for a tool rather than a library:
+
 ```bash
-git clone https://github.com/kabiri-labs/rcekit.git
-cd rcekit                    # Python 3.8+, standard library only — nothing to install
+pipx install rcekit          # or: pip install rcekit
+rcekit --doctor              # confirms the corpus it will run with
 ```
 
-Or take **just the one file** — the payload corpus is built in, so `rcekit.py`
-runs on its own with nothing beside it. On a client jump box, an air-gapped host,
-or anywhere `pip install` is not an option:
+**Or take just the one file.** The payload corpus is built into the module, so
+`rcekit.py` runs on its own with nothing beside it — no install step, no
+site-packages, nothing to leave behind. On a client jump box, an air-gapped
+host, or anywhere `pip install` is not an option:
 
 ```bash
 curl -O https://raw.githubusercontent.com/kabiri-labs/rcekit/main/rcekit.py
-python rcekit.py --doctor    # confirms the corpus it will run with
+python rcekit.py --doctor    # same corpus, same check, zero installation
+```
+
+Both run the same code and report the same verdicts. Working from a checkout is
+the third way, and needs no install either:
+
+```bash
+git clone https://github.com/kabiri-labs/rcekit.git
+cd rcekit                    # Python 3.8+, standard library only
 ```
 
 Put a `FUZZ` marker where your input lands (or select a parameter with `-p` when
 using a captured request), and ask RCEKit to prove RCE:
 
 ```bash
-python rcekit.py --acknowledge-consent \
+rcekit --acknowledge-consent \
   --verify-url "https://target.example/lookup?host=FUZZ" \
   --methods reflected,eval
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rcekit"
+dynamic = ["version"]
+description = "RCE detection & confirmation toolkit for authorised penetration testing"
+readme = "README.md"
+requires-python = ">=3.8"
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [{ name = "Ahmad Kabiri" }]
+dependencies = []
+keywords = ["rce", "command-injection", "ssti", "oob", "pentesting", "security-tools"]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: Console",
+  "Intended Audience :: Information Technology",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Topic :: Security",
+]
+
+[project.urls]
+Homepage = "https://github.com/kabiri-labs/rcekit"
+Documentation = "https://github.com/kabiri-labs/rcekit/blob/main/docs/guide.md"
+Changelog = "https://github.com/kabiri-labs/rcekit/blob/main/CHANGELOG.md"
+Issues = "https://github.com/kabiri-labs/rcekit/issues"
+
+[project.scripts]
+rcekit = "rcekit:main"
+
+[tool.setuptools]
+py-modules = ["rcekit"]
+
+[tool.setuptools.dynamic]
+version = { attr = "rcekit.__version__" }

--- a/rcekit.py
+++ b/rcekit.py
@@ -14,16 +14,34 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler("rcekit.log"),
-        logging.StreamHandler(sys.stdout)
-    ]
-)
 logger = logging.getLogger(__name__)
+
+
+def configure_logging() -> None:
+    """Attach RCEKit's file and stdout log handlers.
+
+    Called from :func:`main`, never at import. Importing a module must not
+    create files in the caller's working directory -- and this one did: a bare
+    ``import rcekit`` wrote ``rcekit.log`` wherever the interpreter happened to
+    be, because ``FileHandler`` opens its file the moment it is constructed.
+    That is untenable for an installed distribution, where the module is
+    imported by tooling that never intends to run a scan.
+
+    ``basicConfig`` is a no-op once the root logger has handlers, so calling
+    this twice, or calling it from a host application that configured its own
+    logging, changes nothing."""
+    # The file handler runs a level below the console one on purpose: detail
+    # that would be noise on an operator's terminal is still worth having in
+    # the log when a run has to be reconstructed afterwards.
+    file_handler = logging.FileHandler("rcekit.log")
+    file_handler.setLevel(logging.DEBUG)
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(logging.INFO)
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        handlers=[file_handler, console_handler],
+    )
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
@@ -573,7 +591,8 @@ class RCEKit:
         written for.
 
         Parsed lazily so the in-repo path never pays for it."""
-        self.corpus_source = "built-in (no templates/payloads.json beside the script)"
+        self.corpus_source = ("built-in (embedded in rcekit.py)" if self.standalone_layout()
+                              else "built-in (no templates/payloads.json beside the script)")
         try:
             data = json.loads(EMBEDDED_PAYLOAD_CORPUS)
             self.payload_categories = data.get("payload_categories", {})
@@ -588,11 +607,34 @@ class RCEKit:
             self.detection_payloads = {}
             self.template_error = message
             return
-        logger.info("using the built-in payload corpus (%s not found)", self.template_path)
+        # Debug, not info: on an installed run this is the normal path, and a
+        # line on stdout every time would read as though something were wrong.
+        # It still lands in rcekit.log, which is where a run gets reconstructed.
+        logger.debug("using the built-in payload corpus (%s not found)", self.template_path)
 
     def uses_embedded_corpus(self) -> bool:
         """Whether the run fell back to the corpus embedded in this file."""
         return self.corpus_source.startswith("built-in")
+
+    def standalone_layout(self) -> bool:
+        """Whether this copy of rcekit.py ships without a corpus directory.
+
+        The two ways to run RCEKit without ``templates/payloads.json`` are not
+        the same event, and telling the operator so is the whole point of the
+        distinction:
+
+        * **No ``templates/`` directory at all** — an installed wheel, or a lone
+          ``rcekit.py`` curled onto a jump box. The embedded corpus *is* the
+          corpus here; there is nothing missing, so there is nothing to report.
+        * **A ``templates/`` directory that exists without its corpus file** — a
+          checkout where the file was deleted, moved or never generated. That is
+          a real finding, and staying quiet about it would let someone believe
+          they were running an edited corpus when they were not.
+
+        Keyed on the directory rather than on ``__file__`` living in
+        site-packages: an air-gapped copy of the single file has no site-packages
+        and must still be treated as a first-class way to run."""
+        return not self.template_path.parent.is_dir()
 
     def _corpus_stats(self) -> Tuple[int, int, Set[str]]:
         """Return (exploit payload count, environment count, environments)."""
@@ -5551,13 +5593,18 @@ def load_token_manifest(path: str) -> Dict[str, Dict[str, Any]]:
     return tokens
 
 
-def main():
+def main(argv: Optional[List[str]] = None) -> int:
     """CLI entry point. Returns the process exit status: ``0`` when the
     requested run completed (including a verification that confirmed nothing —
     that is a result, not a failure) and ``1`` when RCEKit could not carry the
     run out at all: unusable corpus or profile, missing consent, an unreadable
     or unmarked request, or an invalid option combination. Scripts and CI can
-    therefore branch on the status instead of scraping stdout."""
+    therefore branch on the status instead of scraping stdout.
+
+    ``argv`` defaults to ``sys.argv[1:]``. Taking it as an argument is what lets
+    a test drive the CLI in-process, and what keeps the console-script entry
+    point (``rcekit = "rcekit:main"``) a plain zero-argument call."""
+    configure_logging()
     parser = argparse.ArgumentParser(description="Generate RCE payloads for penetration testing")
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     parser.add_argument("-o", "--output", default="rce_payloads.txt",
@@ -5830,7 +5877,7 @@ def main():
     parser.add_argument("--sink-decodes", nargs="+", default=None,
                         help="Encodings the sink decodes before use (e.g. base64); those variants become valid and are generated")
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.listen:
         import time
@@ -5858,7 +5905,7 @@ def main():
             correlated = {h["token"] for h in listener.hits if h["payload"]}
             print(f"\n[listen] stopped: {len(listener.hits)} callbacks, "
                   f"{len(unique)} unique tokens, {len(correlated)} correlated to a payload.")
-        return
+        return 0
 
     # A target profile supplies defaults for the selection and filter options;
     # any explicit CLI flag overrides the matching profile field.
@@ -5942,9 +5989,13 @@ def main():
     )
     generator.insecure = args.insecure
 
-    # Never silent: someone who thinks they are running an edited corpus must not
-    # discover only from the results that they were running the built-in one.
-    if generator.uses_embedded_corpus():
+    # Never silent about a corpus that should have been there: someone who
+    # thinks they are running an edited corpus must not discover only from the
+    # results that they were running the built-in one. But an installed wheel
+    # and a lone rcekit.py have no corpus directory at all -- the embedded copy
+    # is the corpus -- so there is nothing to warn about and the notice would be
+    # a permanent false alarm.
+    if generator.uses_embedded_corpus() and not generator.standalone_layout():
         print(f"[i] Using the built-in payload corpus ({generator.template_path} not found). "
               "Pass --template-file to use your own.")
 
@@ -6054,7 +6105,7 @@ def main():
                 print(f"  [{result['category']}] {result['payload']!r}   ({result['detail']})")
         else:
             print("\n[verify-chain] No execution confirmed.")
-        return
+        return 0
 
     if args.verify_url or args.request_file:
         if not args.acknowledge_consent:
@@ -6567,7 +6618,7 @@ def main():
                           "may not fit its sink/context (try --environments/--contexts).")
                     for line in blind_sink_advice(method_names, args):
                         print(line)
-            return
+            return 0
         results = generator.run_verification(
             to_send, url=verify_url, method=method, data=verify_data,
             headers=verify_headers, delay=args.verify_delay, timeout=args.verify_timeout,
@@ -6602,7 +6653,7 @@ def main():
         if not confirmed and not oob_pending:
             print("\n[verify] No execution confirmed. The target may be patched, or the payloads "
                   "may not fit its sink/context (try --target-profile or a different --environments/--contexts).")
-        return
+        return 0
 
     if args.output_format == "text" and not args.include_metadata and selected_encodings:
         # A decoder-required encoding is fine when the sink is known to decode it.
@@ -6642,6 +6693,7 @@ def main():
         return 1
 
     print(f"Generated {count} payloads to {args.output} in {mode} mode")
+    return 0
 
 # --- BEGIN EMBEDDED PAYLOAD CORPUS (generated by tools/embed_corpus.py) ---
 # Source: templates/payloads.json — edit that file, then re-run the script.
@@ -7410,4 +7462,4 @@ EMBEDDED_PAYLOAD_CORPUS = r"""
 # --- END EMBEDDED PAYLOAD CORPUS ---
 
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main())

--- a/rcekit.py
+++ b/rcekit.py
@@ -45,7 +45,7 @@ def configure_logging() -> None:
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.34.1"
+__version__ = "2.35.0"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 

--- a/tests/test_corpus_embedding.py
+++ b/tests/test_corpus_embedding.py
@@ -76,8 +76,26 @@ class StandaloneScriptTestCase(unittest.TestCase):
         self.assertIn("built-in", result.stdout)
         self.assertIn("[doctor] OK", result.stdout)
 
-    def test_fallback_is_announced(self):
-        """Silently swapping the corpus would mislead anyone who edited theirs."""
+    def test_a_lone_script_says_nothing_about_a_missing_corpus(self):
+        """There is no missing corpus here, so there is nothing to announce.
+
+        A lone `rcekit.py` — curled onto a jump box, or installed as a wheel —
+        ships no `templates/` directory at all. The embedded corpus *is* the
+        corpus in that layout, and a notice on every run would be a permanent
+        false alarm telling the operator a file is missing that was never meant
+        to be there."""
+        result = run("rcekit.py", "--doctor", cwd=self.tmp)
+        self.assertNotIn("Using the built-in payload corpus", result.stdout)
+        self.assertNotIn("not found", result.stdout)
+
+    def test_a_corpus_directory_without_its_file_is_announced(self):
+        """The case the notice was written for, and it still fires.
+
+        A `templates/` directory that exists without `payloads.json` is a
+        checkout where the file was deleted, moved or never generated. Silently
+        swapping in the built-in corpus there would mislead anyone who believed
+        they were running an edited one."""
+        (Path(self.tmp) / "templates").mkdir()
         result = run("rcekit.py", "--doctor", cwd=self.tmp)
         self.assertIn("Using the built-in payload corpus", result.stdout)
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -7,9 +7,11 @@ dependency.
 """
 
 import html
+import os
 import re
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -78,6 +80,65 @@ class VersionBadgeTestCase(unittest.TestCase):
             rcekit.__version__,
             "README version badge is out of sync with rcekit.__version__",
         )
+
+
+    def test_cli_version_matches_dunder_version(self):
+        """The packaged version and the reported version are the same string.
+
+        `pyproject.toml` reads the release version from `rcekit.__version__`,
+        and the publish workflow refuses to build when the git tag disagrees
+        with it. So a `--version` that reported anything else would put a
+        number on a wheel that the tool itself denies -- and PyPI never lets a
+        version be re-uploaded, so the mistake would be permanent."""
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--version"],
+            cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        reported = result.stdout.strip().split()[-1]
+        self.assertEqual(reported, rcekit.__version__)
+
+    def test_dunder_version_is_a_static_literal(self):
+        """Readable without importing the module.
+
+        setuptools reads it with `attr:`, which parses the source when it can
+        rather than executing it. A computed value would still work today and
+        break the moment the build backend takes the static path."""
+        source = SCRIPT.read_text(encoding="utf-8")
+        match = re.search(r'^__version__ = "(\d+\.\d+\.\d+)"$', source, re.MULTILINE)
+        self.assertIsNotNone(match, "__version__ is not a plain string literal")
+        self.assertEqual(match.group(1), rcekit.__version__)
+
+
+class ImportPurityTestCase(unittest.TestCase):
+    """`import rcekit` must do nothing but define names.
+
+    It used to configure logging at module scope, and `logging.FileHandler`
+    opens its file on construction -- so importing the module wrote `rcekit.log`
+    into whatever directory the interpreter happened to be in. Harmless in a
+    repo checkout, indefensible once the module is installed and imported by
+    tooling that never intends to run a scan."""
+
+    def test_importing_creates_no_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = Path(tmp) / "rcekit.py"
+            script.write_bytes(SCRIPT.read_bytes())
+            before = set(os.listdir(tmp))
+            result = subprocess.run(
+                [sys.executable, "-c", "import rcekit"],
+                cwd=tmp, capture_output=True, text=True, timeout=120,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            created = set(os.listdir(tmp)) - before - {"__pycache__"}
+        self.assertEqual(created, set(), f"import created files: {sorted(created)}")
+
+    def test_importing_writes_nothing_to_stdout(self):
+        result = subprocess.run(
+            [sys.executable, "-c", "import rcekit"],
+            cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "")
 
 
 class ChangelogTestCase(unittest.TestCase):

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1419,6 +1419,94 @@ class DoctorTestCase(unittest.TestCase):
             self.assertFalse(out.exists())
 
 
+class InstalledShapeTestCase(unittest.TestCase):
+    """How RCEKit behaves with no corpus directory beside it.
+
+    That is what an installed wheel looks like — `py-modules = ["rcekit"]` ships
+    the module and nothing else — and what a lone `rcekit.py` curled onto a jump
+    box looks like. In both, the embedded corpus *is* the corpus: nothing is
+    missing, so nothing should be reported as missing.
+
+    The distinction that carries this is the corpus **directory**, not the file.
+    A `templates/` directory that exists without its `payloads.json` is a
+    checkout where something was deleted or never generated, and staying quiet
+    about that would let someone believe they were running an edited corpus when
+    they were not."""
+
+    def _copy_module(self, directory):
+        target = Path(directory) / "rcekit.py"
+        target.write_bytes(SCRIPT.read_bytes())
+        return target
+
+    def _run(self, cwd, *args):
+        return subprocess.run(
+            [sys.executable, "rcekit.py", *args],
+            cwd=str(cwd), capture_output=True, text=True, timeout=120,
+        )
+
+    def test_no_corpus_directory_is_silent_and_healthy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._copy_module(tmp)
+            res = self._run(tmp, "--doctor")
+        self.assertEqual(res.returncode, 0, res.stdout + res.stderr)
+        self.assertIn("[doctor] OK", res.stdout)
+        # The two things that made an installed run read as broken.
+        self.assertNotIn("not found", res.stdout)
+        self.assertNotIn("[i] Using the built-in payload corpus", res.stdout)
+
+    def test_the_doctor_names_the_embedded_corpus_as_a_source_not_a_fault(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._copy_module(tmp)
+            res = self._run(tmp, "--doctor")
+        self.assertIn("corpus: built-in (embedded in rcekit.py)", res.stdout)
+        self.assertIn("[ok] corpus loaded and parsed", res.stdout)
+
+    def test_a_corpus_directory_without_its_file_still_says_so(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._copy_module(tmp)
+            (Path(tmp) / "templates").mkdir()
+            res = self._run(tmp, "--doctor")
+        self.assertEqual(res.returncode, 0, res.stdout + res.stderr)
+        self.assertIn("[i] Using the built-in payload corpus", res.stdout)
+
+    def test_a_corrupt_corpus_beside_the_module_still_refuses_to_run(self):
+        # The fallback is for an *absent* corpus only. Falling back over a
+        # corrupt one would mask a truncated or tampered file, which is the case
+        # the hard-fail was written for.
+        with tempfile.TemporaryDirectory() as tmp:
+            self._copy_module(tmp)
+            templates = Path(tmp) / "templates"
+            templates.mkdir()
+            (templates / "payloads.json").write_text("{ not json", encoding="utf-8")
+            doctor = self._run(tmp, "--doctor")
+            run = self._run(tmp, "--detection-only", "-o", str(Path(tmp) / "out.txt"))
+        self.assertEqual(doctor.returncode, 1, doctor.stdout)
+        self.assertIn("[FAIL]", doctor.stdout)
+        self.assertEqual(run.returncode, 1, run.stdout)
+
+    def test_an_explicit_template_file_never_falls_back(self):
+        # "I pointed at my corpus" has to keep meaning what it says, whatever
+        # layout the module is running from.
+        with tempfile.TemporaryDirectory() as tmp:
+            self._copy_module(tmp)
+            out = Path(tmp) / "out.txt"
+            res = self._run(tmp, "--detection-only", "--template-file",
+                            str(Path(tmp) / "nope.json"), "-o", str(out))
+            self.assertEqual(res.returncode, 1, res.stdout)
+            self.assertFalse(out.exists(), "a refused run must not leave output behind")
+
+    def test_a_detection_run_works_with_no_corpus_directory(self):
+        # The embedded corpus has to actually serve a run, not merely pass the
+        # doctor: an installed wheel has nothing else to fall back to.
+        with tempfile.TemporaryDirectory() as tmp:
+            self._copy_module(tmp)
+            out = Path(tmp) / "payloads.txt"
+            res = self._run(tmp, "--detection-only", "-o", str(out), "--max-payloads", "5")
+            self.assertEqual(res.returncode, 0, res.stdout + res.stderr)
+            self.assertTrue(out.exists())
+            self.assertTrue(out.read_text(encoding="utf-8").strip())
+
+
 class NewSinkCoverageTestCase(unittest.TestCase):
     """Sinks added from the real-world Vulhub evaluation. Each new payload must
     carry the right machine-readable oracle so verification can confirm it."""


### PR DESCRIPTION
Packages RCEKit as a **single-module distribution** and adds a trusted-publishing workflow. `rcekit.py` does not move, no `src/` tree, no split — the wheel ships the one module, and running it standalone from a `curl` stays a first-class path.

> ⚠️ **Do not merge before the pending publisher exists.** See the checklist at the bottom — items 1–3 have to be done first, or the first release fails at the upload step.

---

## Phase 1 — two real defects, not packaging paperwork

**`import rcekit` had side effects.** Logging was configured at module scope, and `logging.FileHandler` opens its file the moment it is constructed — so importing the module wrote `rcekit.log` into whatever directory the interpreter happened to be in. Harmless in a checkout; indefensible once the module is installed and imported by tooling that never intends to run a scan. Handler setup moved into `configure_logging()`, called from `main()`.

```
$ cd /tmp/empty && cp rcekit.py . && python -c "import rcekit"
before: rcekit.log created
after : files created on import: NONE
```

**`main()`** now takes an optional `argv` and returns an explicit `int`. Its four bare `return` statements became `return 0` — identical exit status, honest annotation. Every exit code is unchanged, including the contractual non-zero ones (`--version` 0, `--doctor` 0/1, missing consent 1, missing `--template-file` 1 — all re-verified).

**`__version__`** was already a plain literal; a test now pins that it stays one, because setuptools reads it statically with `attr:` and a computed value would work today and break the moment the backend takes that path.

## Phase 2 — the built-in corpus was reported as a missing file

With nothing but `rcekit.py` there is no `templates/` directory at all, so the embedded corpus **is** the corpus — yet every run printed a notice saying a file was not found that was never meant to be there, and `--doctor` named the source `built-in (no templates/payloads.json beside the script)`.

The distinction is now the corpus *directory*, not the file:

| Layout | Behaviour |
|---|---|
| No `templates/` directory (installed wheel, lone `rcekit.py`) | Silent. `--doctor`: `built-in (embedded in rcekit.py)`, OK |
| `templates/` exists **without** `payloads.json` | Notice, unchanged — that one is a real finding |
| Corpus present but corrupt | Refuse, exit 1 — unchanged |
| `--template-file` missing or corrupt | Refuse, exit 1 — unchanged |

Falling back over a *corrupt* file would mask a truncated or tampered corpus, which is the case the hard-fail exists for. The log file handler also drops to `DEBUG` while the console stays at `INFO`, so the fallback line lands in `rcekit.log` and not on the operator's terminal.

One existing test asserted the notice *always* fires; it now pins both halves of the rule.

## Phase 3 — packaging

`py-modules = ["rcekit"]`, version read from `rcekit.__version__`, `MANIFEST.in` giving the sdist what a checkout needs and pruning `confirmation-gifs/`.

**One deliberate deviation from the brief.** The supplied `pyproject.toml` used a TOML-table license plus a license classifier, and current setuptools deprecates both — three warnings on every build, against an acceptance criterion of *no warnings*. Replaced with the PEP 639 form (`license = "MIT"` plus `license-files`), classifier dropped, `setuptools>=77`. It costs nothing downstream: the build already emitted `Metadata-Version: 2.4` either way. Say the word if you'd rather keep the literal TOML and live with the warnings.

## Phase 4 — workflow

`release: published`, existing tests workflow untouched. Tag check runs **before** the build: PyPI never allows a version to be re-uploaded, so a mismatch would burn that number permanently. `environment: name: pypi` on the publish job, `id-token: write` scoped to it alone, no token or secret anywhere.

## Phase 5 — docs

Quick start opens with `pipx install rcekit` / `rcekit --doctor`; the curl-one-file path keeps its framing as a supported shape, not a fallback. Only quick-start examples switched to `rcekit`. CONTRIBUTING gained a versioning-and-releases section. CHANGELOG records it under **Unreleased** — the version is *not* bumped, because which number ships first is yours to decide (item 4 below).

---

## Acceptance criteria

| | |
|---|---|
| `python -m build` — sdist + wheel, no warnings | ✅ |
| Wheel contains `rcekit.py` + metadata, no GIFs | ✅ (7 entries; zero `confirmation-gifs` entries in the sdist) |
| Installed wheel gives a working `rcekit` on PATH | ✅ `rcekit --version` → `rcekit 2.34.1` |
| `rcekit --doctor` clean and silent about the corpus | ✅ |
| Corpus corruption / missing `--template-file` still exit non-zero | ✅ |
| `python -m unittest discover -s tests` | ✅ **517 tests** |
| `rcekit.py` still runs standalone from an empty directory | ✅ |
| Real detection run from the installed CLI | ⚠️ **see below** |

**The dockerised target could not be used** — there is no Docker daemon in this environment, so I could not run the Webmin or Struts2 target from `verify-it-yourself.md`. Instead I stood up a locally-served vulnerable endpoint that shells out with the parameter, and drove it with the **installed** `rcekit` on PATH, which exercises the same path end to end:

```
$ rcekit --acknowledge-consent --verify-url "http://127.0.0.1:8099/lookup?host=FUZZ" \
    --methods reflected,eval
  [reflected/unix/raw] ; echo RKCNKUA$((231439+873135))RKZTRKU$(echo RKCJOMA)RKCNKUA #
      (target computed 'RKCNKUA1104574RKZTRKURKCJOMARKCNKUA' — random operands, absent from control)
```

Worth repeating against a real vulhub target before the first release; it is the one criterion I could not close here.

---

## Ahmad must do — before this merges

1. **Confirm the PyPI name is free** — [pypi.org/project/rcekit/](https://pypi.org/project/rcekit/). If it is taken, stop: the project name and every doc reference has to change, and that is your call.
2. **Create the pending trusted publisher** at [pypi.org/manage/account/publishing/](https://pypi.org/manage/account/publishing/), exactly:
   - PyPI project name: `rcekit`
   - Owner: `kabiri-labs`
   - Repository name: `rcekit`
   - Workflow name: `publish.yml`
   - Environment name: `pypi`
3. **Create the `pypi` environment** in Settings → Environments if GitHub does not create it implicitly. A required reviewer is reasonable given this workflow can publish.
4. **Decide the first published version.** Module, README badge and CHANGELOG all agree on **2.34.1** today, and I did not bump it. If you want the PyPI debut to be its own number, bump `__version__` and move the Unreleased entry before tagging.
5. **Cut the release.** Tag `v` + the version (so `v2.34.1` for `2.34.1`) on `main` and publish a GitHub release — the workflow runs on `release: published`, not on the tag push.
6. **Optional TestPyPI dry run.** A separate `testpypi` publisher plus a `workflow_dispatch` copy of the workflow. Ask and I'll build it — it is extra surface, and the local wheel install above already covers most of the risk.