### PR TITLE
fix: input the tool did not choose must not crash it or pass unnoticed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ formats, or the template schema.
 
 ## [Unreleased]
 
+## [2.35.1] — 2026-08-21
+
+A robustness pass over error handling: no new capability, four ways the tool
+could crash or mislead on input it did not choose.
+
+### Fixed
+
+- **A truncated error response no longer ends the run.** Reading an
+  `HTTPError`'s body happens *inside* the `except` handler, where the sibling
+  `except Exception` cannot reach it — so a target that promised a
+  `Content-Length` it never delivered raised `ConnectionResetError` straight out
+  of `main()`, taking every probe already fired with it. The read is now
+  guarded: the status still comes back, an unreadable body is reported empty.
+  A body that *does* arrive is still returned in full — the 500-stack-trace
+  confirmations that branch exists for are unaffected.
+- **A `--target-profile` is checked before it is used.** A profile is written by
+  hand, so a typo in one is ordinary; it surfaced as a traceback. A top level
+  that is not a JSON object, `deny_chars` that is not text, a `max_length` that
+  is not a number, a selector field that is not a list of names — each is now an
+  operator-readable `[!]` message and exit 1, the same way the sink-shape fields
+  already behaved. Twelve inputs that produced an `AttributeError` or a
+  `TypeError` now produce a sentence.
+- **A selector field given as one string means one name.** `"environments":
+  "unix"` in a profile was iterated character by character, matched nothing, and
+  the empty run that followed was reported as a success. A string is now split
+  on commas: `"unix"` is `["unix"]`, `"raw, html"` is `["raw", "html"]`.
+- **Unknown `--environments` and `--encodings` are named.** Both were silent, so
+  `--environments linux` — the corpus calls it `unix` — produced an empty file
+  and exit 0, indistinguishable from a target with no payloads for it. Both now
+  warn and list the names that exist, as unknown contexts and categories already
+  did. An empty result is also no longer announced as "Successfully generated 0
+  payloads"; it says the selection matched nothing and points at the filters.
+- **A callback cannot rewrite the operator's terminal.** The host and path of an
+  OOB callback are chosen by the target. Printed raw, an ESC byte let that
+  target colour, erase and rewrite lines — hiding a genuine `[HIT]` behind
+  `\x1b[2K\r`, or forging one that never arrived. Control characters are now
+  escaped for display as `\xNN`; the recorded hit and the `--listen-log` JSONL
+  keep the bytes verbatim.
+
 ## [2.35.0] — 2026-08-20
 
 ### Added
@@ -977,7 +1016,8 @@ this file and have not been restated here.
 - **[2.7.0]**
 - **[2.1.0]**
 
-[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.35.0...HEAD
+[Unreleased]: https://github.com/kabiri-labs/rcekit/compare/v2.35.1...HEAD
+[2.35.1]: https://github.com/kabiri-labs/rcekit/compare/v2.35.0...v2.35.1
 [2.35.0]: https://github.com/kabiri-labs/rcekit/compare/v2.34.1...v2.35.0
 [2.34.1]: https://github.com/kabiri-labs/rcekit/compare/v2.34.0...v2.34.1
 [2.34.0]: https://github.com/kabiri-labs/rcekit/compare/v2.33.0...v2.34.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **`confirmed` means the target executed the input. `negative` means the probes reached it.**
 
-**Version 2.35.0** · MIT · Python 3.8+ · zero third-party dependencies
+**Version 2.35.1** · MIT · Python 3.8+ · zero third-party dependencies
 
 RCEKit is an **RCE detection &amp; confirmation toolkit** for authorised penetration
 testing, red teaming and security research. Point it at a target you are allowed

--- a/rcekit.py
+++ b/rcekit.py
@@ -45,7 +45,7 @@ def configure_logging() -> None:
 
 # Bump on every change: PATCH for fixes, MINOR for new capabilities, MAJOR for
 # breaking changes to the CLI, output formats, or template schema.
-__version__ = "2.35.0"
+__version__ = "2.35.1"
 
 SAFETY_ORDER = {"safe": 0, "intrusive": 1, "stateful": 2}
 
@@ -1022,6 +1022,39 @@ class RCEKit:
             return payload.replace("\r", " ").replace("\n", " ")
         return payload
 
+    def _known_environments(self, mode: str) -> Set[str]:
+        """Every environment name the corpus can actually yield in ``mode``."""
+        if mode == "detection":
+            return set(self.detection_payloads)
+        known: Set[str] = set()
+        for category in self.payload_categories.values():
+            known.update(category)
+        return known
+
+    def _warn_unknown_selectors(self, mode: str,
+                                selected_environments: Optional[List[str]],
+                                selected_encodings: Optional[List[str]]) -> None:
+        """Name any explicitly selected environment or encoding that matches
+        nothing, once each.
+
+        A selector that matches nothing produces an empty run, and an empty run
+        is reported as a success -- so ``--environments linux`` (the corpus
+        calls it ``unix``) is indistinguishable from a target for which there
+        are simply no payloads. Unknown contexts and categories were already
+        named; these two went by in silence. Only *explicit* selections are
+        checked: the defaults are the corpus's own and must not warn."""
+        if selected_environments:
+            known = self._known_environments(mode)
+            for env in dict.fromkeys(selected_environments):
+                if env not in known:
+                    logger.warning("Unknown environment: %s (known: %s)",
+                                   env, ", ".join(sorted(known)))
+        if selected_encodings:
+            for enc in dict.fromkeys(selected_encodings):
+                if enc not in self.encoding_methods:
+                    logger.warning("Unknown encoding: %s (known: %s)",
+                                   enc, ", ".join(sorted(self.encoding_methods)))
+
     def generate_payload_records(
         self,
         selected_contexts: Optional[List[str]] = None,
@@ -1039,6 +1072,7 @@ class RCEKit:
         encodings = selected_encodings if selected_encodings else (
             self.safe_detection_encodings if mode == "detection" else list(self.default_encodings)
         )
+        self._warn_unknown_selectors(mode, selected_environments, selected_encodings)
 
         if mode == "detection":
             environments = selected_environments if selected_environments else list(self.detection_payloads.keys())
@@ -1497,7 +1531,18 @@ class RCEKit:
                     for entry in manifest:
                         map_file.write(json.dumps(entry, ensure_ascii=True) + "\n")
 
-            logger.info("Successfully generated %s payloads to %s", count, output_path)
+            if count:
+                logger.info("Successfully generated %s payloads to %s", count, output_path)
+            else:
+                # "Successfully generated 0 payloads" reads as a target with
+                # nothing to fire at. Far more often it is a selector that
+                # matched nothing, and the operator needs to hear the
+                # difference before they conclude anything from the run.
+                logger.warning(
+                    "No payloads matched the selection -- %s is empty. Check "
+                    "--contexts/--categories/--encodings/--environments and any "
+                    "--target-profile filters (--deny-chars, --max-length).",
+                    output_path)
             if include_metadata and output_format == "text":
                 logger.info("Metadata sidecar written to %s", metadata_path)
             if manifest:
@@ -2044,7 +2089,18 @@ class RCEKit:
                 return (response.status, text, self._channels_from_response(response, text, target),
                         time.time() - start)
         except urllib.error.HTTPError as exc:
-            text = exc.read().decode(errors="replace")
+            # Reading the error body can itself fail: a target that truncates
+            # its own error response -- a Content-Length it never delivers,
+            # then a reset -- raises here, mid-`except`. An exception raised
+            # inside an except block is NOT caught by the sibling handler
+            # below, so without this guard one malformed error response ends
+            # the whole run and every probe fired so far is lost. The status
+            # is what the caller needs most; an unreadable body is a body we
+            # report as empty, exactly as a delivery failure would.
+            try:
+                text = exc.read().decode(errors="replace")
+            except Exception:
+                text = ""
             return (exc.code, text, self._channels_from_response(exc, text, target),
                     time.time() - start)
         except Exception as exc:  # network error, timeout, etc.
@@ -2892,6 +2948,31 @@ class RCEKit:
         except Exception as exc:
             logger.error("Unable to log exploitation usage: %s", exc)
 
+
+def terminal_safe(text: str) -> str:
+    """Escape control characters for display on the operator's terminal.
+
+    A callback's host and path are chosen by the *target*, which in an
+    engagement is hostile by definition. Printed raw, an ESC byte lets that
+    target colour, erase and rewrite lines in the operator's own terminal --
+    hiding a genuine hit behind ``\\x1b[2K\\r``, or forging one that never
+    arrived. For a tool whose whole claim is that its output can be trusted,
+    that is the output being forged.
+
+    Escaped rather than stripped: what arrived is still visible, as ``\\xNN``,
+    so the operator can see that something tried this. Only the display is
+    changed -- the recorded hit and the JSONL log keep the bytes verbatim."""
+    out: List[str] = []
+    for char in text:
+        if char.isprintable():
+            out.append(char)
+        elif ord(char) <= 0xFF:
+            out.append("\\x%02x" % ord(char))
+        else:
+            out.append("\\u%04x" % ord(char))
+    return "".join(out)
+
+
 class OOBListener:
     """A lightweight out-of-band listener that records DNS/HTTP callbacks and
     correlates each one back to the payload whose unique token produced it.
@@ -2952,12 +3033,19 @@ class OOBListener:
             "context": entry.get("context") if entry else None,
         }
         self.hits.append(hit)
-        where = f"{host or path}"
+        # Everything interpolated below reached us over the wire (or, for the
+        # manifest fields, out of a file the operator may have hand-edited),
+        # so none of it goes to the terminal unescaped. The hit recorded above
+        # keeps the raw bytes.
+        where = terminal_safe(f"{host or path}")
+        safe_token = terminal_safe(token) if token else token
         if entry:
-            print(f"[HIT] {proto} token={token} from {source} -> {entry.get('payload')} "
-                  f"[{entry.get('category')}/{entry.get('context')}]")
+            print(f"[HIT] {proto} token={safe_token} from {source} "
+                  f"-> {terminal_safe(str(entry.get('payload')))} "
+                  f"[{terminal_safe(str(entry.get('category')))}/"
+                  f"{terminal_safe(str(entry.get('context')))}]")
         else:
-            print(f"[HIT] {proto} from {source} -> {where}  (token={token}; not in manifest)")
+            print(f"[HIT] {proto} from {source} -> {where}  (token={safe_token}; not in manifest)")
         if self.log_path:
             try:
                 with open(self.log_path, "a", encoding="utf-8") as log_file:
@@ -5576,6 +5664,62 @@ def build_request_inputs(text: str, param: Optional[str] = None,
     return url, method, data, out_headers, injection
 
 
+# Selector fields a profile may give as a list of names or as one
+# comma-separated string. Normalised to a list, because a bare string handed
+# to the generator would be iterated *character by character* -- "unix" would
+# select nothing at all, silently.
+_PROFILE_LIST_FIELDS = ("environments", "contexts", "categories", "encodings",
+                        "sink_decodes")
+# Fields whose string form main() already knows how to split itself.
+_PROFILE_STRING_OR_LIST_FIELDS = ("separators", "eval_engines")
+
+
+def validate_target_profile(profile: Any) -> Dict[str, Any]:
+    """Check a loaded target profile's shape and normalise its selector fields,
+    raising ``ValueError`` with an operator-readable message.
+
+    A profile is a file someone writes by hand, so the failure to design for is
+    a typo: a number where a character set belongs, a bare string where a list
+    does. Left unchecked those surface far from their cause -- as a ``TypeError``
+    deep in the payload filter, or as a run that quietly generates nothing.
+    Every check here guards a field the caller goes on to join, index, or
+    compare."""
+    if not isinstance(profile, dict):
+        raise ValueError(f"a target profile must be a JSON object, not "
+                         f"{type(profile).__name__}.")
+
+    def _names(field: str, value: Any) -> List[str]:
+        if isinstance(value, str):
+            return [part.strip() for part in value.split(",") if part.strip()]
+        if isinstance(value, (list, tuple)) and all(isinstance(v, str) for v in value):
+            return list(value)
+        raise ValueError(f"'{field}' must be a string or a list of strings, "
+                         f"not {type(value).__name__}.")
+
+    for field in _PROFILE_LIST_FIELDS:
+        if profile.get(field) is not None:
+            profile[field] = _names(field, profile[field])
+    for field in _PROFILE_STRING_OR_LIST_FIELDS:
+        if profile.get(field) is not None and not isinstance(profile[field], str):
+            _names(field, profile[field])
+
+    deny = profile.get("deny_chars")
+    # A string is already a set of characters; a list is joined into one.
+    if deny is not None and not isinstance(deny, str):
+        _names("deny_chars", deny)
+
+    length = profile.get("max_length")
+    if length is not None and (isinstance(length, bool) or not isinstance(length, int)):
+        raise ValueError(f"'max_length' must be a whole number, not "
+                         f"{type(length).__name__}.")
+
+    request = profile.get("request")
+    if request is not None and not isinstance(request, dict):
+        raise ValueError(f"'request' must be a JSON object, not "
+                         f"{type(request).__name__}.")
+    return profile
+
+
 def load_token_manifest(path: str) -> Dict[str, Dict[str, Any]]:
     """Load a .map.jsonl manifest into a token -> entry dict."""
     tokens: Dict[str, Dict[str, Any]] = {}
@@ -5913,7 +6057,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     if args.target_profile:
         try:
             with open(args.target_profile, "r", encoding="utf-8") as profile_file:
-                profile = json.load(profile_file)
+                profile = validate_target_profile(json.load(profile_file))
         except Exception as exc:
             print(f"[!] Unable to load target profile {args.target_profile}: {exc}")
             return 1

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -6256,3 +6256,215 @@ class DeserializationSinkTestCase(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TruncatedErrorResponseTestCase(unittest.TestCase):
+    """A target may cut its own error response short. Reading that body raises
+    *inside* the ``except HTTPError`` handler, where the sibling ``except
+    Exception`` cannot catch it -- so before the guard, one malformed error
+    response ended the whole run and lost every probe already fired."""
+
+    def _serve(self, handler):
+        import socket
+        import threading
+        server = socket.socket()
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind(("127.0.0.1", 0))
+        server.listen(8)
+        port = server.getsockname()[1]
+
+        def loop():
+            while True:
+                try:
+                    conn, _ = server.accept()
+                except OSError:
+                    return
+                threading.Thread(target=handler, args=(conn,), daemon=True).start()
+
+        threading.Thread(target=loop, daemon=True).start()
+        self.addCleanup(server.close)
+        return port
+
+    def test_error_body_that_never_arrives_does_not_end_the_run(self):
+        def truncate(conn):
+            # Promise 4000 bytes, send 10, then reset the connection.
+            conn.sendall(b"HTTP/1.1 500 Internal Server Error\r\n"
+                         b"Content-Length: 4000\r\n\r\n" + b"A" * 10)
+            conn.close()
+
+        port = self._serve(truncate)
+        generator = RCEKit()
+        status, body, channels, elapsed = generator._fire_channels(
+            "probe", f"http://127.0.0.1:{port}/x?cmd=FUZZ", "GET", None, None,
+            "query_value", "json_string", 5)
+        # The status is what the caller needs most; an unreadable body is
+        # reported as empty rather than as a traceback.
+        self.assertIn(status, (500, None))
+        self.assertIsInstance(body, str)
+        self.assertIsInstance(channels, list)
+        self.assertGreaterEqual(elapsed, 0.0)
+
+    def test_readable_error_body_is_still_returned(self):
+        """The guard must not cost the 500-stack-trace confirmations it exists
+        alongside: a complete error body still comes back in full."""
+        def complete(conn):
+            body = b"computed 1355862 here"
+            conn.sendall(b"HTTP/1.1 500 Internal Server Error\r\n"
+                         b"Content-Length: %d\r\n\r\n" % len(body) + body)
+            conn.close()
+
+        port = self._serve(complete)
+        generator = RCEKit()
+        status, body, _, _ = generator._fire_channels(
+            "probe", f"http://127.0.0.1:{port}/x?cmd=FUZZ", "GET", None, None,
+            "query_value", "json_string", 5)
+        self.assertEqual(status, 500)
+        self.assertIn("1355862", body)
+
+
+class TargetProfileValidationTestCase(unittest.TestCase):
+    """A profile is hand-edited, so a typo in one is ordinary. It must produce
+    an operator-readable message, not a traceback thousands of payloads later."""
+
+    def test_top_level_must_be_an_object(self):
+        for value in ([], None, "hello", 42, True):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError) as caught:
+                    rcekit.validate_target_profile(value)
+                self.assertIn("must be a JSON object", str(caught.exception))
+
+    def test_selector_fields_reject_non_string_values(self):
+        for field in ("environments", "contexts", "categories", "encodings",
+                      "sink_decodes"):
+            with self.subTest(field=field):
+                with self.assertRaises(ValueError) as caught:
+                    rcekit.validate_target_profile({field: 5})
+                self.assertIn(field, str(caught.exception))
+
+    def test_selector_string_is_one_name_not_one_character_each(self):
+        """``"unix"`` iterated as characters selected nothing at all, and the
+        empty run that followed was reported as a success."""
+        profile = rcekit.validate_target_profile({"environments": "unix"})
+        self.assertEqual(profile["environments"], ["unix"])
+        profile = rcekit.validate_target_profile({"contexts": "raw, html"})
+        self.assertEqual(profile["contexts"], ["raw", "html"])
+
+    def test_deny_chars_accepts_a_string_or_a_list(self):
+        self.assertEqual(
+            rcekit.validate_target_profile({"deny_chars": ";|&"})["deny_chars"], ";|&")
+        self.assertEqual(
+            rcekit.validate_target_profile({"deny_chars": [";", "|"]})["deny_chars"],
+            [";", "|"])
+        for bad in (123, True, {"a": 1}):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    rcekit.validate_target_profile({"deny_chars": bad})
+
+    def test_max_length_must_be_a_whole_number(self):
+        self.assertEqual(
+            rcekit.validate_target_profile({"max_length": 120})["max_length"], 120)
+        for bad in ("abc", [1], {}, True):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError) as caught:
+                    rcekit.validate_target_profile({"max_length": bad})
+                self.assertIn("max_length", str(caught.exception))
+
+    def test_request_must_be_an_object(self):
+        with self.assertRaises(ValueError) as caught:
+            rcekit.validate_target_profile({"request": 5})
+        self.assertIn("request", str(caught.exception))
+
+    def test_shipped_profiles_all_validate(self):
+        shipped = sorted((Path(__file__).resolve().parent.parent / "profiles").glob("*.json"))
+        self.assertTrue(shipped, "no profiles shipped to validate")
+        for path in shipped:
+            with self.subTest(profile=path.name):
+                with path.open(encoding="utf-8") as handle:
+                    rcekit.validate_target_profile(json.load(handle))
+
+
+class UnknownSelectorWarningTestCase(unittest.TestCase):
+    """A selector matching nothing yields an empty run, and an empty run reads
+    as 'this target has no payloads'. Unknown names have to be named."""
+
+    def test_unknown_environment_is_named(self):
+        generator = RCEKit()
+        with self.assertLogs("rcekit", level="WARNING") as logs:
+            list(generator.generate_payload_records(selected_environments=["linux"]))
+        joined = "\n".join(logs.output)
+        self.assertIn("Unknown environment: linux", joined)
+        # The message has to carry the answer, not just the complaint.
+        self.assertIn("unix", joined)
+
+    def test_unknown_encoding_is_named(self):
+        generator = RCEKit()
+        with self.assertLogs("rcekit", level="WARNING") as logs:
+            list(generator.generate_payload_records(selected_encodings=["nosuchenc"]))
+        self.assertIn("Unknown encoding: nosuchenc", "\n".join(logs.output))
+
+    def test_known_selectors_stay_quiet(self):
+        generator = RCEKit()
+        with self.assertLogs("rcekit", level="WARNING") as logs:
+            logger_under_test = rcekit.logger
+            logger_under_test.warning("sentinel")
+            list(generator.generate_payload_records(
+                selected_environments=["unix"], selected_encodings=["url_encode"]))
+        self.assertEqual([line for line in logs.output if "Unknown" in line], [])
+
+    def test_defaults_never_warn(self):
+        """The default lists are the corpus's own; warning on them would make
+        every ordinary run noisy."""
+        generator = RCEKit()
+        with self.assertLogs("rcekit", level="WARNING") as logs:
+            rcekit.logger.warning("sentinel")
+            list(generator.generate_payload_records(max_safety="safe"))
+        self.assertEqual(
+            [line for line in logs.output if "Unknown environment" in line], [])
+
+
+class TerminalSafeOutputTestCase(unittest.TestCase):
+    """A callback's host and path are chosen by the target. Printed raw, an ESC
+    byte lets that target rewrite the operator's terminal -- hiding a real hit
+    or forging one."""
+
+    def test_control_bytes_are_escaped(self):
+        self.assertEqual(rcekit.terminal_safe("a\x1b[31mb"), "a\\x1b[31mb")
+        self.assertEqual(rcekit.terminal_safe("x\ry\nz"), "x\\x0dy\\x0az")
+        self.assertEqual(rcekit.terminal_safe("nul\x00here"), "nul\\x00here")
+
+    def test_printable_text_is_untouched(self):
+        for text in ("plain.host.example", "/path?q=1", "; curl http://x/", "héllo"):
+            with self.subTest(text=text):
+                self.assertEqual(rcekit.terminal_safe(text), text)
+
+    def test_non_bmp_and_separator_codepoints_are_escaped(self):
+        # U+2028 LINE SEPARATOR is non-printable but above 0xFF.
+        self.assertEqual(rcekit.terminal_safe("a b"), "a\\u2028b")
+
+    def test_listener_never_prints_a_raw_escape(self):
+        import contextlib
+        import io
+        listener = OOBListener()
+        hostile = "evil\x1b[31mRED\x1b[0m\x1b[2K\rspoofed"
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            hit = listener.record("http", "10.0.0.5", hostile, "/cb")
+        printed = buffer.getvalue()
+        self.assertNotIn("\x1b", printed)
+        self.assertNotIn("\r", printed)
+        self.assertIn("\\x1b", printed)
+        # The record itself stays faithful -- only the display is escaped.
+        self.assertEqual(hit["host"], hostile)
+
+    def test_manifest_payload_is_escaped_on_the_hit_line(self):
+        tokens = {"tok1": {"payload": "; curl http://tok1.oob.test/\r\n",
+                           "category": "oob", "context": "raw"}}
+        listener = OOBListener(tokens=tokens)
+        import contextlib
+        import io
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            listener.record("dns", "10.0.0.5", "tok1.oob.test", "")
+        printed = buffer.getvalue()
+        self.assertNotIn("\r", printed)
+        self.assertIn("\\x0d", printed)


### PR DESCRIPTION
A robustness pass over error handling. No new capability — four ways RCEKit
could crash or mislead on input that came from somewhere other than its own
corpus. Version `2.35.0` → `2.35.1`.

## What was wrong

**A truncated error response ended the whole run.** Reading an `HTTPError`'s
body happens *inside* the `except` handler, where the sibling
`except Exception` cannot reach it. A target that promised a `Content-Length`
it never delivered raised `ConnectionResetError` straight out of `main()`:

```
File "rcekit.py", line 2433, in run_detection
  _, control_body, control_channels, _ = self._fire_channels(
File "rcekit.py", line 2047, in _fire_channels
  text = exc.read().decode(errors="replace")
ConnectionResetError: [Errno 104] Connection reset by peer
```

It fired on the *control* request, so the run could die before sending
anything — and mid-flight it took every probe already fired with it. This
contradicted the module's own stated contract: a delivery error must never
break the run.

**A `--target-profile` was used before it was checked.** A profile is written
by hand, so a typo in one is ordinary; it surfaced as a traceback thousands of
payloads from its cause. Twelve inputs crashed: a top level that is not a JSON
object (`[]`, `null`, `"s"`, `42`, `true`), `deny_chars` that is not text,
`max_length` that is not a number, selector fields given as numbers.

**A selector given as one string meant one character each.**
`"environments": "unix"` was iterated `u`, `n`, `i`, `x`, matched nothing, and
the empty run that followed was reported as a success.

**Unknown `--environments` and `--encodings` were silent.** `--environments
linux` — the corpus calls it `unix` — produced an empty file and exit 0,
indistinguishable from a target with no payloads for it. Unknown contexts and
categories already warned; these two did not.

**A callback could rewrite the operator's terminal.** The host and path of an
OOB callback are chosen by the target. Printed raw, an ESC byte let it colour,
erase and rewrite lines — hiding a genuine `[HIT]` behind `\x1b[2K\r`, or
forging one that never arrived. Confirmed with a crafted `Host:` header; the
bytes reached stdout verbatim:

```
- >   e   v   i   l 033   [   3   1   m   I   N   J   E   C   T   E   D 033   [   0   m 033   [   2   K
```

## What changed

| Fix | Where |
|---|---|
| `exc.read()` guarded; status still returned, unreadable body reported empty | `rcekit.py` `_fire_channels` |
| `validate_target_profile()` — shape and type checks, `[!]` message and exit 1 | new, module level |
| Selector strings split on commas: `"unix"` → `["unix"]`, `"raw, html"` → two names | same function |
| `_warn_unknown_selectors()` — names the value and lists the ones that exist | new, `RCEKit` |
| Empty result no longer announced as "Successfully generated 0 payloads" | `RCEKit` |
| `terminal_safe()` — control characters escaped for display as `\xNN` | new, module level |

The recorded hit and the `--listen-log` JSONL keep the raw bytes; only the
terminal display is escaped. A `500` body that *does* arrive is still returned
in full, so the stack-trace confirmations that branch exists for are untouched.

## Behaviour change worth flagging

In a profile, `"environments": "unix"` now means one name instead of four
characters. This is not a compatibility break — the old behaviour matched
nothing — and all three shipped profiles in `profiles/` use lists. A test
(`test_shipped_profiles_all_validate`) pins that.

## Verification

- **535 tests pass** (517 before + 18 new), 172s, no third-party deps.
- **The regression tests actually catch the bugs.** I stashed the fixes and ran
  the new tests against the unfixed module: all 15 behavioural tests failed.
  The other 3 pass in both states by design — they guard against
  over-correction ("a readable error body is still returned in full",
  "default selectors never warn").
- **Detection behaviour is unchanged.** The same injectable sink returns
  `844 probes: confirmed=446, negative=398` before and after. The negative
  control — an endpoint that reflects the payload verbatim without executing
  it — still comes back `negative` on every probe, zero false positives.
- **ruff and mypy** report the same 17 and 23 findings as the baseline; the new
  code adds none.
